### PR TITLE
Fix `allowed-tools` to use spec-compliant space-delimited strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,7 @@ plugins/
 ---
 name: skill-name              # kebab-case, max 64 chars
 description: "Third-person description of what it does and when to use it"
-allowed-tools:                # Optional: restrict to needed tools only
-  - Read
-  - Grep
+allowed-tools: Read Grep      # Optional: restrict to needed tools only
 ---
 ```
 

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/SKILL.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: agentic-actions-auditor
 description: "Audits GitHub Actions workflows for security vulnerabilities in AI agent integrations including Claude Code Action, Gemini CLI, OpenAI Codex, and GitHub AI Inference. Detects attack vectors where attacker-controlled input reaches AI agents running in CI/CD pipelines, including env var intermediary patterns, direct expression injection, dangerous sandbox configurations, and wildcard user allowlists. Use when reviewing workflow files that invoke AI coding agents, auditing CI/CD pipeline security for prompt injection risks, or evaluating agentic action configurations."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Agentic Actions Auditor

--- a/plugins/audit-context-building/commands/audit-context.md
+++ b/plugins/audit-context-building/commands/audit-context.md
@@ -2,12 +2,7 @@
 name: trailofbits:audit-context
 description: Builds deep architectural context before vulnerability hunting
 argument-hint: "<codebase-path> [--focus <module>]"
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - Task
+allowed-tools: Read Grep Glob Bash Task
 ---
 
 # Build Audit Context

--- a/plugins/burpsuite-project-parser/commands/burp-search.md
+++ b/plugins/burpsuite-project-parser/commands/burp-search.md
@@ -2,9 +2,7 @@
 name: trailofbits:burp-search
 description: Searches Burp Suite project files for security analysis
 argument-hint: "<burp-file> [operation]"
-allowed-tools:
-  - Bash
-  - Read
+allowed-tools: Bash Read
 ---
 
 # Search Burp Suite Project Files

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: burpsuite-project-parser
 description: Searches and explores Burp Suite project files (.burp) from the command line. Use when searching response headers or bodies with regex patterns, extracting security audit findings, dumping proxy history or site map data, or analyzing HTTP traffic captured in a Burp project.
-allowed-tools:
-  - Bash
-  - Read
+allowed-tools: Bash Read
 ---
 
 # Burp Project Parser

--- a/plugins/constant-time-analysis/commands/ct-check.md
+++ b/plugins/constant-time-analysis/commands/ct-check.md
@@ -2,11 +2,7 @@
 name: trailofbits:ct-check
 description: Detects timing side-channels in cryptographic code
 argument-hint: "<source-file> [--warnings] [--json] [--arch <arch>]"
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Bash Read Grep Glob
 ---
 
 # Check Constant-Time Properties

--- a/plugins/culture-index/skills/interpreting-culture-index/SKILL.md
+++ b/plugins/culture-index/skills/interpreting-culture-index/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: interpreting-culture-index
 description: Interprets Culture Index (CI) surveys, behavioral profiles, and personality assessment data. Supports individual profile interpretation, team composition analysis (gas/brake/glue), burnout detection, profile comparison, hiring profiles, manager coaching, interview transcript analysis for trait prediction, candidate debrief, onboarding planning, and conflict mediation. Accepts extracted JSON or PDF input via OpenCV extraction script.
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
-  - Write
+allowed-tools: Bash Read Grep Glob Write
 ---
 
 <essential_principles>

--- a/plugins/differential-review/commands/diff-review.md
+++ b/plugins/differential-review/commands/diff-review.md
@@ -2,12 +2,7 @@
 name: trailofbits:diff-review
 description: Performs security-focused differential review of code changes
 argument-hint: "<pr-url|commit-sha|diff-path> [--baseline <ref>]"
-allowed-tools:
-  - Read
-  - Write
-  - Grep
-  - Glob
-  - Bash
+allowed-tools: Read Write Grep Glob Bash
 ---
 
 # Differential Security Review

--- a/plugins/differential-review/skills/differential-review/SKILL.md
+++ b/plugins/differential-review/skills/differential-review/SKILL.md
@@ -5,12 +5,7 @@ description: >
   Adapts analysis depth to codebase size, uses git history for context, calculates
   blast radius, checks test coverage, and generates comprehensive markdown reports.
   Automatically detects and prevents security regressions.
-allowed-tools:
-  - Read
-  - Write
-  - Grep
-  - Glob
-  - Bash
+allowed-tools: Read Write Grep Glob Bash
 ---
 
 # Differential Security Review

--- a/plugins/dimensional-analysis/skills/dimensional-analysis/SKILL.md
+++ b/plugins/dimensional-analysis/skills/dimensional-analysis/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: dimensional-analysis
 description: "Annotates codebases with dimensional analysis comments documenting units, dimensions, and decimal scaling. Use when someone asks to annotate units in a codebase, perform a dimensional analysis, or find vulnerabilities in a DeFi protocol, offchain code, or other blockchain-related codebase with arithmetic. Prevents dimensional mismatches and catches formula bugs early."
-allowed-tools:
-  - Read
-  - Write
-  - Grep
-  - List
-  - Glob
-  - Task
-  - TodoRead
-  - TodoWrite
+allowed-tools: Read Write Grep List Glob Task TodoRead TodoWrite
 ---
 
 # Dimensional Analysis Skill

--- a/plugins/dwarf-expert/skills/dwarf-expert/SKILL.md
+++ b/plugins/dwarf-expert/skills/dwarf-expert/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: dwarf-expert
 description: Provides expertise for analyzing DWARF debug files and understanding the DWARF debug format/standard (v3-v5). Triggers when understanding DWARF information, interacting with DWARF files, answering DWARF-related questions, or working with code that parses DWARF data.
-allowed-tools:
-  - Read
-  - Bash
-  - Grep
-  - Glob
-  - WebSearch
+allowed-tools: Read Bash Grep Glob WebSearch
 ---
 # Overview
 This skill provides technical knowledge and expertise about the DWARF standard and how to interact with DWARF files. Tasks include answering questions about the DWARF standard, providing examples of various DWARF features, parsing and/or creating DWARF files, and writing/modifying/analyzing code that interacts with DWARF data.

--- a/plugins/entry-point-analyzer/commands/entry-points.md
+++ b/plugins/entry-point-analyzer/commands/entry-points.md
@@ -2,11 +2,7 @@
 name: trailofbits:entry-points
 description: Identifies state-changing entry points in smart contracts
 argument-hint: "[directory-path]"
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Analyze Smart Contract Entry Points

--- a/plugins/entry-point-analyzer/skills/entry-point-analyzer/SKILL.md
+++ b/plugins/entry-point-analyzer/skills/entry-point-analyzer/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: entry-point-analyzer
 description: Analyzes smart contract codebases to identify state-changing entry points for security auditing. Detects externally callable functions that modify state, categorizes them by access level (public, admin, role-restricted, contract-only), and generates structured audit reports. Excludes view/pure/read-only functions. Use when auditing smart contracts (Solidity, Vyper, Solana/Rust, Move, TON, CosmWasm) or when asked to find entry points, audit flows, external functions, access control patterns, or privileged operations.
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Entry Point Analyzer

--- a/plugins/firebase-apk-scanner/commands/scan-apk.md
+++ b/plugins/firebase-apk-scanner/commands/scan-apk.md
@@ -2,11 +2,7 @@
 name: trailofbits:scan-apk
 description: Scans Android APKs for Firebase security misconfigurations
 argument-hint: "<apk-file-or-directory>"
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Bash Read Grep Glob
 ---
 
 # Scan APK for Firebase Misconfigurations

--- a/plugins/firebase-apk-scanner/skills/firebase-apk-scanner/SKILL.md
+++ b/plugins/firebase-apk-scanner/skills/firebase-apk-scanner/SKILL.md
@@ -2,7 +2,7 @@
 name: firebase-apk-scanner
 description: Scans Android APKs for Firebase security misconfigurations including open databases, storage buckets, authentication issues, and exposed cloud functions. Use when analyzing APK files for Firebase vulnerabilities, performing mobile app security audits, or testing Firebase endpoint security. For authorized security research only.
 argument-hint: [apk-file-or-directory]
-allowed-tools: Bash({baseDir}/scanner.sh:*), Bash(apktool:*), Bash(curl:*), Read, Grep, Glob
+allowed-tools: Bash({baseDir}/scanner.sh:*) Bash(apktool:*) Bash(curl:*) Read Grep Glob
 disable-model-invocation: true
 ---
 

--- a/plugins/fp-check/skills/fp-check/SKILL.md
+++ b/plugins/fp-check/skills/fp-check/SKILL.md
@@ -1,20 +1,7 @@
 ---
 name: fp-check
 description: "Systematically verifies suspected security bugs to eliminate false positives. Produces TRUE POSITIVE or FALSE POSITIVE verdicts with documented evidence for each bug."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - LSP
-  - Bash
-  - Task
-  - Write
-  - Edit
-  - AskUserQuestion
-  - TaskCreate
-  - TaskUpdate
-  - TaskList
-  - TaskGet
+allowed-tools: Read Grep Glob LSP Bash Task Write Edit AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet
 ---
 
 # False Positive Check

--- a/plugins/git-cleanup/skills/git-cleanup/SKILL.md
+++ b/plugins/git-cleanup/skills/git-cleanup/SKILL.md
@@ -2,11 +2,7 @@
 name: git-cleanup
 description: "Safely analyzes and cleans up local git branches and worktrees by categorizing them as merged, squash-merged, superseded, or active work."
 disable-model-invocation: true
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - AskUserQuestion
+allowed-tools: Bash Read Grep AskUserQuestion
 ---
 
 # Git Cleanup

--- a/plugins/insecure-defaults/skills/insecure-defaults/SKILL.md
+++ b/plugins/insecure-defaults/skills/insecure-defaults/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: insecure-defaults
 description: "Detects fail-open insecure defaults (hardcoded secrets, weak auth, permissive security) that allow apps to run insecurely in production. Use when auditing security, reviewing config management, or analyzing environment variable handling."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Insecure Defaults Detection

--- a/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
+++ b/plugins/let-fate-decide/skills/let-fate-decide/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: let-fate-decide
 description: "Draws 4 Tarot cards to inject entropy into planning when prompts are vague, ambiguous, or casually delegated. Interprets the spread to guide next steps. Use when the user says 'let fate decide', 'YOLO', 'whatever', 'idk', or other nonchalant phrases, makes Yu-Gi-Oh references, or when you are about to arbitrarily pick between multiple reasonable approaches. Prefer over ask-questions-if-underspecified when the user's tone is casual or playful rather than precision-seeking."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Bash Read Grep Glob
 ---
 
 # Let Fate Decide

--- a/plugins/mutation-testing/skills/mutation-testing/SKILL.md
+++ b/plugins/mutation-testing/skills/mutation-testing/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: mutation-testing
 description: "Configures mewt or muton mutation testing campaigns — scopes targets, tunes timeouts, and optimizes long-running runs. Use when the user mentions mewt, muton, mutation testing, or wants to configure or optimize a mutation testing campaign."
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Grep
+allowed-tools: Read Write Bash Grep
 ---
 
 # Mutation Testing — Campaign Configuration (mewt/muton)

--- a/plugins/seatbelt-sandboxer/skills/seatbelt-sandboxer/SKILL.md
+++ b/plugins/seatbelt-sandboxer/skills/seatbelt-sandboxer/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: seatbelt-sandboxer
 description: "Generates minimal macOS Seatbelt sandbox configurations. Use when sandboxing, isolating, or restricting macOS applications with allowlist-based profiles."
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Glob
-  - Grep
+allowed-tools: Read Write Bash Glob Grep
 ---
 
 # macOS Seatbelt Sandbox Profiling

--- a/plugins/second-opinion/skills/second-opinion/SKILL.md
+++ b/plugins/second-opinion/skills/second-opinion/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: second-opinion
 description: "Runs external LLM code reviews (OpenAI Codex or Google Gemini CLI) on uncommitted changes, branch diffs, or specific commits. Use when the user asks for a second opinion, external review, codex review, gemini review, or mentions /second-opinion."
-allowed-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
-  - AskUserQuestion
+allowed-tools: Bash Read Glob Grep AskUserQuestion
 ---
 
 # Second Opinion

--- a/plugins/semgrep-rule-creator/commands/semgrep-rule.md
+++ b/plugins/semgrep-rule-creator/commands/semgrep-rule.md
@@ -2,14 +2,7 @@
 name: trailofbits:semgrep-rule
 description: Creates Semgrep rules with test-first methodology
 argument-hint: "(uses conversation context for detection pattern)"
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
-  - WebFetch
+allowed-tools: Bash Read Write Edit Glob Grep WebFetch
 ---
 
 # Create Semgrep Rule

--- a/plugins/semgrep-rule-creator/skills/semgrep-rule-creator/SKILL.md
+++ b/plugins/semgrep-rule-creator/skills/semgrep-rule-creator/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: semgrep-rule-creator
 description: Creates custom Semgrep rules for detecting security vulnerabilities, bug patterns, and code patterns. Use when writing Semgrep rules or building custom static analysis detections.
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
-  - WebFetch
+allowed-tools: Bash Read Write Edit Glob Grep WebFetch
 ---
 
 # Semgrep Rule Creator

--- a/plugins/semgrep-rule-variant-creator/skills/semgrep-rule-variant-creator/SKILL.md
+++ b/plugins/semgrep-rule-variant-creator/skills/semgrep-rule-variant-creator/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: semgrep-rule-variant-creator
 description: Creates language variants of existing Semgrep rules. Use when porting a Semgrep rule to specified target languages. Takes an existing rule and target languages as input, produces independent rule+test directories for each language.
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
-  - WebFetch
+allowed-tools: Bash Read Write Edit Glob Grep WebFetch
 ---
 
 # Semgrep Rule Variant Creator

--- a/plugins/sharp-edges/skills/sharp-edges/SKILL.md
+++ b/plugins/sharp-edges/skills/sharp-edges/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: sharp-edges
 description: "Identifies error-prone APIs, dangerous configurations, and footgun designs that enable security mistakes. Use when reviewing API designs, configuration schemas, cryptographic library ergonomics, or evaluating whether code follows 'secure by default' and 'pit of success' principles. Triggers: footgun, misuse-resistant, secure defaults, API usability, dangerous configuration."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Read Grep Glob
 ---
 
 # Sharp Edges Analysis

--- a/plugins/skill-improver/commands/cancel-skill-improver.md
+++ b/plugins/skill-improver/commands/cancel-skill-improver.md
@@ -1,7 +1,7 @@
 ---
 description: "Stops, cancels, or aborts the active skill improvement loop while preserving all changes made to skill files. Use to manually stop, cancel, abort, or kill the iteration process early."
 argument-hint: "[SESSION_ID]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/cancel-skill-improver.sh:*)"]
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/cancel-skill-improver.sh:*)
 ---
 
 # Cancel Skill Improver

--- a/plugins/skill-improver/commands/skill-improver.md
+++ b/plugins/skill-improver/commands/skill-improver.md
@@ -1,7 +1,7 @@
 ---
 description: "Iteratively reviews and fixes a Claude Code skill until it meets quality standards. Triggers on 'fix my skill', 'improve skill quality', 'skill improvement loop'."
 argument-hint: "<SKILL_NAME_OR_PATH> [--max-iterations N]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-skill-improver.sh:*)", "Task", "Read", "Edit", "Write", "Glob", "Grep"]
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-skill-improver.sh:*) Task Read Edit Write Glob Grep
 ---
 
 # Skill Improver

--- a/plugins/skill-improver/skills/skill-improver/SKILL.md
+++ b/plugins/skill-improver/skills/skill-improver/SKILL.md
@@ -1,13 +1,7 @@
 ---
 name: skill-improver
 description: "Iteratively reviews and fixes Claude Code skill quality issues until they meet standards. Runs automated fix-review cycles using the skill-reviewer agent. Use to fix skill quality issues, improve skill descriptions, run automated skill review loops, or iteratively refine a skill. Triggers on 'fix my skill', 'improve skill quality', 'skill improvement loop'. NOT for one-time reviews—use /skill-reviewer directly."
-allowed-tools:
-  - Task
-  - Read
-  - Edit
-  - Write
-  - Glob
-  - Grep
+allowed-tools: Task Read Edit Write Glob Grep
 ---
 
 # Skill Improvement Methodology

--- a/plugins/spec-to-code-compliance/commands/spec-compliance.md
+++ b/plugins/spec-to-code-compliance/commands/spec-compliance.md
@@ -2,13 +2,7 @@
 name: trailofbits:spec-compliance
 description: Verifies code implements specification requirements
 argument-hint: "<spec-document> <codebase-path>"
-allowed-tools:
-  - Read
-  - Write
-  - Grep
-  - Glob
-  - Bash
-  - WebFetch
+allowed-tools: Read Write Grep Glob Bash WebFetch
 ---
 
 # Verify Spec-to-Code Compliance

--- a/plugins/static-analysis/skills/codeql/SKILL.md
+++ b/plugins/static-analysis/skills/codeql/SKILL.md
@@ -6,20 +6,7 @@ description: >-
   codeql database", or "find vulnerabilities with codeql". Supports "run all" (security-and-quality
   + security-experimental suites) and "important only" (high-precision security findings) scan
   modes. Also handles creating data extension models and processing CodeQL SARIF output.
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
-  - AskUserQuestion
-  - TaskCreate
-  - TaskList
-  - TaskUpdate
-  - TaskGet
-  - TodoRead
-  - TodoWrite
+allowed-tools: Bash Read Write Edit Glob Grep AskUserQuestion TaskCreate TaskList TaskUpdate TaskGet TodoRead TodoWrite
 ---
 
 # CodeQL Analysis

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -5,11 +5,7 @@ description: >-
   scanners. Triggers on "parse sarif", "read scan results", "aggregate findings", "deduplicate
   alerts", or "process sarif output". Handles filtering, deduplication, format conversion, and
   CI/CD integration of SARIF data. Does NOT run scans — use the Semgrep or CodeQL skills for that.
-allowed-tools:
-  - Bash
-  - Read
-  - Glob
-  - Grep
+allowed-tools: Bash Read Glob Grep
 ---
 
 # SARIF Parsing Best Practices

--- a/plugins/static-analysis/skills/semgrep/SKILL.md
+++ b/plugins/static-analysis/skills/semgrep/SKILL.md
@@ -8,15 +8,7 @@ description: >-
   to scan code for vulnerabilities, run a security audit with Semgrep, find
   bugs, or perform static analysis. Spawns parallel workers for multi-language
   codebases.
-allowed-tools:
-  - Bash
-  - Read
-  - Glob
-  - Task
-  - AskUserQuestion
-  - TaskCreate
-  - TaskList
-  - TaskUpdate
+allowed-tools: Bash Read Glob Task AskUserQuestion TaskCreate TaskList TaskUpdate
 ---
 
 # Semgrep Security Scan

--- a/plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor/SKILL.md
+++ b/plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: supply-chain-risk-auditor
 description: "Identifies dependencies at heightened risk of exploitation or takeover. Use when assessing supply chain attack surface, evaluating dependency health, or scoping security engagements."
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Glob
-  - Grep
+allowed-tools: Read Write Bash Glob Grep
 ---
 
 # Supply Chain Risk Auditor

--- a/plugins/trailmark/skills/trailmark-structural/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-structural/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: trailmark-structural
 description: "Runs full trailmark structural analysis with all pre-analysis passes (blast radius, taint propagation, privilege boundaries, complexity hotspots). Use when vivisect needs detailed structural data for a target. Triggers: structural analysis, blast radius, taint analysis, complexity hotspots."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Bash Read Grep Glob
 ---
 
 # Trailmark Structural Analysis

--- a/plugins/trailmark/skills/trailmark-summary/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-summary/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: trailmark-summary
 description: "Runs a trailmark summary analysis on a codebase. Returns language detection, entry point count, and dependency graph shape. Use when vivisect or galvanize needs a quick structural overview. Triggers: trailmark summary, code summary, structural overview."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Bash Read Grep Glob
 ---
 
 # Trailmark Summary

--- a/plugins/variant-analysis/commands/variants.md
+++ b/plugins/variant-analysis/commands/variants.md
@@ -2,12 +2,7 @@
 name: trailofbits:variants
 description: Finds similar vulnerabilities using pattern-based analysis
 argument-hint: "(uses conversation context for bug pattern)"
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - Task
+allowed-tools: Read Grep Glob Bash Task
 ---
 
 # Find Vulnerability Variants

--- a/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md
+++ b/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md
@@ -124,7 +124,7 @@ Every workflow skill needs this skeleton, regardless of pattern:
 ---
 name: kebab-case-name
 description: "Third-person description with trigger keywords — this is how Claude decides to activate the skill"
-allowed-tools: "[minimum tools needed, space-delimited]"
+allowed-tools: [minimum tools needed, space-delimited]
 # Optional fields — see tool-assignment-guide.md for full reference:
 # disable-model-invocation: true    # Only user can invoke (not Claude)
 # user-invocable: false             # Only Claude can invoke (hidden from / menu)

--- a/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md
+++ b/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md
@@ -7,12 +7,7 @@ description: >-
   sequential pipelines, routing patterns, safety gates, task tracking,
   phased execution, or any multi-step workflow. Also applies when
   reviewing or refactoring existing workflow skills for quality.
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
-  - TodoRead
-  - TodoWrite
+allowed-tools: Read Glob Grep TodoRead TodoWrite
 ---
 
 # Designing Workflow Skills
@@ -129,8 +124,7 @@ Every workflow skill needs this skeleton, regardless of pattern:
 ---
 name: kebab-case-name
 description: "Third-person description with trigger keywords — this is how Claude decides to activate the skill"
-allowed-tools:
-  - [minimum tools needed]
+allowed-tools: "[minimum tools needed, space-delimited]"
 # Optional fields — see tool-assignment-guide.md for full reference:
 # disable-model-invocation: true    # Only user can invoke (not Claude)
 # user-invocable: false             # Only Claude can invoke (hidden from / menu)

--- a/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md
+++ b/plugins/workflow-skill-design/skills/designing-workflow-skills/SKILL.md
@@ -124,7 +124,7 @@ Every workflow skill needs this skeleton, regardless of pattern:
 ---
 name: kebab-case-name
 description: "Third-person description with trigger keywords — this is how Claude decides to activate the skill"
-allowed-tools: [minimum tools needed, space-delimited]
+allowed-tools: Tool1 Tool2 Tool3  # space-delimited list of tool names
 # Optional fields — see tool-assignment-guide.md for full reference:
 # disable-model-invocation: true    # Only user can invoke (not Claude)
 # user-invocable: false             # Only Claude can invoke (hidden from / menu)

--- a/plugins/workflow-skill-design/skills/designing-workflow-skills/references/anti-patterns.md
+++ b/plugins/workflow-skill-design/skills/designing-workflow-skills/references/anti-patterns.md
@@ -258,8 +258,7 @@ Use distinctive keywords per workflow. If two workflows genuinely overlap, add a
 
 **Before:**
 ```markdown
-allowed-tools:
-  - Bash
+allowed-tools: Bash
 ```
 ```markdown
 Find all Python files:
@@ -270,10 +269,7 @@ find . -name "*.py" -type f
 
 **After:**
 ```markdown
-allowed-tools:
-  - Glob
-  - Grep
-  - Read
+allowed-tools: Glob Grep Read
 ```
 ```markdown
 Find all Python files using Glob with pattern `**/*.py`.
@@ -289,22 +285,12 @@ Find all Python files using Glob with pattern `**/*.py`.
 
 **Before:**
 ```yaml
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Glob
-  - Grep
-  - Task
-  - AskUserQuestion
+allowed-tools: Bash Read Write Glob Grep Task AskUserQuestion
 ```
 
 **After (for a read-only analysis skill):**
 ```yaml
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
+allowed-tools: Read Glob Grep
 ```
 
 Only list tools the skill actually needs. Audit by checking which tools appear in instructions.

--- a/plugins/workflow-skill-design/skills/designing-workflow-skills/references/tool-assignment-guide.md
+++ b/plugins/workflow-skill-design/skills/designing-workflow-skills/references/tool-assignment-guide.md
@@ -111,12 +111,7 @@ Map the operation you need to the correct tool:
 Skills that examine code without modifying it:
 
 ```yaml
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
-  - TodoRead
-  - TodoWrite
+allowed-tools: Read Glob Grep TodoRead TodoWrite
 ```
 
 ### Interactive Analysis Skills
@@ -124,13 +119,7 @@ allowed-tools:
 Skills that need user input during execution:
 
 ```yaml
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
-  - AskUserQuestion
-  - TodoRead
-  - TodoWrite
+allowed-tools: Read Glob Grep AskUserQuestion TodoRead TodoWrite
 ```
 
 ### Code Generation Skills
@@ -138,14 +127,7 @@ allowed-tools:
 Skills that produce output files:
 
 ```yaml
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
-  - Write
-  - Bash
-  - TodoRead
-  - TodoWrite
+allowed-tools: Read Glob Grep Write Bash TodoRead TodoWrite
 ```
 
 ### Pipeline Skills (Multi-Step)
@@ -153,19 +135,7 @@ allowed-tools:
 Skills that orchestrate complex workflows:
 
 ```yaml
-allowed-tools:
-  - Bash
-  - Read
-  - Write
-  - Glob
-  - Grep
-  - AskUserQuestion
-  - Task
-  - TaskCreate
-  - TaskList
-  - TaskUpdate
-  - TodoRead
-  - TodoWrite
+allowed-tools: Bash Read Write Glob Grep AskUserQuestion Task TaskCreate TaskList TaskUpdate TodoRead TodoWrite
 ```
 
 ### Agents

--- a/plugins/zeroize-audit/agents/0-preflight.md
+++ b/plugins/zeroize-audit/agents/0-preflight.md
@@ -2,12 +2,7 @@
 name: 0-preflight
 description: "Performs preflight validation, config merging, TU enumeration, and work directory setup for zeroize-audit. Produces merged-config.yaml, preflight.json, and orchestrator-state.json."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
+tools: Read, Grep, Glob, Write, Bash
 ---
 
 # 0-preflight

--- a/plugins/zeroize-audit/agents/1-mcp-resolver.md
+++ b/plugins/zeroize-audit/agents/1-mcp-resolver.md
@@ -2,16 +2,7 @@
 name: 1-mcp-resolver
 description: "Resolves symbol definitions, types, and cross-file references using Serena MCP for zeroize-audit. Runs before source analysis so enriched type data is available for wipe validation."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
-  - mcp__serena__activate_project
-  - mcp__serena__find_symbol
-  - mcp__serena__find_referencing_symbols
-  - mcp__serena__get_symbols_overview
+tools: Read, Grep, Glob, Write, Bash, mcp__serena__activate_project, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__get_symbols_overview
 ---
 
 # 1-mcp-resolver

--- a/plugins/zeroize-audit/agents/2-source-analyzer.md
+++ b/plugins/zeroize-audit/agents/2-source-analyzer.md
@@ -2,12 +2,7 @@
 name: 2-source-analyzer
 description: "Identifies sensitive objects, detects wipe calls, validates correctness, and performs data-flow/heap analysis for zeroize-audit. Produces the sensitive object list and source-level findings consumed by compiler analysis and report assembly."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
+tools: Read, Grep, Glob, Write, Bash
 ---
 
 # 2-source-analyzer

--- a/plugins/zeroize-audit/agents/2b-rust-source-analyzer.md
+++ b/plugins/zeroize-audit/agents/2b-rust-source-analyzer.md
@@ -2,12 +2,7 @@
 name: 2b-rust-source-analyzer
 description: "Performs source-level zeroization analysis for Rust crates in zeroize-audit. Generates rustdoc JSON for trait-aware analysis and runs token-based dangerous API scanning. Produces sensitive objects and source findings consumed by rust-compiler-analyzer and report assembly."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
+tools: Read, Grep, Glob, Write, Bash
 ---
 
 # 2b-rust-source-analyzer

--- a/plugins/zeroize-audit/agents/3-tu-compiler-analyzer.md
+++ b/plugins/zeroize-audit/agents/3-tu-compiler-analyzer.md
@@ -2,12 +2,7 @@
 name: 3-tu-compiler-analyzer
 description: "Performs per-TU compiler-level analysis (IR diff, assembly, semantic IR, CFG) for zeroize-audit. One instance runs per translation unit, enabling parallel execution across TUs."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
+tools: Read, Grep, Glob, Write, Bash
 ---
 
 # 3-tu-compiler-analyzer

--- a/plugins/zeroize-audit/agents/3b-rust-compiler-analyzer.md
+++ b/plugins/zeroize-audit/agents/3b-rust-compiler-analyzer.md
@@ -2,12 +2,7 @@
 name: 3b-rust-compiler-analyzer
 description: "Performs crate-level MIR and LLVM IR analysis for Rust in zeroize-audit. A single instance runs per crate (unlike 3-tu-compiler-analyzer which runs one per C/C++ TU). Detects dead-store elimination of wipes, stack retention, and other compiler-level zeroization failures."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
+tools: Read, Grep, Glob, Write, Bash
 ---
 
 # 3b-rust-compiler-analyzer

--- a/plugins/zeroize-audit/agents/4-report-assembler.md
+++ b/plugins/zeroize-audit/agents/4-report-assembler.md
@@ -2,12 +2,7 @@
 name: 4-report-assembler
 description: "Collects all findings from source and compiler analysis, applies supersessions and confidence gates, normalizes IDs, and produces a comprehensive markdown report with structured JSON for downstream tools. Supports dual-mode invocation: interim (findings.json only) and final (merge PoC results, produce final-report.md)."
 model: inherit
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Write
-  - Bash
+tools: Read, Grep, Glob, Write, Bash
 ---
 
 # 4-report-assembler

--- a/plugins/zeroize-audit/agents/5-poc-generator.md
+++ b/plugins/zeroize-audit/agents/5-poc-generator.md
@@ -2,12 +2,7 @@
 name: 5-poc-generator
 description: "Crafts bespoke proof-of-concept programs demonstrating that zeroize-audit findings are exploitable. Reads source code and finding details to generate tailored PoCs — each PoC is individually written, not templated. Each PoC exits 0 if the secret persists or 1 if wiped. Mandatory for every finding."
 model: inherit
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Grep
-  - Glob
+tools: Read, Write, Bash, Grep, Glob
 ---
 
 # 5-poc-generator

--- a/plugins/zeroize-audit/agents/5b-poc-validator.md
+++ b/plugins/zeroize-audit/agents/5b-poc-validator.md
@@ -2,11 +2,7 @@
 name: 5b-poc-validator
 description: "Compiles and runs all PoCs for zeroize-audit findings. Produces poc_validation_results.json consumed by the verification agent and the orchestrator."
 model: inherit
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Grep
+tools: Read, Write, Bash, Grep
 ---
 
 # 5b-poc-validator

--- a/plugins/zeroize-audit/agents/5c-poc-verifier.md
+++ b/plugins/zeroize-audit/agents/5c-poc-verifier.md
@@ -2,11 +2,7 @@
 name: 5c-poc-verifier
 description: "Verifies that each zeroize-audit PoC actually proves the vulnerability it claims to demonstrate. Reads PoC source code, finding details, and original source to check alignment between the PoC and the finding. Produces poc_verification.json consumed by the orchestrator."
 model: inherit
-allowed-tools:
-  - Read
-  - Write
-  - Grep
-  - Glob
+tools: Read, Write, Grep, Glob
 ---
 
 # 5c-poc-verifier

--- a/plugins/zeroize-audit/agents/6-test-generator.md
+++ b/plugins/zeroize-audit/agents/6-test-generator.md
@@ -2,12 +2,7 @@
 name: 6-test-generator
 description: "Generates runtime validation test harnesses (C tests, MSAN, Valgrind targets) for confirmed zeroize-audit findings. Produces a Makefile for automated test execution."
 model: inherit
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Grep
-  - Glob
+tools: Read, Write, Bash, Grep, Glob
 ---
 
 # 6-test-generator

--- a/plugins/zeroize-audit/skills/zeroize-audit/SKILL.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/SKILL.md
@@ -1,18 +1,7 @@
 ---
 name: zeroize-audit
 description: "Detects missing zeroization of sensitive data in source code and identifies zeroization removed by compiler optimizations, with assembly-level analysis, and control-flow verification. Use for auditing C/C++/Rust code handling secrets, keys, passwords, or other sensitive data."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash
-  - Write
-  - Task
-  - AskUserQuestion
-  - mcp__serena__activate_project
-  - mcp__serena__find_symbol
-  - mcp__serena__find_referencing_symbols
-  - mcp__serena__get_symbols_overview
+allowed-tools: Read Grep Glob Bash Write Task AskUserQuestion mcp__serena__activate_project mcp__serena__find_symbol mcp__serena__find_referencing_symbols mcp__serena__get_symbols_overview
 ---
 
 # zeroize-audit — Claude Skill


### PR DESCRIPTION
Per the [agentskills.io specification](https://agentskills.io/specification#allowed-tools-field), `allowed-tools` must be a single string of space-delimited patterns, not a YAML list. Converted all 23 SKILL.md files from the `- Item` list format to the correct `"Item1 Item2"` string format. Also updated the frontmatter examples in CLAUDE.md and the workflow-skill-design skill template to match.