### PR TITLE
Harden validate workflow with explicit permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,8 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
+    name: Validate plugins and skills
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to follow principle of least privilege
- Add concurrency limits to cancel redundant workflow runs  
- Add job name for clearer GitHub Actions UI

Fixes CodeQL alert #2 (`actions/missing-workflow-permissions`)

## Verification
```
$ zizmor --pedantic .github/workflows/
No findings to report. Good job!
```

🤖 Generated with [Claude Code](https://claude.ai/code)