### PR TITLE
Add --write flag to shfmt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.12.0-2
     hooks:
       - id: shfmt
-        args: [-i, "2", -ci]
+        args: [-i, "2", -ci, --write]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## Summary

- Fix shfmt pre-commit hook to actually reformat files in place

Custom `args` in `.pre-commit-config.yaml` **replace** the default args rather than extend them. The shfmt hook's default includes `--write`, but our custom args (`-i 2 -ci`) omitted it. Without `--write`, shfmt outputs formatted code to stdout and exits 0 regardless of differences—so formatting issues were never caught or fixed.

## Test plan

- [ ] Run `echo 'if true;then echo "bad";fi' > /tmp/test.sh && pre-commit run shfmt --files /tmp/test.sh && cat /tmp/test.sh`
- [ ] Verify file is reformatted to `if true; then echo "bad"; fi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)