### PR TITLE
Update pytest config to modern [tool.pytest] syntax

### DIFF
--- a/plugins/modern-python/skills/modern-python/SKILL.md
+++ b/plugins/modern-python/skills/modern-python/SKILL.md
@@ -156,8 +156,8 @@ target-version = "py311"
 select = ["ALL"]
 ignore = ["D", "COM812", "ISC001"]
 
-[tool.pytest.ini_options]
-addopts = "--cov=myproject --cov-fail-under=80"
+[tool.pytest]
+addopts = ["--cov=myproject", "--cov-fail-under=80"]
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/plugins/modern-python/skills/modern-python/references/pyproject.md
+++ b/plugins/modern-python/skills/modern-python/references/pyproject.md
@@ -78,7 +78,7 @@ quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
 
-[tool.pytest.ini_options]
+[tool.pytest]
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = [

--- a/plugins/modern-python/skills/modern-python/references/testing.md
+++ b/plugins/modern-python/skills/modern-python/references/testing.md
@@ -13,7 +13,7 @@ uv add --group test pytest pytest-cov hypothesis
 ## pyproject.toml Configuration
 
 ```toml
-[tool.pytest.ini_options]
+[tool.pytest]
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = [


### PR DESCRIPTION
pytest now fully supports [tool.pytest] in pyproject.toml, making the legacy [tool.pytest.ini_options] section unnecessary. Also converts the string-form addopts in SKILL.md to a proper TOML array.