### PR TITLE
let-fate-decide: regression tests for missing `import os`

### DIFF
--- a/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
+++ b/plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py
@@ -199,6 +199,25 @@ def test_cli_out_of_range():
     assert result.returncode == 1
 
 
+def test_cli_content_flag():
+    """Regression for missing `import os`: --content exercises os.path calls
+    in draw() that NameError'd between PR #125 and PR #144."""
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "draw_cards.py"), "--content", "2"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    cards = json.loads(result.stdout)
+    assert len(cards) == 2
+    for card in cards:
+        assert "content" in card, "--content did not attach card content"
+        assert card["content"], "card content is empty"
+        assert "(card file not found" not in card["content"], (
+            f"card file not found: {card['file']}"
+        )
+
+
 def test_no_secure_randbelow_function():
     """Regression: the custom secure_randbelow must be removed."""
     source = Path(__file__).parent / "draw_cards.py"


### PR DESCRIPTION
## Summary
Stacks on #144. Adds `test_cli_content_flag`, a real end-to-end regression test that runs `draw_cards.py --content 2` -- the exact invocation path the agent uses -- and verifies the output JSON contains real card content (not a "file not found" placeholder). This exercises the `os.path` calls in `draw()` that NameError'd between #125 and #144.

Earlier version of this PR also had a grep-based \"does the source mention os.\" check; dropped it -- the right test is to actually call the thing.

## Verification
Against the pre-#144 broken \`draw_cards.py\` (\`40f192b\`):
\`\`\`
FAIL  test_cli_content_flag: CLI failed: Error: draw_cards.py failed: name 'os' is not defined
\`\`\`
On the #144 fix: 28/28 pass.

## Why #125 wasn't caught at merge
Most of the *existing* \`test_draw_*\` / \`test_cli_*\` tests also fail on the broken version -- the problem is they don't run in CI. \`lint.yml\` runs pre-commit + bats, \`validate.yml\` checks SKILL.md frontmatter, neither invokes Python tests. Wiring \`test_draw_cards.py\` into CI is a separate (bigger) change I left out of this PR.

## Test plan
- [x] New test passes on \`let-fate-decide-fix\`
- [x] New test fails on \`40f192b\` (pre-fix)
- [ ] CI green