### PR TITLE
Fix Python version in README (3.10 -> 3.11)

### DIFF
--- a/plugins/modern-python/README.md
+++ b/plugins/modern-python/README.md
@@ -25,7 +25,7 @@ This skill provides guidance on:
 - **pytest** - Testing with coverage enforcement
 - **PEP 723** - Inline script metadata for single-file scripts
 - **src/ layout** - Standard package structure
-- **Python 3.10+** - Minimum version requirement
+- **Python 3.11+** - Minimum version requirement
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Fix minimum Python version in modern-python README from 3.10 to 3.11

The skill content consistently uses 3.11 as the minimum (`requires-python = ">=3.11"`).

## Test plan
- [x] Verified no other 3.10 references remain in the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)