### PR TITLE
Refresh trailmark skills for public Trailmark 0.2.x

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -225,7 +225,7 @@
     },
     {
       "name": "trailmark",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "description": "Builds multi-language source code graphs for security analysis: call graphs, attack surface mapping, blast radius, taint propagation, complexity hotspots, and entry point enumeration. Generates Mermaid diagrams (call graphs, class hierarchies, dependency maps, heatmaps). Compares code graph snapshots for structural diff and evolution analysis. Runs graph-informed mutation testing triage (genotoxic). Generates mutation-driven test vectors (vector-forge). Extracts crypto protocol message flows and converts Mermaid diagrams to ProVerif models. Projects SARIF and weAudit findings onto code graphs. Use when analyzing call paths, mapping attack surface, visualizing code architecture, triaging survived mutants, generating cryptographic test vectors, diagramming crypto protocols, formally verifying protocols, or augmenting audits with static analysis findings.",
       "author": {
         "name": "Scott Arciszewski",

--- a/plugins/trailmark/.claude-plugin/plugin.json
+++ b/plugins/trailmark/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trailmark",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Builds multi-language source code graphs for security analysis: call graphs, attack surface mapping, blast radius, taint propagation, complexity hotspots, and entry point enumeration. Generates Mermaid diagrams (call graphs, class hierarchies, dependency maps, heatmaps). Compares code graph snapshots for structural diff and evolution analysis. Runs graph-informed mutation testing triage (genotoxic). Generates mutation-driven test vectors (vector-forge). Extracts crypto protocol message flows and converts Mermaid diagrams to ProVerif models. Projects SARIF and weAudit findings onto code graphs. Use when analyzing call paths, mapping attack surface, visualizing code architecture, triaging survived mutants, generating cryptographic test vectors, diagramming crypto protocols, formally verifying protocols, or augmenting audits with static analysis findings.",
   "author": {
     "name": "Scott Arciszewski",

--- a/plugins/trailmark/README.md
+++ b/plugins/trailmark/README.md
@@ -2,6 +2,10 @@
 
 **Source code graph analysis for security auditing.** Parses code into queryable graphs of functions, classes, and calls, then uses that structure for diagram generation, mutation testing triage, protocol verification, and differential review.
 
+These skills target Trailmark 0.2.x. Prefer `--language auto`,
+`trailmark.parse.detect_languages()`, and `QueryEngine.preanalysis()`
+instead of older 0.1.x-era manual language detection workflows.
+
 ## Prerequisites
 
 [Trailmark](https://pypi.org/project/trailmark/) ([source](https://github.com/trailofbits/trailmark)) must be installed:
@@ -22,7 +26,7 @@ uv pip install trailmark
 | `graph-evolution` | Compare code graphs at two snapshots to surface security-relevant structural changes text diffs miss |
 | `mermaid-to-proverif` | Convert Mermaid sequence diagrams into ProVerif formal verification models |
 | `audit-augmentation` | Project SARIF and weAudit findings onto code graphs as annotations and subgraphs |
-| `trailmark-summary` | Quick structural overview (language detection, entry points, dependencies) for vivisect/galvanize |
+| `trailmark-summary` | Quick structural overview (auto-detected languages, entry points, dependencies) for vivisect/galvanize |
 | `trailmark-structural` | Full structural analysis with all pre-analysis passes (blast radius, taint, privilege boundaries, complexity) |
 
 ## Directory Structure

--- a/plugins/trailmark/skills/audit-augmentation/SKILL.md
+++ b/plugins/trailmark/skills/audit-augmentation/SKILL.md
@@ -73,7 +73,7 @@ uv run trailmark augment {targetDir} \
 ```python
 from trailmark.query.api import QueryEngine
 
-engine = QueryEngine.from_directory("{targetDir}", language="python")
+engine = QueryEngine.from_directory("{targetDir}", language="auto")
 
 # Run pre-analysis first for cross-referencing
 engine.preanalysis()
@@ -93,6 +93,9 @@ engine.subgraph("sarif:semgrep")                        # By tool name
 engine.annotations_of("function_name")                  # Per-node lookup
 ```
 
+If auto-detection is wrong for the target, rerun with an explicit language or
+comma-separated list such as `python,rust`.
+
 ## Workflow
 
 ```
@@ -108,9 +111,12 @@ Augmentation Progress:
 context:
 
 ```python
-engine = QueryEngine.from_directory("{targetDir}", language="{lang}")
+engine = QueryEngine.from_directory("{targetDir}", language="auto")
 engine.preanalysis()
 ```
+
+If auto-detection is wrong for the target, rerun with an explicit language or
+comma-separated list such as `python,rust`.
 
 **Step 2:** Locate input files:
 - **SARIF**: Usually output by tools like `semgrep --sarif -o results.sarif`

--- a/plugins/trailmark/skills/diagramming-code/SKILL.md
+++ b/plugins/trailmark/skills/diagramming-code/SKILL.md
@@ -48,7 +48,7 @@ report the error to the user.
 
 ```bash
 uv run {baseDir}/scripts/diagram.py \
-    --target {targetDir} --type call-graph \
+    --target {targetDir} --language auto --type call-graph \
     --focus main --depth 2
 ```
 
@@ -91,18 +91,21 @@ Diagram Progress:
 - [ ] Step 6: Embed diagram in response
 ```
 
-**Step 1:** Run `uv run trailmark analyze --summary {targetDir}`. Install
+**Step 1:** Run `uv run trailmark analyze --language auto --summary {targetDir}`. Install
 if it fails. Then run pre-analysis via the programmatic API:
 
 ```python
 from trailmark.query.api import QueryEngine
 
-engine = QueryEngine.from_directory("{targetDir}", language="{lang}")
+engine = QueryEngine.from_directory("{targetDir}", language="auto")
 engine.preanalysis()
 ```
 
 Pre-analysis enriches the graph with blast radius, taint propagation,
 and privilege boundary data used by `data-flow` diagrams.
+
+If auto-detection is wrong for the target, rerun with an explicit language or
+comma-separated list such as `python,rust`.
 
 **Step 2:** Match the user's request to a `--type` using the decision tree
 above.
@@ -170,6 +173,10 @@ reduce clutter. The script warns if the diagram exceeds 100 nodes.
 
 **Focus:** Always use `--focus` for `call-graph` on non-trivial codebases.
 For `data-flow`, omitting focus auto-targets the top 10 complexity hotspots.
+
+**Language:** Prefer `--language auto` for polyglot or unfamiliar repos.
+Use an explicit language only when you know the target is single-language or
+you need to exclude unrelated components.
 
 ---
 

--- a/plugins/trailmark/skills/genotoxic/SKILL.md
+++ b/plugins/trailmark/skills/genotoxic/SKILL.md
@@ -71,7 +71,7 @@ false positives, missing unit tests, and fuzzing targets.
 
 ```bash
 # 1. Build the code graph
-uv run trailmark analyze --summary {targetDir}
+uv run trailmark analyze --language auto --summary {targetDir}
 
 # 2. Run mutation testing (language-dependent)
 # Python:
@@ -132,13 +132,16 @@ mutation testing. Pre-analysis computes blast radius, entry points, privilege
 boundaries, and taint propagation, which Phase 3 uses for triage.
 
 ```bash
-uv run trailmark analyze --summary {targetDir}
+uv run trailmark analyze --language auto --summary {targetDir}
 ```
 
 Use the `QueryEngine` API to build the graph and run pre-analysis:
-1. `QueryEngine.from_directory("{targetDir}", language="{lang}")`
+1. `QueryEngine.from_directory("{targetDir}", language="auto")`
 2. Call `engine.preanalysis()` — **mandatory** before triage
 3. Export with `engine.to_json()` for cross-referencing with mutation results
+
+If auto-detection is wrong for the target, rerun with an explicit language or
+comma-separated list such as `python,rust`.
 
 See [references/graph-analysis.md](references/graph-analysis.md) for the
 full API: node mapping, reachability queries, blast radius, and

--- a/plugins/trailmark/skills/genotoxic/references/graph-analysis.md
+++ b/plugins/trailmark/skills/genotoxic/references/graph-analysis.md
@@ -61,11 +61,7 @@ Determine whether a mutated function is reachable from untrusted input.
 ```python
 def is_entrypoint_reachable(engine, node_id: str) -> bool:
     """Check if any entrypoint can reach this node."""
-    for ep in engine.attack_surface():
-        paths = engine.paths_between(ep["node_id"], node_id)
-        if paths:
-            return True
-    return False
+    return bool(engine.entrypoint_paths_to(node_id))
 ```
 
 ### Entrypoint Path Details
@@ -75,17 +71,19 @@ For fuzzing targets, include the specific entrypoint paths in the report:
 ```python
 def entrypoint_paths(engine, node_id: str) -> list[dict]:
     """Get all entrypoint paths to this node with metadata."""
+    surface_by_id = {
+        ep["node_id"]: ep for ep in engine.attack_surface()
+    }
     results = []
-    for ep in engine.attack_surface():
-        paths = engine.paths_between(ep["node_id"], node_id)
-        for path in paths:
-            results.append({
-                "entrypoint": ep["node_id"],
-                "trust_level": ep["trust_level"],
-                "kind": ep["kind"],
-                "path": path,
-                "hops": len(path),
-            })
+    for path in engine.entrypoint_paths_to(node_id):
+        ep = surface_by_id.get(path[0], {})
+        results.append({
+            "entrypoint": path[0],
+            "trust_level": ep.get("trust_level"),
+            "kind": ep.get("kind"),
+            "path": path,
+            "hops": len(path),
+        })
     return results
 ```
 
@@ -129,17 +127,18 @@ For critical functions, calculate transitive callers (all functions
 that eventually call this one):
 
 ```python
-from trailmark.storage.graph_store import GraphStore
-
-# Build the store from the graph
-store = GraphStore(graph)
-
-# All nodes that can reach this function
-# (predecessors in the call graph)
-transitive = store.entrypoint_paths_to(node_id)
-transitive_count = len(set(
-    node for path in transitive for node in path
-))
+def transitive_context(engine, node_id: str) -> dict:
+    """Calculate transitive caller and entrypoint context."""
+    ancestors = [
+        node for node in engine.ancestors_of(node_id)
+        if node["kind"] in {"function", "method"}
+    ]
+    paths = engine.entrypoint_paths_to(node_id)
+    return {
+        "transitive_callers": len(ancestors),
+        "entrypoint_paths": len(paths),
+        "entrypoint_reachable": bool(paths),
+    }
 ```
 
 ### Blast Radius Classification

--- a/plugins/trailmark/skills/graph-evolution/SKILL.md
+++ b/plugins/trailmark/skills/graph-evolution/SKILL.md
@@ -84,7 +84,7 @@ programmatically. If installation fails, report the error.
 │  └─ Read: references/report-format.md
 │
 ├─ Already have two graph JSON exports?
-│  └─ Jump to Phase 3 (run graph_diff.py directly)
+│  └─ Jump to Phase 3 (run native diff + graph_diff.py)
 │
 └─ Starting from two git refs?
    └─ Start at Phase 1
@@ -128,10 +128,9 @@ Pre-analysis computes blast radius, taint propagation, privilege
 boundaries, and entrypoint enumeration.
 
 ```python
-import json
 from trailmark.query.api import QueryEngine
 
-def build_and_export(target_dir, language, output_path):
+def build_and_export(target_dir, output_path, language="auto"):
     """Build graph, run pre-analysis, export JSON."""
     engine = QueryEngine.from_directory(target_dir, language=language)
     engine.preanalysis()
@@ -146,43 +145,57 @@ before_json = os.path.join(work_dir, "before_graph.json")
 after_json = os.path.join(work_dir, "after_graph.json")
 
 before_summary = build_and_export(
-    "{before_dir}", "{lang}", before_json
+    "{before_dir}", before_json
 )
 after_summary = build_and_export(
-    "{after_dir}", "{lang}", after_json
+    "{after_dir}", after_json
 )
 ```
 
 Verify both graphs built successfully by checking the summary output.
-If either fails, check that the language parameter matches the codebase
-and that trailmark supports all file types present.
+If either fails, rerun with an explicit language or comma-separated list
+instead of `auto`.
 
 ### Phase 3: Compute Structural Diff
 
-Run the diff script on the two exported JSON files (using the same
-`work_dir` from Phase 2):
+Run **both**:
+
+1. Trailmark's native structural diff for nodes, edges, and entrypoints
+2. The plugin's `graph_diff.py` helper for subgraph membership changes
+
+Using the same `work_dir` from Phase 2:
 
 ```bash
+trailmark diff --json "{before_dir}" "{after_dir}" > "{work_dir}/trailmark_diff.json" 2>/dev/null || \
+  uv run trailmark diff --json "{before_dir}" "{after_dir}" > "{work_dir}/trailmark_diff.json"
+
 uv run {baseDir}/scripts/graph_diff.py \
     --before "{before_json}" \
-    --after "{after_json}" > "{work_dir}/evolution_diff.json"
+    --after "{after_json}" > "{work_dir}/subgraph_diff.json"
 ```
 
-The output JSON contains:
+The native Trailmark diff contains:
 
 | Key | Contents |
 |-----|----------|
 | `summary_delta` | Changes in node/edge/entrypoint counts |
 | `nodes.added` | New functions, classes, methods |
 | `nodes.removed` | Deleted functions, classes, methods |
-| `nodes.modified` | Functions with changed CC, params, return type, span |
+| `nodes.modified` | Functions with changed CC, params, line span |
 | `edges.added` | New call/inheritance/import relationships |
 | `edges.removed` | Deleted relationships |
+| `entrypoints` | Added, removed, and modified entrypoints |
+
+The subgraph diff contains:
+
+| Key | Contents |
+|-----|----------|
 | `subgraphs` | Per-subgraph membership changes (tainted, high_blast_radius, etc.) |
 
 ### Phase 4: Interpret Diff and Generate Report
 
-Read the diff JSON and generate a security-focused markdown report.
+Read **both** diff JSON files and generate a security-focused markdown
+report.
 See [references/report-format.md](references/report-format.md) for
 the full template.
 
@@ -192,8 +205,9 @@ the full template.
    especially if they also appear in added edges targeting sensitive
    functions
 2. **Privilege boundary changes** — new or removed trust transitions
+   from the native entrypoint/edge diff plus the subgraph diff
 3. **Attack surface growth** — new entrypoints, especially
-   `untrusted_external`
+   `untrusted_external`, from `trailmark_diff.json`
 4. **Blast radius increases** — nodes entering `high_blast_radius`
 5. **Complexity spikes** — CC increases > 3 on tainted or
    entrypoint-reachable nodes
@@ -228,11 +242,21 @@ git worktree remove "{after_dir}"
 
 ---
 
-## Diff Script Reference
+## Diff Reference
 
 ```
+trailmark diff --json BEFORE AFTER
 uv run {baseDir}/scripts/graph_diff.py [OPTIONS]
 ```
+
+Use `trailmark diff` for:
+- Node/edge changes
+- Added/removed/modified entrypoints
+- Human-readable structural diff reports
+
+Use `graph_diff.py` for:
+- Subgraph membership changes derived from `engine.preanalysis()`
+- `tainted`, `high_blast_radius`, `privilege_boundary`, and related sets
 
 | Argument | Default | Description |
 |----------|---------|-------------|
@@ -240,8 +264,8 @@ uv run {baseDir}/scripts/graph_diff.py [OPTIONS]
 | `--after` | required | Path to the "after" graph JSON |
 | `--indent` | `2` | JSON output indentation |
 
-Input format: Trailmark JSON exports from `engine.to_json()`.
-Output: JSON structural diff to stdout.
+`graph_diff.py` input format: Trailmark JSON exports from `engine.to_json()`.
+`graph_diff.py` output: JSON structural diff for nodes, edges, and subgraphs.
 
 ---
 
@@ -251,7 +275,8 @@ Before delivering the report:
 
 - [ ] Both graphs built successfully (check summaries)
 - [ ] Pre-analysis ran on both snapshots
-- [ ] Structural diff computed (non-empty diff JSON)
+- [ ] Native Trailmark diff computed (`trailmark_diff.json`)
+- [ ] Subgraph diff computed (`subgraph_diff.json`)
 - [ ] All subgraph changes interpreted (tainted, blast radius, etc.)
 - [ ] Critical findings include evidence (node IDs, edge diffs)
 - [ ] Severity levels assigned to all findings

--- a/plugins/trailmark/skills/graph-evolution/SKILL.md
+++ b/plugins/trailmark/skills/graph-evolution/SKILL.md
@@ -166,13 +166,16 @@ Run **both**:
 Using the same `work_dir` from Phase 2:
 
 ```bash
-trailmark diff --json "{before_dir}" "{after_dir}" > "{work_dir}/trailmark_diff.json" 2>/dev/null || \
+trailmark diff --json "{before_dir}" "{after_dir}" > "{work_dir}/trailmark_diff.json" || \
   uv run trailmark diff --json "{before_dir}" "{after_dir}" > "{work_dir}/trailmark_diff.json"
 
 uv run {baseDir}/scripts/graph_diff.py \
     --before "{before_json}" \
     --after "{after_json}" > "{work_dir}/subgraph_diff.json"
 ```
+
+If either diff command fails or writes an empty JSON file, stop and report the
+error instead of continuing to Phase 4.
 
 The native Trailmark diff contains:
 
@@ -275,8 +278,8 @@ Before delivering the report:
 
 - [ ] Both graphs built successfully (check summaries)
 - [ ] Pre-analysis ran on both snapshots
-- [ ] Native Trailmark diff computed (`trailmark_diff.json`)
-- [ ] Subgraph diff computed (`subgraph_diff.json`)
+- [ ] Native Trailmark diff computed and non-empty (`trailmark_diff.json`)
+- [ ] Subgraph diff computed and non-empty (`subgraph_diff.json`)
 - [ ] All subgraph changes interpreted (tainted, blast radius, etc.)
 - [ ] Critical findings include evidence (node IDs, edge diffs)
 - [ ] Severity levels assigned to all findings

--- a/plugins/trailmark/skills/trailmark-structural/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-structural/SKILL.md
@@ -55,26 +55,34 @@ trailmark themselves.
 **Step 2: Detect languages with Trailmark's parse API.**
 
 ```bash
-python3 -c 'from trailmark.parse import detect_languages; import json; print(json.dumps(detect_languages(r"{args}")))' 2>/dev/null
+python3 - "{args}" <<'PY'
+import json
+import sys
+
+from trailmark.parse import detect_languages
+
+print(json.dumps(detect_languages(sys.argv[1])))
+PY
 ```
 
-If the import fails, rerun the same command under `uv run python -c ...`.
+If the import fails, rerun the same snippet with `uv run python - "{args}"`.
 If the result is `[]`, report "Trailmark found no supported languages under
 target" and return.
 
 **Step 3: Run the full structural analysis via `QueryEngine`.**
 
 Run this snippet with `python3`. If the import fails, rerun the same snippet
-under `uv run python`.
+under `uv run python - "{args}"`.
 
 ```bash
-python3 - <<'PY'
+python3 - "{args}" <<'PY'
 import json
+import sys
 
 from trailmark.parse import detect_languages
 from trailmark.query.api import QueryEngine
 
-target = r"{args}"
+target = sys.argv[1]
 languages = detect_languages(target)
 engine = QueryEngine.from_directory(target, language="auto")
 preanalysis = engine.preanalysis()

--- a/plugins/trailmark/skills/trailmark-structural/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-structural/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trailmark-structural
-description: "Runs full trailmark structural analysis with all pre-analysis passes (blast radius, taint propagation, privilege boundaries, complexity hotspots). Use when vivisect needs detailed structural data for a target. Triggers: structural analysis, blast radius, taint analysis, complexity hotspots."
+description: "Runs full Trailmark structural analysis on Trailmark 0.2.x by building a graph, running `preanalysis()`, and reporting hotspots, taint, blast radius, privilege boundaries, and attack surface. Use when vivisect needs detailed structural data for a target. Triggers: structural analysis, blast radius, taint analysis, complexity hotspots."
 allowed-tools:
   - Bash
   - Read
@@ -10,7 +10,8 @@ allowed-tools:
 
 # Trailmark Structural Analysis
 
-Runs `trailmark analyze` with all four pre-analysis passes.
+Builds a Trailmark graph and runs `engine.preanalysis()` to compute all
+four pre-analysis passes.
 
 ## When to Use
 
@@ -51,57 +52,64 @@ and return. Do NOT run `pip install`, `uv pip install`,
 `git clone`, or any install command. The user must install
 trailmark themselves.
 
-**Step 2: Detect the primary language.**
+**Step 2: Detect languages with Trailmark's parse API.**
 
 ```bash
-find {args} -type f \( -name '*.rs' -o -name '*.py' \
-  -o -name '*.go' -o -name '*.js' -o -name '*.jsx' \
-  -o -name '*.ts' -o -name '*.tsx' -o -name '*.sol' \
-  -o -name '*.c' -o -name '*.h' -o -name '*.cpp' \
-  -o -name '*.hpp' -o -name '*.hh' -o -name '*.cc' \
-  -o -name '*.cxx' -o -name '*.hxx' \
-  -o -name '*.rb' -o -name '*.php' -o -name '*.cs' \
-  -o -name '*.java' -o -name '*.hs' -o -name '*.erl' \
-  -o -name '*.cairo' -o -name '*.circom' \) 2>/dev/null | \
-  sed 's/.*\.//' | sort | uniq -c | sort -rn | head -5
+python3 -c 'from trailmark.parse import detect_languages; import json; print(json.dumps(detect_languages(r"{args}")))' 2>/dev/null
 ```
 
-Map the most common extension to a language flag:
-- `.rs` -> `--language rust`
-- `.py` -> (no flag, Python is default)
-- `.go` -> `--language go`
-- `.js`/`.jsx` -> `--language javascript`
-- `.ts`/`.tsx` -> `--language typescript`
-- `.sol` -> `--language solidity`
-- `.c`/`.h` -> `--language c`
-- `.cpp`/`.hpp`/`.hh`/`.cc`/`.cxx`/`.hxx` -> `--language cpp`
-- `.rb` -> `--language ruby`
-- `.php` -> `--language php`
-- `.cs` -> `--language c_sharp`
-- `.java` -> `--language java`
-- `.hs` -> `--language haskell`
-- `.erl` -> `--language erlang`
-- `.cairo` -> `--language cairo`
-- `.circom` -> `--language circom`
+If the import fails, rerun the same command under `uv run python -c ...`.
+If the result is `[]`, report "Trailmark found no supported languages under
+target" and return.
 
-**Step 3: Run the full structural analysis.**
+**Step 3: Run the full structural analysis via `QueryEngine`.**
+
+Run this snippet with `python3`. If the import fails, rerun the same snippet
+under `uv run python`.
 
 ```bash
-trailmark analyze \
-  --passes blast_radius,taint,privilege_boundary,complexity \
-  {language_flag} {args} 2>&1 || \
-uv run trailmark analyze \
-  --passes blast_radius,taint,privilege_boundary,complexity \
-  {language_flag} {args} 2>&1
+python3 - <<'PY'
+import json
+
+from trailmark.parse import detect_languages
+from trailmark.query.api import QueryEngine
+
+target = r"{args}"
+languages = detect_languages(target)
+engine = QueryEngine.from_directory(target, language="auto")
+preanalysis = engine.preanalysis()
+
+def summarize_subgraph(name: str, limit: int = 25) -> dict[str, object]:
+    nodes = engine.subgraph(name)
+    return {
+        "count": len(nodes),
+        "sample_ids": [node["id"] for node in nodes[:limit]],
+    }
+
+payload = {
+    "languages": languages,
+    "summary": engine.summary(),
+    "preanalysis": preanalysis,
+    "attack_surface": engine.attack_surface()[:25],
+    "hotspots": engine.complexity_hotspots(10)[:25],
+    "subgraphs": {
+        name: summarize_subgraph(name)
+        for name in engine.subgraph_names()
+    },
+}
+
+print(json.dumps(payload, indent=2))
+PY
 ```
 
 **Step 4: Verify the output.**
 
 The output should include:
-- Hotspot scores (complexity data)
-- Tainted node list (taint propagation data)
-- Blast radius data
-- Privilege boundary information
+- `languages`
+- `summary`
+- `preanalysis`
+- `hotspots` (possibly empty)
+- `subgraphs` with counts and sample IDs
 
-Some passes may produce no data for some codebases (this is
-normal). Return the full output regardless.
+Some subgraphs may have zero nodes for some codebases (this is
+normal). Return the full JSON payload regardless.

--- a/plugins/trailmark/skills/trailmark-summary/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-summary/SKILL.md
@@ -54,10 +54,17 @@ trailmark themselves.
 **Step 2: Detect languages with Trailmark's parse API.**
 
 ```bash
-python3 -c 'from trailmark.parse import detect_languages; import json; print(json.dumps(detect_languages(r"{args}")))' 2>/dev/null
+python3 - "{args}" <<'PY'
+import json
+import sys
+
+from trailmark.parse import detect_languages
+
+print(json.dumps(detect_languages(sys.argv[1])))
+PY
 ```
 
-If the import fails, rerun the same command under `uv run python -c ...`.
+If the import fails, rerun the same snippet with `uv run python - "{args}"`.
 If the result is `[]`, report "Trailmark found no supported languages under
 target" and return.
 

--- a/plugins/trailmark/skills/trailmark-summary/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trailmark-summary
-description: "Runs a trailmark summary analysis on a codebase. Returns language detection, entry point count, and dependency graph shape. Use when vivisect or galvanize needs a quick structural overview. Triggers: trailmark summary, code summary, structural overview."
+description: "Runs a Trailmark summary analysis on a codebase. Returns auto-detected languages, entry point count, and dependency list. Use when vivisect or galvanize needs a quick structural overview. Triggers: trailmark summary, code summary, structural overview."
 allowed-tools:
   - Bash
   - Read
@@ -10,12 +10,12 @@ allowed-tools:
 
 # Trailmark Summary
 
-Runs `trailmark analyze --summary` on a target directory.
+Runs `trailmark analyze --language auto --summary` on a target directory.
 
 ## When to Use
 
 - Vivisect Phase 0 needs a quick structural overview before decomposition
-- Galvanize Phase 1 needs language detection and entry point count
+- Galvanize Phase 1 needs detected languages and entry point count
 - Quick orientation on an unfamiliar codebase before deeper analysis
 
 ## When NOT to Use
@@ -28,9 +28,9 @@ Runs `trailmark analyze --summary` on a target directory.
 
 | Rationalization | Why It's Wrong | Required Action |
 |-----------------|----------------|-----------------|
-| "I can read the code manually instead" | Manual reading misses dependency graph shape and entry point enumeration | Install and run trailmark |
-| "Language detection doesn't matter" | Wrong language flag produces empty or incorrect analysis | Detect language from file extensions first |
-| "Partial output is good enough" | Missing any of the three required outputs (language, entry points, dependencies) means incomplete analysis | Verify all three are present |
+| "I can read the code manually instead" | Manual reading misses parser-based language detection, dependency data, and entry point enumeration | Install and run trailmark |
+| "Language detection doesn't matter" | Wrong language selection produces empty or partial analysis | Use Trailmark's parser-based detection or `--language auto` |
+| "Partial output is good enough" | Missing any of the three required outputs (detected languages, entry points, dependencies) means incomplete analysis | Verify all three are present |
 | "Tool isn't installed, I'll skip it" | This skill exists specifically to run trailmark | Report the installation gap instead of skipping |
 
 ## Usage
@@ -51,53 +51,30 @@ and return. Do NOT run `pip install`, `uv pip install`,
 `git clone`, or any install command. The user must install
 trailmark themselves.
 
-**Step 2: Detect the primary language.**
+**Step 2: Detect languages with Trailmark's parse API.**
 
 ```bash
-find {args} -type f \( -name '*.rs' -o -name '*.py' \
-  -o -name '*.go' -o -name '*.js' -o -name '*.jsx' \
-  -o -name '*.ts' -o -name '*.tsx' -o -name '*.sol' \
-  -o -name '*.c' -o -name '*.h' -o -name '*.cpp' \
-  -o -name '*.hpp' -o -name '*.hh' -o -name '*.cc' \
-  -o -name '*.cxx' -o -name '*.hxx' \
-  -o -name '*.rb' -o -name '*.php' -o -name '*.cs' \
-  -o -name '*.java' -o -name '*.hs' -o -name '*.erl' \
-  -o -name '*.cairo' -o -name '*.circom' \) 2>/dev/null | \
-  sed 's/.*\.//' | sort | uniq -c | sort -rn | head -5
+python3 -c 'from trailmark.parse import detect_languages; import json; print(json.dumps(detect_languages(r"{args}")))' 2>/dev/null
 ```
 
-Map the most common extension to a language flag:
-- `.rs` -> `--language rust`
-- `.py` -> (no flag, Python is default)
-- `.go` -> `--language go`
-- `.js`/`.jsx` -> `--language javascript`
-- `.ts`/`.tsx` -> `--language typescript`
-- `.sol` -> `--language solidity`
-- `.c`/`.h` -> `--language c`
-- `.cpp`/`.hpp`/`.hh`/`.cc`/`.cxx`/`.hxx` -> `--language cpp`
-- `.rb` -> `--language ruby`
-- `.php` -> `--language php`
-- `.cs` -> `--language c_sharp`
-- `.java` -> `--language java`
-- `.hs` -> `--language haskell`
-- `.erl` -> `--language erlang`
-- `.cairo` -> `--language cairo`
-- `.circom` -> `--language circom`
+If the import fails, rerun the same command under `uv run python -c ...`.
+If the result is `[]`, report "Trailmark found no supported languages under
+target" and return.
 
-**Step 3: Run the summary.**
+**Step 3: Run the summary with auto-detection.**
 
 ```bash
-trailmark analyze --summary {language_flag} {args} 2>&1 || \
-  uv run trailmark analyze --summary {language_flag} {args} 2>&1
+trailmark analyze --language auto --summary {args} 2>&1 || \
+  uv run trailmark analyze --language auto --summary {args} 2>&1
 ```
 
 **Step 4: Verify the output.**
 
 The output must include ALL THREE of:
-1. Language detection (at least one language name)
-2. Entry point count (or "no entry points found")
-3. Dependency graph shape (module count or "single module")
+1. Detected languages from Step 2
+2. `Entrypoints:` line from the summary output
+3. `Dependencies:` line from the summary output
 
 If any are missing, report the gap. Do not fabricate output.
 
-Return the full trailmark output.
+Return the detected language list plus the full Trailmark summary output.

--- a/plugins/trailmark/skills/trailmark/SKILL.md
+++ b/plugins/trailmark/skills/trailmark/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: trailmark
-description: "Builds and queries multi-language source code graphs for security analysis. Includes pre-analysis passes for blast radius, taint propagation, privilege boundaries, and entry point enumeration. Use when analyzing call paths, mapping attack surface, finding complexity hotspots, enumerating entry points, tracing taint propagation, measuring blast radius, or building a code graph for audit prioritization. Supports 16 languages including Solidity, Cairo, Circom, Rust, Go, Python, C/C++, TypeScript."
+description: "Builds and queries multi-language source code graphs for security analysis. Includes pre-analysis passes for blast radius, taint propagation, privilege boundaries, and entry point enumeration. Use when analyzing call paths, mapping attack surface, finding complexity hotspots, enumerating entry points, tracing taint propagation, measuring blast radius, or building a code graph for audit prioritization. Prefer `trailmark.parse.detect_languages()` or `--language auto` when the target language is unknown or polyglot."
 ---
 
 # Trailmark
 
 Parses source code into a directed graph of functions, classes, calls, and
-semantic metadata for security analysis. Supports 16 languages.
+semantic metadata for security analysis.
 
 ## When to Use
 
@@ -55,25 +55,30 @@ to the user instead of silently switching to manual code reading.
 ## Quick Start
 
 ```bash
-# Python (default)
-uv run trailmark analyze --summary {targetDir}
+# Auto-detect and merge every supported language under the tree
+uv run trailmark analyze --language auto --summary {targetDir}
 
-# Other languages
+# Explicit languages (single language or comma-separated list)
 uv run trailmark analyze --language rust {targetDir}
-uv run trailmark analyze --language javascript {targetDir}
-uv run trailmark analyze --language go --summary {targetDir}
+uv run trailmark analyze --language python,rust {targetDir}
 
 # Complexity hotspots
-uv run trailmark analyze --complexity 10 {targetDir}
+uv run trailmark analyze --language auto --complexity 10 {targetDir}
 ```
 
 ### Programmatic API
 
 ```python
+from trailmark.parse import detect_languages, supported_languages
 from trailmark.query.api import QueryEngine
 
-# Specify language (defaults to "python")
-engine = QueryEngine.from_directory("{targetDir}", language="rust")
+# Ask the installed Trailmark build what it supports
+supported_languages()
+detect_languages("{targetDir}")
+
+# Prefer auto for unknown or polyglot trees; use explicit lists when needed
+engine = QueryEngine.from_directory("{targetDir}", language="auto")
+engine = QueryEngine.from_directory("{targetDir}", language="python,rust")
 
 engine.callers_of("function_name")
 engine.callees_of("function_name")
@@ -127,31 +132,33 @@ Results are stored as annotations and named subgraphs on the graph.
 For detailed documentation, see
 [references/preanalysis-passes.md](references/preanalysis-passes.md).
 
-## Supported Languages
+## Language Selection
 
-| Language | `--language` value | Extensions |
-| --- | --- | --- |
-| Python | `python` | `.py` |
-| JavaScript | `javascript` | `.js`, `.jsx` |
-| TypeScript | `typescript` | `.ts`, `.tsx` |
-| PHP | `php` | `.php` |
-| Ruby | `ruby` | `.rb` |
-| C | `c` | `.c`, `.h` |
-| C++ | `cpp` | `.cpp`, `.hpp`, `.cc`, `.hh`, `.cxx`, `.hxx` |
-| C# | `c_sharp` | `.cs` |
-| Java | `java` | `.java` |
-| Go | `go` | `.go` |
-| Rust | `rust` | `.rs` |
-| Solidity | `solidity` | `.sol` |
-| Cairo | `cairo` | `.cairo` |
-| Haskell | `haskell` | `.hs` |
-| Circom | `circom` | `.circom` |
-| Erlang | `erlang` | `.erl` |
+Do not hardcode a stale language table in downstream workflows. Ask the
+installed Trailmark build what it supports:
+
+```python
+from trailmark.parse import detect_languages, supported_languages
+
+supported_languages()
+detect_languages("{targetDir}")
+```
+
+CLI patterns:
+
+```bash
+# Auto-detect and merge
+uv run trailmark analyze --language auto {targetDir}
+
+# Explicit list for a known polyglot target
+uv run trailmark analyze --language python,rust {targetDir}
+```
 
 ## Graph Model
 
 **Node kinds:** `function`, `method`, `class`, `module`, `struct`,
-`interface`, `trait`, `enum`, `namespace`, `contract`, `library`
+`interface`, `trait`, `enum`, `namespace`, `contract`, `library`,
+`template`
 
 **Edge kinds:** `calls`, `inherits`, `implements`, `contains`, `imports`
 
@@ -163,7 +170,8 @@ For detailed documentation, see
 - Cyclomatic complexity and branch metadata
 - Docstrings
 - Annotations: `assumption`, `precondition`, `postcondition`, `invariant`,
-  `blast_radius`, `privilege_boundary`, `taint_propagation`
+  `blast_radius`, `privilege_boundary`, `taint_propagation`, `finding`,
+  `audit_note` (last two set by `augment_sarif` / `augment_weaudit`)
 
 ### Per Edge
 - Source/target node IDs, edge kind, confidence level

--- a/plugins/trailmark/skills/trailmark/references/preanalysis-passes.md
+++ b/plugins/trailmark/skills/trailmark/references/preanalysis-passes.md
@@ -60,11 +60,15 @@ full set of reachable nodes from any entrypoint.
 | `entrypoints:trusted_internal` | Entrypoints at trusted level |
 
 ```python
+import json
+
 engine.preanalysis()
 
 # Nodes NOT reachable from any entrypoint (potential dead code)
-all_ids = {n["id"] for n in engine.subgraph("entrypoint_reachable")}
-# Compare with full node set from engine.summary()
+reachable_ids = {n["id"] for n in engine.subgraph("entrypoint_reachable")}
+graph = json.loads(engine.to_json())
+all_ids = set(graph["nodes"])
+dead_ids = sorted(all_ids - reachable_ids)
 ```
 
 ---

--- a/plugins/trailmark/skills/trailmark/references/query-patterns.md
+++ b/plugins/trailmark/skills/trailmark/references/query-patterns.md
@@ -9,7 +9,7 @@ Find all entrypoints and trace what they can reach:
 ```python
 from trailmark.query.api import QueryEngine
 
-engine = QueryEngine.from_directory("{targetDir}")
+engine = QueryEngine.from_directory("{targetDir}", language="auto")
 
 # All entrypoints
 for ep in engine.attack_surface():
@@ -56,8 +56,7 @@ for caller in callers:
 Check if a function is reachable from any entrypoint:
 
 ```python
-surface = engine.attack_surface()
-paths = engine.paths_between("main", "sensitive_function_id")
+paths = engine.entrypoint_paths_to("sensitive_function_id")
 if paths:
     print(f"Reachable via {len(paths)} path(s)")
 else:
@@ -74,33 +73,40 @@ import json
 json_str = engine.to_json()
 with open("graph.json", "w") as f:
     f.write(json_str)
+
+# Current export includes: summary, nodes, edges, subgraphs.
+# Query attack_surface() and annotations_of() directly for entrypoint
+# metadata and per-node annotations.
 ```
 
 ## 7. Multi-Language Analysis
 
-Analyze non-Python projects by specifying the language:
+Ask Trailmark which languages it supports, detect what exists under the
+target tree, then choose `auto` or an explicit list:
 
 ```python
+from trailmark.parse import detect_languages, supported_languages
 from trailmark.query.api import QueryEngine
 
-engine = QueryEngine.from_directory("{targetDir}", language="rust")
-engine = QueryEngine.from_directory("{targetDir}", language="go")
-engine = QueryEngine.from_directory("{targetDir}", language="typescript")
-```
+print(supported_languages())
+print(detect_languages("{targetDir}"))
 
-Supported `--language` values: `python`, `javascript`, `typescript`, `php`,
-`ruby`, `c`, `cpp`, `c_sharp`, `java`, `go`, `rust`, `solidity`, `cairo`,
-`haskell`, `circom`, `erlang`.
+engine = QueryEngine.from_directory("{targetDir}", language="auto")
+engine = QueryEngine.from_directory("{targetDir}", language="python,rust")
+```
 
 ## 8. CLI Patterns
 
 ```bash
-# Quick summary (Python, default)
-uv run trailmark analyze --summary {targetDir}
+# Quick summary with auto-detection
+uv run trailmark analyze --language auto --summary {targetDir}
 
-# Analyze other languages
+# Analyze explicit languages
 uv run trailmark analyze --language rust --summary {targetDir}
-uv run trailmark analyze --language go --complexity 8 {targetDir}
+uv run trailmark analyze --language python,rust --complexity 8 {targetDir}
+
+# Entrypoint inventory
+uv run trailmark entrypoints --language auto {targetDir}
 
 # Full JSON output for piping to other tools
 uv run trailmark analyze {targetDir} | jq '.nodes | to_entries[] | select(.value.cyclomatic_complexity > 10)'

--- a/plugins/trailmark/skills/trailmark/references/query-patterns.md
+++ b/plugins/trailmark/skills/trailmark/references/query-patterns.md
@@ -138,6 +138,8 @@ engine.clear_annotations("handle_request")
 
 **Annotation kinds:** `ASSUMPTION`, `PRECONDITION`, `POSTCONDITION`, `INVARIANT`.
 Pre-analysis adds: `BLAST_RADIUS`, `PRIVILEGE_BOUNDARY`, `TAINT_PROPAGATION`.
+Audit augmentation adds: `FINDING`, `AUDIT_NOTE` (set by `augment_sarif()` /
+`augment_weaudit()`).
 
 **Source convention:** Use `"llm"` for LLM-inferred annotations, `"docstring"`
 for annotations extracted from source, `"manual"` for human-added annotations.


### PR DESCRIPTION
Aligns all skills with the now-public trailmark package (pypi.org/project/trailmark, github.com/trailofbits/trailmark):

- Replace hardcoded language tables with runtime detection via trailmark.parse.detect_languages() and --language auto, so the skill never goes stale as Trailmark adds languages (21 supported as of 0.2.x: Python, JS/TS, PHP, Ruby, C/C++, C#, Java, Go, Rust, Solidity, Cairo, Circom, Haskell, Erlang, Miden Assembly, Swift, Objective-C, Kotlin, Dart)
- Remove phantom --passes CLI flag from trailmark-structural; pre-analysis is a QueryEngine.preanalysis() method, not a flag
- Use native trailmark diff --json in graph-evolution alongside the subgraph-diff helper script
- Add `finding` and `audit_note` annotation kinds to the documented list (set by augment_sarif / augment_weaudit)
- Document trailmark entrypoints and trailmark augment subcommands that exist in the public package
- Bump plugin to 0.8.1