### PR TITLE
Update plugin version from 0.8.1 to 0.3.1

### DIFF
--- a/plugins/trailmark/.claude-plugin/plugin.json
+++ b/plugins/trailmark/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trailmark",
-  "version": "0.8.1",
+  "version": "0.3.1",
   "description": "Builds multi-language source code graphs for security analysis: call graphs, attack surface mapping, blast radius, taint propagation, complexity hotspots, and entry point enumeration. Generates Mermaid diagrams (call graphs, class hierarchies, dependency maps, heatmaps). Compares code graph snapshots for structural diff and evolution analysis. Runs graph-informed mutation testing triage (genotoxic). Generates mutation-driven test vectors (vector-forge). Extracts crypto protocol message flows and converts Mermaid diagrams to ProVerif models. Projects SARIF and weAudit findings onto code graphs. Use when analyzing call paths, mapping attack surface, visualizing code architecture, triaging survived mutants, generating cryptographic test vectors, diagramming crypto protocols, formally verifying protocols, or augmenting audits with static analysis findings.",
   "author": {
     "name": "Scott Arciszewski",


### PR DESCRIPTION
I suspect there might be a typo here.
And the reason for that is latest version in https://github.com/trailofbits/trailmark/releases is 0.3.1.