### PR TITLE
fix: shorten Claude in Chrome skill name

### DIFF
--- a/plugins/claude-in-chrome-troubleshooting/skills/claude-in-chrome-troubleshooting/SKILL.md
+++ b/plugins/claude-in-chrome-troubleshooting/skills/claude-in-chrome-troubleshooting/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: claude-in-chrome-troubleshooting
+name: chrome-mcp-troubleshooting
 description: Diagnose and fix Claude in Chrome MCP extension connectivity issues. Use when mcp__claude-in-chrome__* tools fail, return "Browser extension is not connected", or behave erratically.
 ---
 


### PR DESCRIPTION
## Summary
- shorten the Claude in Chrome skill frontmatter name to keep the plugin-prefixed skill name under the 64-character limit
- preserve the plugin path and install surface so only the invalid metadata changes

## Verification
- ran `python3 .github/scripts/validate_codex_skills.py`
- verified the full prefixed skill name length is now 59 characters
