### PR TITLE
Add Skills宝 as a Chinese Codex entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ A Claude Code plugin marketplace from Trail of Bits providing skills to enhance 
 
 Codex-native skill discovery is supported via the sidecar `.codex/skills/` tree in this repository.
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 Install with:
 
 ```sh


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to search and install agent skills directly. This fits the repository Codex discovery focus and gives Chinese users a faster entry point to the existing skills marketplace.