### PR TITLE
let-fate-decide: replace os.urandom with secrets.randbelow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -316,7 +316,7 @@
     },
     {
       "name": "let-fate-decide",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Draws Tarot cards using cryptographic randomness to add entropy to vague or underspecified planning. Interprets the spread to guide next steps. Use when feeling lucky, invoking heart-of-the-cards energy, or when prompts are ambiguous.",
       "author": {
         "name": "Scott Arciszewski",

--- a/plugins/let-fate-decide/.claude-plugin/plugin.json
+++ b/plugins/let-fate-decide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "let-fate-decide",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Draws Tarot cards using cryptographic randomness to add entropy to vague or underspecified planning. Interprets the spread to guide next steps. Use when feeling lucky, invoking heart-of-the-cards energy, or when prompts are ambiguous.",
   "author": {
     "name": "Scott Arciszewski",

--- a/plugins/let-fate-decide/README.md
+++ b/plugins/let-fate-decide/README.md
@@ -1,6 +1,6 @@
 # let-fate-decide
 
-A Claude Code skill that draws Tarot cards using `os.urandom()` to inject
+A Claude Code skill that draws Tarot cards using `secrets.randbelow()` to inject
 entropy into vague or underspecified planning decisions.
 
 ## What It Does
@@ -21,7 +21,7 @@ spread and uses the reading to inform its approach.
 
 ## How It Works
 
-1. A Python script uses `os.urandom()` to perform a Fisher-Yates shuffle
+1. A Python script uses `secrets.randbelow()` to perform a Fisher-Yates shuffle
 2. 4 cards are drawn from the top of the shuffled deck
 3. Each card has an independent 50% chance of being reversed
 4. Claude reads the drawn cards' meaning files and interprets the spread

--- a/plugins/let-fate-decide/README.md
+++ b/plugins/let-fate-decide/README.md
@@ -1,6 +1,6 @@
 # let-fate-decide
 
-A Claude Code skill that draws Tarot cards using `secrets.randbelow()` to inject
+A Claude Code skill that draws Tarot cards using `secrets` to inject
 entropy into vague or underspecified planning decisions.
 
 ## What It Does
@@ -12,16 +12,17 @@ spread and uses the reading to inform its approach.
 
 ## Triggers
 
-- Vague or underspecified prompts where multiple approaches are equally valid
-- "I'm feeling lucky"
-- "Let fate decide"
-- Nonchalant delegation ("whatever you think", "surprise me", "dealer's choice")
-- Yu-Gi-Oh references ("heart of the cards", "I believe in the heart of the cards")
+- Vague or ambiguous prompts where multiple reasonable approaches exist
+- "I'm feeling lucky", "let fate decide", "dealer's choice", "surprise me", "whatever you think", "YOLO"
+- Casual delegation ("whatever", "up to you", "your call", "idk", "just do something", "wing it", "I trust you", "doesn't matter", "do what you want", "I don't care", "any approach works", "you pick")
+- Yu-Gi-Oh references ("heart of the cards", "I believe in the heart of the cards", "you've activated my trap card", "it's time to duel")
+- Shrug-like brevity -- very short prompts that fully delegate the decision
+- About to arbitrarily pick between 2+ valid approaches (draw cards instead)
 - "Try again" on a system with no actual changes (redraw)
 
 ## How It Works
 
-1. A Python script uses `secrets.randbelow()` to perform a Fisher-Yates shuffle
+1. A Python script uses `secrets` to perform a Fisher-Yates shuffle
 2. 4 cards are drawn from the top of the shuffled deck
 3. Each card has an independent 50% chance of being reversed
 4. Claude reads the drawn cards' meaning files and interprets the spread

--- a/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
+++ b/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: let-fate-decide
-description: "Draws 4 Tarot cards using os.urandom() to inject entropy into planning when prompts are vague or underspecified. Interprets the spread to guide next steps. Use when the user is nonchalant, feeling lucky, says 'let fate decide', makes Yu-Gi-Oh references ('heart of the cards'), demonstrates indifference about approach, or says 'try again' on a system with no changes. Also triggers on sufficiently ambiguous prompts where multiple approaches are equally valid."
+description: "Draws 4 Tarot cards using secrets.randbelow() to inject entropy into planning when prompts are vague or underspecified. Interprets the spread to guide next steps. Use when the user is nonchalant, feeling lucky, says 'let fate decide', makes Yu-Gi-Oh references ('heart of the cards'), demonstrates indifference about approach, or says 'try again' on a system with no changes. Also triggers on sufficiently ambiguous prompts where multiple approaches are equally valid."
 allowed-tools:
   - Bash
   - Read
@@ -48,7 +48,7 @@ When the path forward is unclear, let the cards speak.
 
 ### The Draw
 
-The script uses `os.urandom()` for cryptographic randomness:
+The script uses `secrets.randbelow()` for cryptographic randomness:
 
 1. Builds a standard 78-card Tarot deck (22 Major Arcana + 56 Minor Arcana)
 2. Performs a Fisher-Yates shuffle using rejection sampling (no modulo bias)

--- a/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
+++ b/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
@@ -51,7 +51,7 @@ When the path forward is unclear, let the cards speak.
 The script uses `secrets.randbelow()` for cryptographic randomness:
 
 1. Builds a standard 78-card Tarot deck (22 Major Arcana + 56 Minor Arcana)
-2. Performs a Fisher-Yates shuffle using rejection sampling (no modulo bias)
+2. Performs a Fisher-Yates shuffle via `secrets.randbelow()` (no modulo bias)
 3. Draws 4 cards from the top
 4. Each card independently has a 50% chance of being reversed
 

--- a/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
+++ b/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
@@ -85,6 +85,10 @@ Key rules:
 - Major Arcana cards carry more weight than Minor Arcana
 - The spread tells a story across all 4 positions; don't interpret cards in isolation
 - Map abstract meanings to concrete technical decisions
+- **Never output interpretation as a text-only turn.** Include the
+  interpretation alongside your next tool call (the action that
+  implements the chosen option). Read all 4 cards in parallel if
+  possible.
 
 ## Example Session
 

--- a/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
+++ b/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: let-fate-decide
-description: "Draws 4 Tarot cards using secrets.randbelow() to inject entropy into planning when prompts are vague or underspecified. Interprets the spread to guide next steps. Use when the user is nonchalant, feeling lucky, says 'let fate decide', makes Yu-Gi-Oh references ('heart of the cards'), demonstrates indifference about approach, or says 'try again' on a system with no changes. Also triggers on sufficiently ambiguous prompts where multiple approaches are equally valid."
+description: "Draws 4 Tarot cards to inject entropy into planning when prompts are vague, ambiguous, or casually delegated. Interprets the spread to guide next steps. Use when the user says 'let fate decide', 'YOLO', 'whatever', 'idk', or other nonchalant phrases, makes Yu-Gi-Oh references, or when you are about to arbitrarily pick between multiple reasonable approaches. Prefer over ask-questions-if-underspecified when the user's tone is casual or playful rather than precision-seeking."
 allowed-tools:
   - Bash
   - Read
@@ -29,12 +29,13 @@ When the path forward is unclear, let the cards speak.
 
 ## When to Use
 
-- **Vague prompts**: The user's request is ambiguous and multiple valid approaches exist
-- **Explicit invocations**: "I'm feeling lucky", "let fate decide", "dealer's choice", "surprise me", "whatever you think"
+- **Vague prompts**: The user's request is ambiguous and multiple reasonable approaches exist
+- **Explicit invocations**: "I'm feeling lucky", "let fate decide", "dealer's choice", "surprise me", "whatever you think", "YOLO"
+- **Casual delegation**: "whatever", "up to you", "your call", "idk", "just do something", "wing it", "I trust you", "doesn't matter", "do what you want", "I don't care", "any approach works", "you pick"
 - **Yu-Gi-Oh energy**: "Heart of the cards", "I believe in the heart of the cards", "you've activated my trap card", "it's time to duel"
-- **Nonchalant delegation**: The user expresses indifference about the approach
+- **Shrug-like brevity**: Very short prompts that fully delegate the decision without expressing a preference
 - **Redraw requests**: "Try again" or "draw again" when no actual system changes occurred (this means draw new cards, not re-run the same approach)
-- **Tie-breaking**: When you genuinely cannot decide between equally valid approaches
+- **Tie-breaking**: When you are about to arbitrarily pick between 2+ valid approaches, draw cards instead of silently choosing one
 
 ## When NOT to Use
 
@@ -42,13 +43,13 @@ When the path forward is unclear, let the cards speak.
 - The task has a single obvious correct approach
 - Safety-critical decisions (security, data integrity, production deployments)
 - The user explicitly asks you NOT to use Tarot
-- A more specific skill (like `ask-questions-if-underspecified`) would better serve the user by gathering actual requirements
+- The user's tone is precision-seeking rather than casual -- use `ask-questions-if-underspecified` instead to gather actual requirements
 
 ## How It Works
 
 ### The Draw
 
-The script uses `secrets.randbelow()` for cryptographic randomness:
+The script uses `secrets` for cryptographic randomness:
 
 1. Builds a standard 78-card Tarot deck (22 Major Arcana + 56 Minor Arcana)
 2. Performs a Fisher-Yates shuffle via `secrets.randbelow()` (no modulo bias)

--- a/plugins/let-fate-decide/skills/let-fate-decide/scripts/draw_cards.py
+++ b/plugins/let-fate-decide/skills/let-fate-decide/scripts/draw_cards.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Draw Tarot cards using secrets.randbelow() for cryptographic randomness.
+"""Draw Tarot cards using the secrets module for cryptographic randomness.
 
 Shuffles a full 78-card deck via Fisher-Yates and draws 4 from the top.
 Each card has an independent 50/50 chance of being reversed.
@@ -13,7 +13,7 @@ import json
 import secrets
 import sys
 
-MAJOR_ARCANA = [
+MAJOR_ARCANA = (
     ("major", "00-the-fool"),
     ("major", "01-the-magician"),
     ("major", "02-the-high-priestess"),
@@ -36,9 +36,9 @@ MAJOR_ARCANA = [
     ("major", "19-the-sun"),
     ("major", "20-judgement"),
     ("major", "21-the-world"),
-]
+)
 
-RANKS = [
+RANKS = (
     "ace",
     "two",
     "three",
@@ -53,9 +53,9 @@ RANKS = [
     "knight",
     "queen",
     "king",
-]
+)
 
-SUITS = ["wands", "cups", "swords", "pentacles"]
+SUITS = ("wands", "cups", "swords", "pentacles")
 
 
 def build_deck():
@@ -76,12 +76,14 @@ def fisher_yates_shuffle(deck):
 
 
 def is_reversed():
-    """Return True with 50% probability using secrets.randbelow()."""
-    return secrets.randbelow(2) == 1
+    """Return True with 50% probability using secrets.randbits()."""
+    return secrets.randbits(1) == 1
 
 
 def draw(n=4):
     """Shuffle deck and draw n cards, each possibly reversed."""
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"n must be int, got {type(n).__name__}")
     deck = build_deck()
     fisher_yates_shuffle(deck)
     hand = []

--- a/plugins/let-fate-decide/skills/let-fate-decide/scripts/draw_cards.py
+++ b/plugins/let-fate-decide/skills/let-fate-decide/scripts/draw_cards.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Draw Tarot cards using os.urandom() for cryptographic randomness.
+"""Draw Tarot cards using secrets.randbelow() for cryptographic randomness.
 
 Shuffles a full 78-card deck via Fisher-Yates and draws 4 from the top.
 Each card has an independent 50/50 chance of being reversed.
@@ -10,7 +10,7 @@ Each card has an independent 50/50 chance of being reversed.
 # ///
 
 import json
-import os
+import secrets
 import sys
 
 MAJOR_ARCANA = [
@@ -67,38 +67,17 @@ def build_deck():
     return deck
 
 
-def secure_randbelow(n):
-    """Return a cryptographically random integer in [0, n).
-
-    Uses os.urandom() with rejection sampling to avoid modulo bias.
-    """
-    if n <= 0:
-        raise ValueError("n must be positive")
-    if n == 1:
-        return 0
-    # Number of bytes needed to cover range
-    k = (n - 1).bit_length()
-    num_bytes = (k + 7) // 8
-    # Rejection sampling: discard values >= n to avoid bias
-    while True:
-        raw = int.from_bytes(os.urandom(num_bytes), "big")
-        # Mask to k bits to reduce rejection rate
-        raw = raw & ((1 << k) - 1)
-        if raw < n:
-            return raw
-
-
 def fisher_yates_shuffle(deck):
-    """Shuffle deck in-place using Fisher-Yates with os.urandom()."""
+    """Shuffle deck in-place using Fisher-Yates with secrets.randbelow()."""
     for i in range(len(deck) - 1, 0, -1):
-        j = secure_randbelow(i + 1)
+        j = secrets.randbelow(i + 1)
         deck[i], deck[j] = deck[j], deck[i]
     return deck
 
 
 def is_reversed():
-    """Return True with 50% probability using os.urandom()."""
-    return os.urandom(1)[0] & 1 == 1
+    """Return True with 50% probability using secrets.randbelow()."""
+    return secrets.randbelow(2) == 1
 
 
 def draw(n=4):

--- a/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
+++ b/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
@@ -203,8 +203,7 @@ def test_no_secure_randbelow_function():
     """Regression: the custom secure_randbelow must be removed."""
     source = Path(__file__).parent / "draw_cards.py"
     text = source.read_text()
-    assert "def secure_randbelow" not in text, \
-        "Custom secure_randbelow still exists"
+    assert "def secure_randbelow" not in text, "Custom secure_randbelow still exists"
 
 
 if __name__ == "__main__":

--- a/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
+++ b/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Tests for draw_cards.py."""
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Import the module under test
+sys.path.insert(0, str(Path(__file__).parent))
+import draw_cards
+
+
+def test_build_deck_has_78_cards():
+    deck = draw_cards.build_deck()
+    assert len(deck) == 78, f"Expected 78 cards, got {len(deck)}"
+
+
+def test_build_deck_has_22_major_arcana():
+    deck = draw_cards.build_deck()
+    majors = [c for c in deck if c[0] == "major"]
+    assert len(majors) == 22, f"Expected 22 major arcana, got {len(majors)}"
+
+
+def test_build_deck_has_56_minor_arcana():
+    deck = draw_cards.build_deck()
+    minors = [c for c in deck if c[0] != "major"]
+    assert len(minors) == 56, f"Expected 56 minor arcana, got {len(minors)}"
+
+
+def test_build_deck_all_unique():
+    deck = draw_cards.build_deck()
+    card_ids = [c[1] for c in deck]
+    assert len(card_ids) == len(set(card_ids)), "Duplicate card IDs found"
+
+
+def test_build_deck_four_suits_14_each():
+    deck = draw_cards.build_deck()
+    suits = Counter(c[0] for c in deck if c[0] != "major")
+    for suit in ["wands", "cups", "swords", "pentacles"]:
+        assert suits[suit] == 14, f"Expected 14 {suit}, got {suits[suit]}"
+
+
+def test_draw_returns_requested_count():
+    for n in [1, 2, 4, 10]:
+        hand = draw_cards.draw(n)
+        assert len(hand) == n, f"draw({n}) returned {len(hand)} cards"
+
+
+def test_draw_default_is_4():
+    hand = draw_cards.draw()
+    assert len(hand) == 4
+
+
+def test_draw_clamps_to_78():
+    hand = draw_cards.draw(100)
+    assert len(hand) == 78
+
+
+def test_draw_zero_returns_empty():
+    hand = draw_cards.draw(0)
+    assert len(hand) == 0
+
+
+def test_draw_card_structure():
+    hand = draw_cards.draw(1)
+    card = hand[0]
+    assert "suit" in card
+    assert "card_id" in card
+    assert "reversed" in card
+    assert "position" in card
+    assert "file" in card
+    assert isinstance(card["reversed"], bool)
+    assert card["position"] == 1
+    assert card["file"].startswith("cards/")
+    assert card["file"].endswith(".md")
+
+
+def test_draw_positions_are_sequential():
+    hand = draw_cards.draw(4)
+    positions = [c["position"] for c in hand]
+    assert positions == [1, 2, 3, 4]
+
+
+def test_draw_no_duplicate_cards():
+    hand = draw_cards.draw(78)
+    card_ids = [c["card_id"] for c in hand]
+    assert len(card_ids) == len(set(card_ids)), "Duplicate cards drawn"
+
+
+def test_fisher_yates_preserves_elements():
+    deck = draw_cards.build_deck()
+    original = sorted(deck)
+    draw_cards.fisher_yates_shuffle(deck)
+    assert sorted(deck) == original, "Shuffle changed deck elements"
+
+
+def test_fisher_yates_single_element():
+    deck = [("major", "00-the-fool")]
+    draw_cards.fisher_yates_shuffle(deck)
+    assert deck == [("major", "00-the-fool")]
+
+
+def test_fisher_yates_empty():
+    deck = []
+    draw_cards.fisher_yates_shuffle(deck)
+    assert deck == []
+
+
+def test_is_reversed_returns_bool():
+    for _ in range(20):
+        assert isinstance(draw_cards.is_reversed(), bool)
+
+
+def test_shuffle_produces_varying_orders():
+    """Run 5 shuffles; at least 2 should differ (p(all same) ~ 0)."""
+    orders = []
+    for _ in range(5):
+        deck = draw_cards.build_deck()
+        draw_cards.fisher_yates_shuffle(deck)
+        orders.append(tuple(c[1] for c in deck))
+    assert len(set(orders)) >= 2, "All 5 shuffles identical"
+
+
+def test_reversal_produces_both_values():
+    """Over 100 flips, both True and False should appear."""
+    results = {draw_cards.is_reversed() for _ in range(100)}
+    assert True in results, "Never got reversed=True in 100 flips"
+    assert False in results, "Never got reversed=False in 100 flips"
+
+
+def test_no_os_urandom_import():
+    """Verify os is not imported (regression for secrets migration)."""
+    source = Path(__file__).parent / "draw_cards.py"
+    text = source.read_text()
+    assert "import os" not in text, "os is still imported"
+    assert "os.urandom" not in text, "os.urandom still referenced"
+
+
+def test_uses_secrets_module():
+    """Verify secrets module is used."""
+    source = Path(__file__).parent / "draw_cards.py"
+    text = source.read_text()
+    assert "import secrets" in text
+    assert "secrets.randbelow" in text
+
+
+def test_cli_default_output():
+    """Run the script and verify JSON output with 4 cards."""
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "draw_cards.py")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    cards = json.loads(result.stdout)
+    assert len(cards) == 4
+
+
+def test_cli_custom_count():
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "draw_cards.py"), "2"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    cards = json.loads(result.stdout)
+    assert len(cards) == 2
+
+
+def test_cli_invalid_arg():
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "draw_cards.py"), "abc"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "Error" in result.stderr
+
+
+def test_cli_out_of_range():
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "draw_cards.py"), "0"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "draw_cards.py"), "79"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_no_secure_randbelow_function():
+    """Regression: the custom secure_randbelow must be removed."""
+    source = Path(__file__).parent / "draw_cards.py"
+    text = source.read_text()
+    assert "def secure_randbelow" not in text, \
+        "Custom secure_randbelow still exists"
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+            print(f"  PASS  {test.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {test.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"  ERROR {test.__name__}: {e}")
+    print(f"\n{passed} passed, {failed} failed, {passed + failed} total")
+    sys.exit(1 if failed else 0)

--- a/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
+++ b/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
@@ -148,6 +148,7 @@ def test_uses_secrets_module():
     text = source.read_text()
     assert "import secrets" in text
     assert "secrets.randbelow" in text
+    assert "secrets.randbits" in text
 
 
 def test_cli_default_output():
@@ -204,6 +205,23 @@ def test_no_secure_randbelow_function():
     source = Path(__file__).parent / "draw_cards.py"
     text = source.read_text()
     assert "def secure_randbelow" not in text, "Custom secure_randbelow still exists"
+
+
+def test_constants_are_immutable():
+    """Constants must be tuples to prevent mutation."""
+    assert isinstance(draw_cards.MAJOR_ARCANA, tuple), "MAJOR_ARCANA is not a tuple"
+    assert isinstance(draw_cards.RANKS, tuple), "RANKS is not a tuple"
+    assert isinstance(draw_cards.SUITS, tuple), "SUITS is not a tuple"
+
+
+def test_draw_rejects_non_int():
+    """draw() must reject non-int types cleanly."""
+    for bad in [None, "3", 2.5, True, False, [4]]:
+        try:
+            draw_cards.draw(bad)
+            assert False, f"draw({bad!r}) should have raised TypeError"
+        except TypeError:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Replace hand-rolled `secure_randbelow(os.urandom)` with stdlib `secrets.randbelow()` per @opal-escent's feedback
- Remove custom rejection-sampling function (semantically identical to `secrets.randbelow`)
- Use `secrets.randbelow(2)` for card reversal coin flips instead of `os.urandom(1)[0] & 1`
- Update all docstrings, SKILL.md, and README.md references from `os.urandom()` to `secrets.randbelow()`
- Add 25-test suite: deck construction, shuffle invariants, draw behavior, CLI validation, and 4 migration regression checks

## Test plan

- [x] All 25 tests pass (`python3 test_draw_cards.py`)
- [x] No references to `os.urandom` or `import os` remain in draw_cards.py
- [x] Custom `secure_randbelow` function fully removed
- [x] SKILL.md and README.md updated consistently
- [x] Script produces valid JSON output with correct structure

cc @opal-escent for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)