### PR TITLE
fix(gh-cli): exit 0 when CLAUDE_ENV_FILE is unset

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "gh-cli",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "description": "Intercepts GitHub URL fetches and curl/wget commands, redirecting to the authenticated gh CLI.",
       "author": {
         "name": "William Tan",

--- a/plugins/gh-cli/.claude-plugin/plugin.json
+++ b/plugins/gh-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Intercepts GitHub URL fetches and curl/wget commands, redirecting to the authenticated gh CLI.",
   "author": {
     "name": "William Tan",

--- a/plugins/gh-cli/hooks/setup-shims.bats
+++ b/plugins/gh-cli/hooks/setup-shims.bats
@@ -19,10 +19,10 @@ teardown() {
   rm -rf "$FAKE_BIN"
 }
 
-@test "exits with error when CLAUDE_ENV_FILE is not set" {
+@test "exits gracefully when CLAUDE_ENV_FILE is not set" {
   run env -u CLAUDE_ENV_FILE PATH="${FAKE_BIN}:${ORIG_PATH}" \
     bash "$SETUP_SCRIPT" 2>&1
-  [[ $status -eq 1 ]]
+  [[ $status -eq 0 ]]
   [[ "$output" == *"CLAUDE_ENV_FILE not set"* ]]
 }
 

--- a/plugins/gh-cli/hooks/setup-shims.sh
+++ b/plugins/gh-cli/hooks/setup-shims.sh
@@ -13,7 +13,7 @@ fi
 # Guard: CLAUDE_ENV_FILE must be set by the runtime
 if [[ -z "${CLAUDE_ENV_FILE:-}" ]]; then
   echo "gh-cli: CLAUDE_ENV_FILE not set; shims will not be installed" >&2
-  exit 1
+  exit 0
 fi
 
 shims_dir="$(cd "$(dirname "$0")/shims" && pwd)" || {


### PR DESCRIPTION
## Summary
- `setup-shims.sh` exits 1 when `CLAUDE_ENV_FILE` is not set, causing a `SessionStart:startup hook error` in Claude Code
- This is a graceful degradation case (shims won't install), not a fatal error — identical to the `gh` not-found guard on line 10 which already exits 0
- Changes `exit 1` → `exit 0` on line 16 for consistency

## Test plan
- [ ] Start a Claude Code session — no more `SessionStart:startup hook error` from gh-cli
- [ ] When `CLAUDE_ENV_FILE` is set, shims install normally (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)