### PR TITLE
Improve modern-python skill with migration guide and Python 3.11

### DIFF
--- a/plugins/modern-python/skills/modern-python/SKILL.md
+++ b/plugins/modern-python/skills/modern-python/SKILL.md
@@ -18,13 +18,14 @@ Guide for modern Python tooling and best practices, based on [trailofbits/cookie
 ## When NOT to Use This Skill
 
 - **User wants to keep legacy tooling**: Respect existing workflows if explicitly requested
-- **Python < 3.10 required**: These tools target modern Python
+- **Python < 3.11 required**: These tools target modern Python
 - **Non-Python projects**: Mixed codebases where Python isn't primary
 
 ## Anti-Patterns to Avoid
 
 | Avoid | Use Instead |
 |-------|-------------|
+| `[tool.ty]` python-version | `[tool.ty.environment]` python-version |
 | `uv pip install` | `uv add` and `uv sync` |
 | Editing pyproject.toml manually to add deps | `uv add <pkg>` / `uv remove <pkg>` |
 | `hatchling` build backend | `uv_build` (simpler, sufficient for most cases) |
@@ -125,17 +126,18 @@ Key sections:
 [project]
 name = "myproject"
 version = "0.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = []
 
 [dependency-groups]
+dev = [{include-group = "lint"}, {include-group = "test"}, {include-group = "audit"}]
 lint = ["ruff", "ty"]
 test = ["pytest", "pytest-cov"]
-dev = [{include-group = "lint"}, {include-group = "test"}]
+audit = ["pip-audit"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -146,13 +148,14 @@ addopts = "--cov=myproject --cov-fail-under=80"
 
 [tool.ty]
 error-on-warning = true
-python-version = "3.10"
+
+[tool.ty.environment]
+python-version = "3.11"
 
 [tool.ty.rules]
-# Upgrade warnings to errors for stricter checking
+# Strict from day 1 for new projects
 possibly-unbound = "error"
-possibly-unresolved-reference = "warn"  # Disabled by default; may have false positives
-unused-ignore-comment = "warn"          # Catch stale type: ignore comments
+unused-ignore-comment = "warn"
 ```
 
 ### 3. Install Dependencies
@@ -273,7 +276,7 @@ Install with: `uv sync --group dev --group test`
 ## Best Practices Checklist
 
 - [ ] Use `src/` layout for packages
-- [ ] Set `requires-python = ">=3.10"`
+- [ ] Set `requires-python = ">=3.11"`
 - [ ] Configure ruff with `select = ["ALL"]` and explicit ignores
 - [ ] Use ty for type checking
 - [ ] Enforce test coverage minimum (80%+)
@@ -283,6 +286,7 @@ Install with: `uv sync --group dev --group test`
 
 ## Read Next
 
+- [migration-checklist.md](./references/migration-checklist.md) - Step-by-step migration cleanup
 - [pyproject.md](./references/pyproject.md) - Complete pyproject.toml reference
 - [uv-commands.md](./references/uv-commands.md) - uv command reference
 - [ruff-config.md](./references/ruff-config.md) - Ruff linting/formatting configuration

--- a/plugins/modern-python/skills/modern-python/references/migration-checklist.md
+++ b/plugins/modern-python/skills/modern-python/references/migration-checklist.md
@@ -1,0 +1,140 @@
+# Migration Checklist
+
+Comprehensive checklist for migrating Python projects to modern tooling.
+
+## Before Migration
+
+- [ ] **Determine layout**: `src/` or flat? Configure `[tool.uv.build-backend]` if flat
+- [ ] **Decide uv.lock strategy**: app (commit) vs library (.gitignore)
+- [ ] **Backup current state**: Create a branch or tag before starting
+
+## Cleanup Old Artifacts
+
+Find and remove legacy linter comments:
+
+```bash
+# Find files with old linter pragmas
+rg "# pylint:|# noqa:|# type: ignore" --files-with-matches
+
+# Find missing __init__.py files
+uv run ruff check --select=INP001 .
+```
+
+Remove these files after migration:
+- [ ] `requirements.txt`, `requirements-dev.txt`
+- [ ] `setup.py`, `setup.cfg`, `MANIFEST.in`
+- [ ] `.flake8`, `mypy.ini`, `pyrightconfig.json`
+- [ ] `tox.ini` (if not needed)
+- [ ] `Pipfile`, `Pipfile.lock`
+- [ ] Old virtual environments (`venv/`, `.venv/`)
+
+## .gitignore Updates
+
+Add these entries:
+
+```gitignore
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+
+# Tools
+.ruff_cache/
+.ty/
+
+# uv (for libraries only - apps should commit uv.lock)
+# uv.lock
+```
+
+## pyproject.toml Sections to Remove
+
+- [ ] `[tool.black]`
+- [ ] `[tool.isort]`
+- [ ] `[tool.mypy]`
+- [ ] `[tool.pyright]`
+- [ ] `[tool.pylint]`
+- [ ] `[tool.flake8]` (if present)
+
+## Post-Migration Easy Wins
+
+Run these to modernize code automatically:
+
+```bash
+# Pyupgrade modernization (typing, syntax)
+uv run ruff check --select=UP --fix .
+
+# Unnecessary variable assignments before return
+uv run ruff check --select=RET504 --fix .
+
+# Simplifications (conditionals, comprehensions)
+uv run ruff check --select=SIM --fix .
+
+# Remove commented-out code
+uv run ruff check --select=ERA --fix .
+```
+
+## CI Cleanup
+
+- [ ] Remove scheduled CI triggers (activity without progress is theater)
+- [ ] Update CI to use `uv sync` and `uv run`
+- [ ] Add `pip-audit` security check step
+- [ ] Pin GitHub Actions to SHA hashes
+
+## Gradual ty Adoption
+
+For legacy codebases with many type errors, start lenient:
+
+```toml
+[tool.ty]
+error-on-warning = true
+
+[tool.ty.environment]
+python-version = "3.11"
+
+[tool.ty.rules]
+# Start with these ignored for legacy codebases
+possibly-missing-attribute = "ignore"
+unresolved-import = "ignore"
+invalid-argument-type = "ignore"
+not-subscriptable = "ignore"
+unresolved-attribute = "ignore"
+```
+
+Remove rules as you fix errors. Track progress:
+
+```bash
+# Count remaining issues
+uv run ty check src/ 2>&1 | grep -c "error"
+```
+
+## Supply Chain Security
+
+- [ ] Add pip-audit to dependency groups
+- [ ] Run `uv run pip-audit` before releases
+- [ ] Configure Dependabot with 7-day cooldown (see [dependabot.md](./dependabot.md))
+- [ ] Pin exact versions in production (`==` not `>=`)
+
+## Verification
+
+After migration, verify everything works:
+
+```bash
+# Install all dependencies
+uv sync --all-groups
+
+# Run linting
+uv run ruff check .
+uv run ruff format --check .
+
+# Run type checking
+uv run ty check src/
+
+# Run tests
+uv run pytest
+
+# Security audit
+uv run pip-audit
+
+# Build package (if distributable)
+uv build
+```

--- a/plugins/modern-python/skills/modern-python/references/pyproject.md
+++ b/plugins/modern-python/skills/modern-python/references/pyproject.md
@@ -13,14 +13,13 @@ version = "0.1.0"
 description = "A modern Python project"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Your Name", email = "you@example.com" }
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -56,7 +55,7 @@ default-groups = ["dev", "test"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 src = ["src"]
 
 [tool.ruff.lint]
@@ -153,6 +152,13 @@ build-backend = "uv_build"
 
 `uv_build` is simpler and sufficient for most use cases. Use static versioning in `[project] version` rather than VCS-aware dynamic versioning.
 
+For flat layout (no `src/` directory), configure the module root:
+
+```toml
+[tool.uv.build-backend]
+module-root = ""
+```
+
 > **Note:** These tools evolve rapidly. Prefer `>=X.Y,<X+1` constraints to automatically get newer releases within the same major version.
 
 ### [dependency-groups]
@@ -161,10 +167,11 @@ Development dependencies (PEP 735). Unlike optional-dependencies, these are NOT 
 
 ```toml
 [dependency-groups]
-dev = ["ruff", "ty"]
+dev = [{include-group = "lint"}, {include-group = "test"}, {include-group = "audit"}]
+lint = ["ruff", "ty"]
 test = ["pytest", "pytest-cov"]
+audit = ["pip-audit"]
 docs = ["sphinx", "myst-parser"]
-lint = ["ruff"]
 ```
 
 Install with: `uv sync --group dev --group test`
@@ -190,6 +197,13 @@ python-preference = "managed"
 | `>=1.0,<2.0` | Version 1.x only |
 | `~=1.4` | Compatible release (>=1.4, <2.0) |
 | `==1.4.*` | Any 1.4.x version |
+
+## uv.lock Handling
+
+| Project Type | uv.lock in Git? | Why |
+|--------------|-----------------|-----|
+| Application | ✅ Commit | Reproducible deploys |
+| Library | ❌ .gitignore | Users resolve their own deps |
 
 ## Common Patterns
 

--- a/plugins/modern-python/skills/modern-python/references/ruff-config.md
+++ b/plugins/modern-python/skills/modern-python/references/ruff-config.md
@@ -9,7 +9,7 @@ Add to `pyproject.toml`:
 ```toml
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 src = ["src"]
 
 [tool.ruff.lint]
@@ -218,3 +218,27 @@ Ruff includes isort. Remove:
 - [tool.isort] config
 
 Use `[tool.ruff.lint.isort]` for isort settings.
+
+## Code Modernization
+
+Run pyupgrade rules to modernize syntax to your target Python version:
+
+```bash
+uv run ruff check --select=UP --fix .  # Auto-fix upgrades
+uv run ruff check --select=UP .        # Preview only
+```
+
+Common modernizations include:
+- `typing.Optional[X]` → `X | None`
+- `typing.List[X]` → `list[X]`
+- `super(ClassName, self)` → `super()`
+- Format strings and other syntax upgrades
+
+## Line Length Migration
+
+If migrating from 120 to 100 char lines, expect manual fixes.
+For less churn during initial migration, keep existing:
+
+```toml
+line-length = 120  # Match existing; tighten later
+```

--- a/plugins/modern-python/skills/modern-python/references/testing.md
+++ b/plugins/modern-python/skills/modern-python/references/testing.md
@@ -256,6 +256,11 @@ def test_unix_feature():
     uv sync --group test
     uv run pytest --cov-report=xml
 
+- name: Security audit
+  run: |
+    uv sync --group audit
+    uv run pip-audit
+
 - name: Upload coverage
   uses: codecov/codecov-action@<sha>  # <latest> https://github.com/codecov/codecov-action/releases
   with:


### PR DESCRIPTION
## Summary

- Add `migration-checklist.md` for gradual adoption of strict typing in existing codebases
- Bump minimum Python from 3.10 to 3.11 throughout
- Fix ty.rules in Full Project Setup to be strict from day 1 (migration guidance now in separate file)
- Use `[tool.ty.environment]` for python-version (correct ty syntax)
- Add `pip-audit` to dependency groups for supply chain security

## Test plan

- [ ] Verify SKILL.md Full Project Setup shows strict rules without migration language
- [ ] Verify migration-checklist.md contains gradual adoption guidance
- [ ] Confirm all Python version references are 3.11

🤖 Generated with [Claude Code](https://claude.ai/code)