### PR TITLE
Improve Move references in entry-point-analyzer

### DIFF
--- a/plugins/entry-point-analyzer/skills/entry-point-analyzer/SKILL.md
+++ b/plugins/entry-point-analyzer/skills/entry-point-analyzer/SKILL.md
@@ -94,7 +94,8 @@ If `which slither` returns nothing, proceed with manual analysis using the langu
 | `.sol` | Solidity | [{baseDir}/references/solidity.md]({baseDir}/references/solidity.md) |
 | `.vy` | Vyper | [{baseDir}/references/vyper.md]({baseDir}/references/vyper.md) |
 | `.rs` + `Cargo.toml` with `solana-program` | Solana (Rust) | [{baseDir}/references/solana.md]({baseDir}/references/solana.md) |
-| `.move` | Move (Aptos/Sui) | [{baseDir}/references/move.md]({baseDir}/references/move.md) |
+| `.move` + `Move.toml` with `edition` | [{baseDir}/references/move-sui.md]({baseDir}/references/move-sui.md) |
+| `.move` + `Move.toml` with `Aptos` | [{baseDir}/references/move-aptos.md]({baseDir}/references/move-aptos.md) |
 | `.fc`, `.func`, `.tact` | TON (FunC/Tact) | [{baseDir}/references/ton.md]({baseDir}/references/ton.md) |
 | `.rs` + `Cargo.toml` with `cosmwasm-std` | CosmWasm | [{baseDir}/references/cosmwasm.md]({baseDir}/references/cosmwasm.md) |
 

--- a/plugins/entry-point-analyzer/skills/entry-point-analyzer/references/move-aptos.md
+++ b/plugins/entry-point-analyzer/skills/entry-point-analyzer/references/move-aptos.md
@@ -1,8 +1,8 @@
-# Move Entry Point Detection (Aptos/Sui)
+# Move Entry Point Detection (Aptos)
 
 ## Entry Point Identification (State-Changing Only)
 
-In Move, `entry` functions are designed for transactions and typically modify state. **Include all entry functions** by default, as they represent the attack surface. Pure `public fun` (non-entry) functions are module-callable only and excluded.
+In Move, `public` functions can be invoked from transaction scripts (Aptos) and typically modify state. In addition, all `entry` functions are entrypoints. Package-protected (`public package`) and friend (`friend` or `public friend`) functions should be excluded.
 
 ### Aptos Move
 ```move
@@ -14,15 +14,6 @@ public fun helper(): u64 { }
 
 // Entry-only functions (can't be called by other modules)
 entry fun private_entry(account: &signer) { }
-```
-
-### Sui Move
-```move
-// Entry functions in Sui
-public entry fun transfer(ctx: &mut TxContext) { }
-
-// Public functions
-public fun compute(): u64 { }
 ```
 
 ### Visibility Rules
@@ -61,17 +52,6 @@ public entry fun admin_action(admin: &signer) acquires AdminCap {
 }
 ```
 
-### Sui Object Ownership
-```move
-// Object ownership provides access control
-public entry fun use_owned_object(obj: &mut MyObject, ctx: &mut TxContext) {
-    // Only owner of obj can call this
-}
-
-// Shared objects - anyone can access
-public entry fun use_shared(obj: &mut SharedObject) { }
-```
-
 ### Access Control Classification
 | Pattern | Classification |
 |---------|----------------|
@@ -80,8 +60,6 @@ public entry fun use_shared(obj: &mut SharedObject) { }
 | `exists<AdminCap>(addr)` | Admin (capability) |
 | `exists<GovernanceCap>(addr)` | Governance |
 | `exists<GuardianCap>(addr)` | Guardian |
-| Owned object parameter | Owner of object |
-| Shared object, no signer check | Public (Unrestricted) |
 | `&signer` with no checks | Review Required |
 
 ## Contract-Only Detection
@@ -114,15 +92,6 @@ public fun on_transfer_hook(amount: u64): bool {
    - `exists<*Cap>` checks → Capability-based
    - No access checks → Public (Unrestricted)
 
-### Sui
-1. Parse all `.move` files
-2. Find `module` declarations
-3. Extract `public entry` and `entry` functions
-4. Analyze parameters:
-   - Owned object types → Owner-restricted
-   - Shared objects without signer → Public
-   - `&signer`/`&mut TxContext` with checks → Role-based
-
 ## Move-Specific Considerations
 
 1. **Resource Model**: Access control often through resource ownership
@@ -134,7 +103,5 @@ public fun on_transfer_hook(amount: u64): bool {
 ## Common Gotchas
 
 1. **Init Functions**: `init` or `initialize` often create initial capabilities
-2. **Object Wrapping (Sui)**: Wrapped objects transfer ownership
-3. **Shared vs Owned (Sui)**: Shared objects have different access semantics
-4. **Module Upgrades**: Check upgrade capability ownership
-5. **Phantom Types**: Type parameters with `phantom` don't affect runtime
+2. **Module Upgrades**: Check upgrade capability ownership
+3. **Phantom Types**: Type parameters with `phantom` don't affect runtime

--- a/plugins/entry-point-analyzer/skills/entry-point-analyzer/references/move-sui.md
+++ b/plugins/entry-point-analyzer/skills/entry-point-analyzer/references/move-sui.md
@@ -1,0 +1,87 @@
+# Move Entry Point Detection (Sui)
+
+## Entry Point Identification (State-Changing Only)
+
+In Move, `public` functions can be invoked from programmable transaction blocks (Sui) or transaction scripts (Aptos) and typically modify state. In addition, private `entry` functions are entrypoints. Package-protected (`public(package) fun`) and private (`fun`) functions should be excluded.
+
+```move
+// Public functions
+public fun compute(obj: &mut Object): u64 { }
+
+// Entry functions in Sui
+public entry fun transfer(ctx: &mut TxContext) { }
+```
+
+### Visibility Rules
+| Visibility | Include? | Notes |
+|------------|----------|-------|
+| `public entry fun` | **Yes** | Callable from transactions and modules |
+| `public fun` | **Yes** | Callable from transactions and modules |
+| `entry fun` | **Yes** | Callable from transactions, but not other modules |
+| `fun` (private) | No | Not externally callable |
+| `public(package) fun` | No | Only callable by other modules in the same package |
+
+## Access Control Patterns
+
+```move
+// Object types have the key ability
+public struct MyObject has key { id: ID, ... }
+
+// Capability objects typically have names that end with "Cap"
+public struct AdminCap has key { id: ID, ... }
+
+// Shared objects are created via `public_share
+public struct Pool has key { id: ID, ... }
+
+// Object ownership provides access control
+public fun use_owned_object(obj: &mut MyObject) {
+    // Only owner of obj can call this
+}
+
+// Shared object - anyone can access
+public fun use_shared(pool: &mut Pool) { }
+
+// Shared Pool object gated by capability - only owner of AdminCap can call
+public fun capability_gate(_cap: &AdminCap, pool: &mut Pool) {}
+```
+
+### Access Control Classification
+| Pattern | Classification |
+|---------|----------------|
+| Owned object parameter | Owner of object |
+| Shared object | Public (Unrestricted) |
+
+## Contract-Only Detection
+
+### Package-protected Functions
+```move
+// Only callable by other modules in the same Move package
+public(protected) fun internal_fun() { }
+```
+
+## Extraction Strategy
+
+1. Parse all `.move` files
+2. Find `module` declarations
+3. Extract `public`, `public entry`, and `entry` functions
+4. Extract object type declarations (`struct`'s that have the `key` ability)
+5. Determine whether each object type is **owned** (passed as parameter to `transfer` or `public_transfer` functions) or **shared** (passed as parameter to `share` or `public_share` functions)
+6. Analyze parameters:
+   - Owned object type with "XCap" in name -> X role (e.g., AdminCap = Admin role, GuardianCap = Guardian role)
+   - Owned object type without "Cap" in name -> Owner role
+   - Shared object type -> Public
+
+## Move-Specific Considerations
+
+1. **Object Model**: Access control typically through object ownership (rather than runtime assertions)
+2. **Capabilities**: `Cap` suffix typically indicates capability pattern
+4. **Generic Types**: Type parameters may carry capability constraints
+5. **Package Visibility**: `public(pacakge)` limits callers to modules in the same package
+
+## Common Gotchas
+
+1. **Module Initializers**: `init` functions often create singletone shared objects and initial capabilities
+2. **Object Wrapping**: Wrapped objects transfer ownership
+3. **Shared vs Owned**: Shared objects can be accessed by anyone, owned objects only by a transaction sent by the owner
+4. **Package Upgrades**: Upgrades can introduce new types and functions and change old ones in type-compatible ways
+5. **Phantom Types**: Type parameters with `phantom` don't affect runtime


### PR DESCRIPTION
- Split into separate refs for Sui and Aptos (since both the syntax and semantics are pretty different). Tweak SKILL.md to detect the correct file type
- Make the Sui ref more accurate--old one would skip all `public` but non-`entry` functions, which is a substantial part of the attack surface