### PR TITLE
ci: run plugin Python test suites (catches the PR #125 regression)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,16 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
+      - name: Install toolchain dependencies
+        # constant-time-analysis tests cross-compile C to aarch64 via clang.
+        # The aarch64 cross gcc pulls in libc6-dev-arm64-cross so clang finds
+        # <bits/libc-header-start.h> when targeting aarch64-unknown-linux-gnu.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            gcc-aarch64-linux-gnu \
+            libc6-dev-arm64-cross
       - name: Discover and run plugin Python tests
         shell: bash
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,32 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run bats tests
         run: find plugins -name "*.bats" -type f -print0 | xargs -0 --no-run-if-empty bats
+
+  python-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Discover and run plugin Python tests
+        shell: bash
+        run: |
+          set -uo pipefail
+          mapfile -d '' files < <(find plugins -type f \( -name 'test_*.py' -o -name '*_test.py' \) -print0)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Python test files found under plugins/."
+            exit 0
+          fi
+          failed=0
+          for f in "${files[@]}"; do
+            echo "::group::$f"
+            if ! python3 "$f"; then
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$failed"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,9 +53,14 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install toolchain dependencies
-        # constant-time-analysis tests cross-compile C to aarch64 via clang.
-        # The aarch64 cross gcc pulls in libc6-dev-arm64-cross so clang finds
-        # <bits/libc-header-start.h> when targeting aarch64-unknown-linux-gnu.
+        # constant-time-analysis tests cross-compile C to aarch64 via
+        # `clang --target=aarch64-unknown-linux-gnu`. Without the cross
+        # sysroot, clang fails with:
+        #   fatal error: 'bits/libc-header-start.h' file not found
+        # libc6-dev-arm64-cross supplies the aarch64 headers and crt files;
+        # gcc-aarch64-linux-gnu pulls in binutils-aarch64-linux-gnu (the
+        # cross linker clang invokes). --no-install-recommends suppresses
+        # Recommends, so each package must be listed explicitly.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -65,6 +70,8 @@ jobs:
       - name: Discover and run plugin Python tests
         shell: bash
         run: |
+          # Intentionally omit -e: we want every test file to run even if
+          # one fails, then exit with a combined failure code via `failed`.
           set -uo pipefail
           mapfile -d '' files < <(find plugins -type f \( -name 'test_*.py' -o -name '*_test.py' \) -print0)
           if [ "${#files[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary
Adds a `python-tests` job to `lint.yml`, parallel to the existing `bats` job. Discovers `test_*.py` / `*_test.py` under `plugins/` and runs each as a script. Currently exercises:

- `plugins/constant-time-analysis/ct_analyzer/tests/test_analyzer.py` (unittest, 60 tests)
- `plugins/let-fate-decide/skills/let-fate-decide/scripts/test_draw_cards.py` (stdlib self-runner, 27 tests)

Both test files already existed; no CI job invoked them.

## Motivation
PR #125 ("replace os.urandom with secrets.randbelow") removed `import os` but left `os.path` calls inside `draw()`. Ruff F821 catches this today, but the check went green at merge time (the PR's head commit was pushed 12 days before merge and wasn't re-run against drifted main). The existing `test_draw_*` / `test_cli_*` tests in `test_draw_cards.py` would also have caught it — `draw()` raises `NameError` on every call — but no CI job ran them. PR #144 fixes the one-line import.

A Python-tests CI job would have caught the regression independently of ruff.

## Expected CI behavior on this PR
**The `python-tests` job will FAIL on this PR until #144 merges.** That failure is the point — it demonstrates the regression. Once #144 lands on main, rebase this PR and the job goes green. Suggested merge order:

1. Merge #144 (one-line `import os` fix)
2. Rebase & merge this PR

Or merge both together; either way the end state is green.

## Design notes
- Executes tests as scripts (`python3 path/to/test.py`) rather than invoking `pytest`. Matches how the existing tests are authored (each has an `if __name__ == '__main__':` main block or uses `unittest`'s auto-discovery), avoids pytest rootdir/conftest surprises, and keeps the job dependency-free.
- `find` discovery means new plugin test files are picked up automatically — no per-plugin config.
- Job uses `::group::` folding so each test file's output is collapsed in the Actions UI.

## Test plan
- [x] Locally, discovery finds both existing test files
- [x] Both pass on the #144 fix branch (`let-fate-decide-fix`)
- [x] `test_draw_cards.py` fails on current `main` (the #125 bug), `test_analyzer.py` passes
- [ ] CI fails on this PR (expected) until #144 merges