### PR TITLE
Improve modern-python skill description and add UV_PROJECT_ENVIRONMENT

### DIFF
--- a/plugins/modern-python/skills/modern-python/SKILL.md
+++ b/plugins/modern-python/skills/modern-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: modern-python
-description: Modern Python best practices. Use when creating new Python projects, and writing Python scripts, or migrating existing projects from legacy tools.
+description: Configures Python projects with modern tooling (uv, ruff, ty). Use when creating projects, writing standalone scripts, or migrating from pip/Poetry/mypy/black.
 ---
 
 # Modern Python

--- a/plugins/modern-python/skills/modern-python/references/uv-commands.md
+++ b/plugins/modern-python/skills/modern-python/references/uv-commands.md
@@ -170,7 +170,28 @@ uv run script_with_metadata.py
 | `UV_NO_CACHE` | Disable caching |
 | `UV_PYTHON` | Default Python version |
 | `UV_PROJECT` | Project directory path |
+| `UV_PROJECT_ENVIRONMENT` | Custom venv directory (e.g., `.venv-dev`) |
 | `UV_SYSTEM_PYTHON` | Use system Python |
+
+## Container/Host Development
+
+When developing on a host machine while also running in containers, you can use separate venvs to avoid rebuilding on each context switch:
+
+```bash
+# On host machine (add to shell profile or .envrc)
+export UV_PROJECT_ENVIRONMENT=.venv-dev
+
+# Now host uses .venv-dev, containers use default .venv
+uv sync  # creates .venv-dev on host
+```
+
+Add both to `.gitignore`:
+```
+.venv/
+.venv-dev/
+```
+
+This avoids rebuilding the venv when switching between host and container (different OS, Python versions, or native dependencies).
 
 ## Performance Tips
 


### PR DESCRIPTION
## Summary

- Tightens frontmatter description to use third-person verb ("Configures") and name specific tools (uv, ruff, ty) for better trigger matching
- Lists migration triggers (pip/Poetry/mypy/black) to improve skill discovery
- Documents `UV_PROJECT_ENVIRONMENT` variable for container/host development workflows
- Adds "Container/Host Development" section explaining how to use separate venvs when switching between host and container contexts

## Test plan

- [ ] Verify frontmatter YAML is valid
- [ ] Confirm new section renders correctly in markdown
- [ ] Check skill triggers correctly on relevant prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)