### PR TITLE
fix(fp-check): remove top-level Stop hook to stop firing on unrelated sessions (#143)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,7 +375,7 @@
     },
     {
       "name": "fp-check",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Systematic false positive verification for security bug analysis with mandatory gate reviews",
       "author": {
         "name": "Maciej Domanski"

--- a/plugins/fp-check/.claude-plugin/plugin.json
+++ b/plugins/fp-check/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-check",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Systematic false positive verification for security bug analysis with mandatory gate reviews",
   "author": {
     "name": "Maciej Domanski"

--- a/plugins/fp-check/hooks/hooks.json
+++ b/plugins/fp-check/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
-  "description": "Enforce fp-check verification completeness — prevent premature verdicts and incomplete agent output",
+  "description": "Enforce fp-check subagent output completeness — verify data-flow-analyzer, exploitability-verifier, and poc-builder produced their required phase outputs",
   "hooks": {
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "You are a verification completeness checker for the fp-check false positive analysis skill. The agent is about to stop. Check whether the verification process was completed properly.\n\nScan the conversation for evidence of ALL of the following for EVERY bug that was being verified:\n\n1. Phase 1 (Data Flow Analysis): Trust boundaries mapped, API contracts checked, environment protections analyzed, cross-references checked\n2. Phase 2 (Exploitability Verification): Attacker control confirmed or denied, mathematical bounds analyzed (or marked N/A), race conditions analyzed (or marked N/A), adversarial analysis completed\n3. Phase 3 (Impact Assessment): Real security impact vs operational robustness distinguished, primary controls vs defense-in-depth distinguished\n4. Phase 4 (PoC Creation): Pseudocode PoC created, executable/unit test PoCs created or explicitly skipped with justification, negative PoC created, PoC verification completed\n5. Phase 5 (Devil's Advocate): All 13 challenge questions addressed\n6. Gate Review: All 6 gates (Process, Reachability, Real Impact, PoC Validation, Math Bounds, Environment) evaluated with pass/fail\n7. Verdict: Each bug has a TRUE POSITIVE or FALSE POSITIVE verdict with evidence\n\nIf ANY bug is missing ANY of these phases or the gate review, return 'block' with the specific gaps.\nIf all bugs have complete verification with verdicts, return 'approve'.\nIf the conversation is not about fp-check verification at all, return 'approve'.",
-            "timeout": 30
-          }
-        ]
-      }
-    ],
     "SubagentStop": [
       {
         "matcher": "*",


### PR DESCRIPTION
## Summary

Closes #143.

The `Stop` hook in `plugins/fp-check/hooks/hooks.json` is registered with `"matcher": "*"`, so it fires on **every** Claude Code session stop — including sessions that have nothing to do with fp-check verification. This burns a full 30-second LLM turn on every unrelated stop and pollutes the parent context with stop-feedback blocks.

The hook's own fallback rule (`"If the conversation is not about fp-check verification at all, return 'approve'"`) does not prevent the issue: the hook still fires, the model still runs, the turn is still consumed — just to discover that it should no-op.

## Fix

Removes the top-level `Stop` hook entirely (option 3 of three workarounds discussed in #143).

The companion `SubagentStop` hook stays. It is the right place to enforce structured-output completeness, because it only matches actual fp-check subagents (`data-flow-analyzer`, `exploitability-verifier`, `poc-builder`) and never fires on unrelated sessions. Verification rigor is preserved at the level where it is actionable.

## Impact

- Verification rigor: unchanged. `SubagentStop` continues to enforce phase-output completeness on every fp-check subagent.
- Unrelated sessions: no longer pay the cost of a full LLM turn at every `Stop`.
- Plugin version bumped from `1.0.0` to `1.0.1` (per repo CLAUDE.md guidance: substantive change to hook behavior).

## Validation

```
$ python3 .github/scripts/validate_codex_skills.py
Validated 73 plugin skills against 74 Codex entries successfully.
```

CODEOWNERS unchanged (`/plugins/fp-check/ @ahpaleus @dguido`).

## Test plan

- [x] Diff reviewed for completeness (3 files: hooks.json + 2 version bumps)
- [x] Codex skills validator passes
- [x] No CODEOWNERS change required
- [ ] CI green
- [ ] Reviewer ack from @ahpaleus or @dguido that removing the top-level Stop hook is acceptable (per @GeeksikhSecurity's own recommendation in #143: "Option 3 is the simplest and loses no real coverage.")