### PR TITLE
Fix for when CLAUDE_PLUGIN_ROOT contains spaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -365,7 +365,7 @@
     },
     {
       "name": "skill-improver",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Automatically reviews and fixes Claude Code skills through iterative refinement until they meet quality standards. Requires plugin-dev plugin.",
       "author": {
         "name": "Paweł Płatek",

--- a/plugins/skill-improver/.claude-plugin/plugin.json
+++ b/plugins/skill-improver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-improver",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Automatically reviews and fixes Claude Code skills through iterative refinement until they meet quality standards. Requires plugin-dev plugin.",
   "author": {
     "name": "Paweł Płatek",

--- a/plugins/skill-improver/hooks/hooks.json
+++ b/plugins/skill-improver/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\"",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
My Claude is installed under `~/Library/Application Support`. Before this change I was getting this error:
```
Stop hook error: Failed with non-blocking status code: /bin/sh: ~/Library/Application: No such file or directory
```