### PR TITLE
fix(gh-cli): fall back to well-known install paths for shim PATH walk (closes #145)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "gh-cli",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "description": "Intercepts GitHub URL fetches and curl/wget commands, redirecting to the authenticated gh CLI.",
       "author": {
         "name": "William Tan",

--- a/plugins/gh-cli/.claude-plugin/plugin.json
+++ b/plugins/gh-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-cli",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Intercepts GitHub URL fetches and curl/wget commands, redirecting to the authenticated gh CLI.",
   "author": {
     "name": "William Tan",

--- a/plugins/gh-cli/hooks/shims/gh
+++ b/plugins/gh-cli/hooks/shims/gh
@@ -65,5 +65,38 @@ for dir in "${path_entries[@]}"; do
   fi
 done
 
+# Fallback for PATH-stripping environments. Some parents fork with PATH
+# stripped to internal/system dirs only — most notably Homebrew's superenv
+# during `brew install` with HOMEBREW_VERIFY_ATTESTATIONS=true (issue #145):
+# the shim wins ensure_executable!'s ORIGINAL_PATHS resolution, then runs
+# under a stripped child PATH that no longer contains the Homebrew prefix,
+# so the PATH walk above can't find the real gh.
+#
+# Check well-known install paths directly. The Cellar opt symlinks
+# (.../opt/gh/bin/gh) are stable across upgrades; the prefix bin entries
+# cover manual installs and non-Homebrew system packages. Tests can
+# override the list via GH_SHIM_FALLBACKS (colon-separated absolute paths).
+if [[ -n "${GH_SHIM_FALLBACKS:-}" ]]; then
+  IFS=: read -ra fallbacks <<<"$GH_SHIM_FALLBACKS"
+else
+  fallbacks=(
+    /opt/homebrew/opt/gh/bin/gh
+    /opt/homebrew/bin/gh
+    /usr/local/opt/gh/bin/gh
+    /usr/local/bin/gh
+    /home/linuxbrew/.linuxbrew/opt/gh/bin/gh
+    /home/linuxbrew/.linuxbrew/bin/gh
+    /usr/bin/gh
+  )
+fi
+for fallback in "${fallbacks[@]}"; do
+  if [[ -x "$fallback" ]]; then
+    set +e
+    exec "$fallback" "$@"
+    echo "ERROR: gh-cli shim: failed to exec $fallback (exit $?)" >&2
+    exit 126
+  fi
+done
+
 echo "ERROR: real gh binary not found on PATH" >&2
 exit 127

--- a/plugins/gh-cli/hooks/shims/gh-shim.bats
+++ b/plugins/gh-cli/hooks/shims/gh-shim.bats
@@ -23,6 +23,7 @@ setup() {
 
 teardown() {
   rm -rf "$FAKE_GH_DIR"
+  [[ -n "${STRIP_PATH_ESSENTIALS_DIR:-}" ]] && rm -rf "$STRIP_PATH_ESSENTIALS_DIR"
   export PATH="$ORIG_PATH"
 }
 
@@ -361,6 +362,10 @@ assert_blocked() {
 
 # Helper: rebuild PATH with the shim dir and only directories that don't
 # contain a gh binary, so the PATH walk is forced into the fallback path.
+# On CI runners gh is apt-installed into /usr/bin alongside bash/rm/mktemp,
+# so naively skipping every dir that contains gh strips core utilities. We
+# symlink the essentials we need (run_shim invokes `bash`, teardown uses
+# `rm`, several tests call `mktemp`) into a clean dir and keep that on PATH.
 strip_path_of_gh() {
   local path_without_gh=""
   local IFS=:
@@ -369,7 +374,14 @@ strip_path_of_gh() {
     [[ -x "$dir/gh" ]] && continue
     path_without_gh="${path_without_gh:+${path_without_gh}:}$dir"
   done
-  export PATH="${SHIM_DIR}:${path_without_gh}"
+  STRIP_PATH_ESSENTIALS_DIR="$(mktemp -d)"
+  local cmd cmd_path
+  for cmd in bash sh rm mktemp printf chmod cat env; do
+    if cmd_path="$(command -v "$cmd" 2>/dev/null)"; then
+      ln -sf "$cmd_path" "${STRIP_PATH_ESSENTIALS_DIR}/${cmd}"
+    fi
+  done
+  export PATH="${SHIM_DIR}:${STRIP_PATH_ESSENTIALS_DIR}${path_without_gh:+:${path_without_gh}}"
 }
 
 @test "shim: falls back to GH_SHIM_FALLBACKS when PATH walk finds nothing" {

--- a/plugins/gh-cli/hooks/shims/gh-shim.bats
+++ b/plugins/gh-cli/hooks/shims/gh-shim.bats
@@ -342,5 +342,92 @@ assert_blocked() {
     path_without_gh="${path_without_gh:+${path_without_gh}:}$dir"
   done
   export PATH="${SHIM_DIR}:${path_without_gh}"
+  # Neutralize the Homebrew-superenv fallback list so this test exercises the
+  # PATH-walk branch in isolation (CI runners often have /usr/bin/gh installed,
+  # which the default fallback list would pick up).
+  export GH_SHIM_FALLBACKS="/__gh_shim_test_no_fallback__/gh"
   run -127 bash -c '"$0" "$@" 2>&1' "$SHIM" pr list
+}
+
+# =============================================================================
+# Homebrew superenv fallback (issue #145)
+# =============================================================================
+#
+# The shim wins ensure_executable!'s ORIGINAL_PATHS resolution inside
+# Homebrew, then forks under a stripped PATH that no longer contains the
+# Homebrew prefix. Without a fallback the PATH walk fails and `brew install`
+# breaks under HOMEBREW_VERIFY_ATTESTATIONS=true. These tests pin that the
+# fallback fires only when the PATH walk finds nothing.
+
+# Helper: rebuild PATH with the shim dir and only directories that don't
+# contain a gh binary, so the PATH walk is forced into the fallback path.
+strip_path_of_gh() {
+  local path_without_gh=""
+  local IFS=:
+  for dir in $ORIG_PATH; do
+    [[ "$dir" == "$FAKE_GH_DIR" ]] && continue
+    [[ -x "$dir/gh" ]] && continue
+    path_without_gh="${path_without_gh:+${path_without_gh}:}$dir"
+  done
+  export PATH="${SHIM_DIR}:${path_without_gh}"
+}
+
+@test "shim: falls back to GH_SHIM_FALLBACKS when PATH walk finds nothing" {
+  strip_path_of_gh
+  export GH_SHIM_FALLBACKS="$FAKE_GH_DIR/gh"
+  run_shim pr list
+  assert_passthrough
+}
+
+@test "shim: prefers PATH-found gh over fallback" {
+  # FAKE_GH_DIR is on PATH (setup) and emits REAL_GH_CALLED. If the shim
+  # incorrectly preferred the fallback, output would carry MARKER_FALLBACK
+  # instead.
+  local marker_dir
+  marker_dir="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\necho "MARKER_FALLBACK"\n' >"$marker_dir/gh"
+  chmod +x "$marker_dir/gh"
+  export GH_SHIM_FALLBACKS="$marker_dir/gh"
+  run_shim pr list
+  assert_passthrough
+  if [[ "$output" == *"MARKER_FALLBACK"* ]]; then
+    echo "Unexpected fallback invocation:"
+    echo "$output"
+    return 1
+  fi
+  rm -rf "$marker_dir"
+}
+
+@test "shim: tries fallbacks in order, skipping non-executable entries" {
+  strip_path_of_gh
+  local nonexec_dir
+  nonexec_dir="$(mktemp -d)"
+  : >"$nonexec_dir/gh" # exists but not executable
+  export GH_SHIM_FALLBACKS="$nonexec_dir/gh:$FAKE_GH_DIR/gh"
+  run_shim issue view 1
+  assert_passthrough
+  rm -rf "$nonexec_dir"
+}
+
+@test "shim: exits 127 when neither PATH nor fallback have gh" {
+  strip_path_of_gh
+  export GH_SHIM_FALLBACKS="/__gh_shim_test_no_fallback__/gh"
+  run -127 bash -c '"$0" "$@" 2>&1' "$SHIM" pr list
+}
+
+@test "shim: anti-pattern checks fire before fallback (api contents)" {
+  # Even when gh is reachable only via fallback, the deny rules run first,
+  # exit 1, and never invoke the fallback binary.
+  strip_path_of_gh
+  export GH_SHIM_FALLBACKS="$FAKE_GH_DIR/gh"
+  run_shim api repos/owner/repo/contents/file.txt
+  assert_blocked
+}
+
+@test "shim: anti-pattern checks fire before fallback (clone temp path)" {
+  strip_path_of_gh
+  export GH_SHIM_FALLBACKS="$FAKE_GH_DIR/gh"
+  unset CLAUDE_SESSION_ID 2>/dev/null || true
+  run_shim repo clone owner/repo /tmp/repos/repo
+  assert_blocked
 }


### PR DESCRIPTION
## Summary

Closes #145.

The `gh-cli` plugin's PATH shim (`hooks/shims/gh`) fails to find the real `gh` binary when Homebrew forks an `attestation verify` subprocess under its build-isolation superenv. Homebrew's `ensure_executable!` resolves `gh` against `ORIGINAL_PATHS`, picks our shim (first match), then `system_command!` forks under the parent's stripped `PATH` (`/opt/homebrew/Library/Homebrew/shims/shared:/usr/bin:/bin:/usr/sbin:/sbin`). The shim's PATH walk doesn't include `/opt/homebrew/bin`, finds nothing, and exits 127.

User impact: `brew install` / `brew reinstall` / `brew bundle` fails for any formula with `HOMEBREW_VERIFY_ATTESTATIONS=true` set, the moment a Claude Code session is the parent context. Reporter pinned the cause with `brew ruby` and 6 captured shim invocations.

## Fix

Add a fallback after the PATH walk covering the well-known install paths. The Homebrew Cellar opt symlinks (`.../opt/gh/bin/gh`) are stable across upgrades, the prefix `bin` entries cover manual installs, and `/usr/bin/gh` covers system package managers (apt/dnf/pacman):

```bash
fallbacks=(
  /opt/homebrew/opt/gh/bin/gh           # macOS Apple Silicon Homebrew
  /opt/homebrew/bin/gh
  /usr/local/opt/gh/bin/gh              # macOS Intel Homebrew
  /usr/local/bin/gh
  /home/linuxbrew/.linuxbrew/opt/gh/bin/gh
  /home/linuxbrew/.linuxbrew/bin/gh
  /usr/bin/gh                           # System package managers
)
```

`GH_SHIM_FALLBACKS` (colon-separated) overrides the list — used by tests, also doubles as an escape hatch for non-standard installs.

The anti-pattern checks (`api contents` deny, non-session-scoped clone deny) still execute *before* the fallback, so the security/anti-pattern coverage is preserved when `gh` is reachable only via the fallback list — pinned by two new tests.

The reporter offered two alternatives I deliberately did not take:
- Direct-exec the shim'd binary (`exec gh`): re-introduces the recursion the shim already guards against; doesn't fix Homebrew's resolution, just shifts the error.
- Detect Homebrew superenv and degrade behavior: brittle (Homebrew's PATH layout varies by version), and the runtime fallback is simpler and works for any PATH-stripping parent (cron, sandbox, etc.), not just Homebrew.

## Tests

`plugins/gh-cli/hooks/shims/gh-shim.bats` — 6 new cases under a new "Homebrew superenv fallback" section, plus an updated `exits 127 when real gh not found` to neutralize the new fallback list (CI runners often have `/usr/bin/gh` pre-installed):

1. `falls back to GH_SHIM_FALLBACKS when PATH walk finds nothing` — the bug-fix pin.
2. `prefers PATH-found gh over fallback` — regression guard for normal-PATH callers.
3. `tries fallbacks in order, skipping non-executable entries` — pins ordering and `-x` check.
4. `exits 127 when neither PATH nor fallback have gh` — preserves the original failure mode when nothing is reachable.
5. `anti-pattern checks fire before fallback (api contents)` — pins ordering with deny rules.
6. `anti-pattern checks fire before fallback (clone temp path)` — same, for the clone deny.

Red-baseline verified: tests #48 (`falls back to GH_SHIM_FALLBACKS…`) and #50 (`tries fallbacks in order…`) FAIL on `main` (`stash` the source change → run bats), then PASS once the source change is restored.

## Local gates

- `bats plugins/gh-cli/hooks/shims/gh-shim.bats` → 53/53 pass.
- `find plugins/gh-cli -name '*.bats' -type f -print0 | xargs -0 bats` → 144/144 pass (all gh-cli bats suites).
- `shellcheck -x plugins/gh-cli/hooks/shims/gh` → clean.
- `shfmt -i 2 -ci -d plugins/gh-cli/hooks/shims/gh plugins/gh-cli/hooks/shims/gh-shim.bats` → clean.
- `python3 .github/scripts/validate_codex_skills.py` → 73/74 OK.
- `python3 .github/scripts/validate_plugin_metadata.py` → all in sync.
- `python3 -c 'import json; json.load(...)'` on both `plugin.json` files → valid.
- `grep -rPn '(?<![a-zA-Z])(/home/[a-z]|/Users/[A-Z])' plugins/ --include='*.md' --include='*.py' --include='*.json'` → no matches (excluded extensions cover the bash file).

## Version bump

`gh-cli` 1.4.1 → 1.4.2 in both `plugins/gh-cli/.claude-plugin/plugin.json` and the root `.claude-plugin/marketplace.json` per CONTRIBUTING.md (substantive change to a published plugin).

## Reproducer (from issue #145)

> macOS 26 Tahoe, Apple Silicon, Homebrew 5.1.5, `gh 2.89.0` via Homebrew, `gh-cli` plugin v1.4.0.
> `export HOMEBREW_VERIFY_ATTESTATIONS=true`
> `rm -f "$(brew --cache <formula>)"`
> `brew install <formula>` from within Claude Code → exit 127 with `attestation verification failed`.
> Reporter confirmed the suggested fix unblocks the install.

## Out of scope

- The shim's recursion guard (skipping `shim_dir` in PATH walk) is unchanged. The fallback paths are absolute and do not include the shim dir, so that guard's invariant still holds.
- Other PATH-stripping parents (cron, restrictive sandboxes) benefit incidentally; if they expose a different gh location, `GH_SHIM_FALLBACKS=...` is the documented override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)