### PR TITLE
[codex] Avoid pinning Codex model in second-opinion

### DIFF
--- a/plugins/second-opinion/skills/second-opinion/SKILL.md
+++ b/plugins/second-opinion/skills/second-opinion/SKILL.md
@@ -172,14 +172,15 @@ structured output schema.
 
 Summary:
 - Uses `codex exec` (not `codex review`) for headless operation
-- Model: `gpt-5.3-codex`, reasoning: `xhigh`
+- Model: configured/default Codex model, reasoning: `xhigh`
 - Uses OpenAI's published code review prompt (fine-tuned into the model)
 - Diff is generated manually and piped via stdin with the prompt
 - `--output-schema` produces structured JSON findings
 - `-o` captures only the final message (no thinking/exec noise)
 - All three scopes (uncommitted, branch, commit) support project
   context and focus instructions (no limitations)
-- Falls back to `gpt-5.2-codex` on auth errors
+- For pinned runs, pass `-m <model>` or `--model <model>` with a
+  currently available Codex model
 - Output is clean JSON — parse and present findings by priority
 - Set `timeout: 600000` on the Bash call
 
@@ -219,7 +220,7 @@ When the user picks "Both" (the default):
 2. Collect both results, then present with clear headers:
 
 ```
-## Codex Review (gpt-5.3-codex)
+## Codex Review (configured/default model)
 <codex output>
 
 ## Gemini Review (gemini-3.1-pro-preview)
@@ -236,7 +237,7 @@ Summarize where the two reviews agree and differ.
 | `gemini: command not found` | Tell user: `npm i -g @google/gemini-cli` |
 | Gemini `code-review` extension missing | Tell user: `gemini extensions install https://github.com/gemini-cli-extensions/code-review` |
 | Gemini `gemini-cli-security` extension missing | Tell user: `gemini extensions install https://github.com/gemini-cli-extensions/security` |
-| Model auth error (Codex) | Retry with `gpt-5.2-codex` |
+| Model auth error (Codex) | Retry without an explicit model so Codex uses the configured/default model; if the user requested a pinned run, ask them for a currently available model from the Codex model list |
 | Empty diff | Tell user there are no changes to review |
 | Timeout | Inform user and suggest narrowing the diff scope |
 | Tool partially unavailable | Run only the available tool, note the skip |

--- a/plugins/second-opinion/skills/second-opinion/references/codex-invocation.md
+++ b/plugins/second-opinion/skills/second-opinion/references/codex-invocation.md
@@ -2,7 +2,7 @@
 
 ## Default Configuration
 
-- Model: `gpt-5.3-codex`
+- Model: configured/default Codex model
 - Reasoning effort: `xhigh`
 
 ## Approach
@@ -17,8 +17,7 @@ stdout.
 
 Use this prompt verbatim — it is from OpenAI's [Build Code Review
 with the Codex SDK](https://developers.openai.com/cookbook/examples/codex/build_code_review_with_codex_sdk)
-cookbook, and GPT-5.2-codex and later received specific training
-on it:
+cookbook, and Codex models are trained to use it:
 
 ```
 You are acting as a reviewer for a proposed code change made by another engineer.
@@ -86,7 +85,6 @@ been staged would be silently excluded. Generate the full diff:
 
 ```bash
 codex exec \
-  -c model='"gpt-5.3-codex"' \
   -c model_reasoning_effort='"xhigh"' \
   --sandbox read-only \
   --ephemeral \
@@ -139,18 +137,24 @@ End with the overall verdict and confidence.
 If the output file is empty or missing, read `$stderr_log` to
 diagnose the failure.
 
-## Model Fallback
+## Model Selection
 
-If `gpt-5.3-codex` fails with an auth error (e.g., "not supported
-when using Codex with a ChatGPT account"), retry with
-`gpt-5.2-codex`. Log the fallback for the user.
+Do not pin a model by default. Let `codex exec` use the user's
+configured/default Codex model so the skill continues to work as
+model availability changes across ChatGPT and API-key accounts.
+
+For pinned runs, add `-m <model>` or `--model <model>` to the base
+command with a currently available model from the Codex model list.
+If a pinned model fails with an auth or availability error, retry
+without the explicit model and log that Codex used the configured
+default instead.
 
 ## Error Handling
 
 | Error | Action |
 |-------|--------|
 | `codex: command not found` | Tell user: `npm i -g @openai/codex` |
-| Model auth error | Retry with `gpt-5.2-codex` |
+| Model auth error | Retry without an explicit model so Codex uses the configured/default model; if the user requested a pinned run, ask them for a currently available model from the Codex model list |
 | Timeout | Suggest narrowing the diff scope |
 | `EPERM` / sandbox errors | Expected — `codex exec` runs sandboxed. Ignore these. |
 | Empty/missing output file | Read `$stderr_log` to diagnose the failure |


### PR DESCRIPTION
## Summary

- remove the hard-coded `gpt-5.3-codex` model from the `second-opinion` Codex invocation docs
- document that `codex exec` should use the configured/default Codex model by default
- replace the outdated `gpt-5.2-codex` auth fallback with guidance for optional explicit `-m` / `--model` overrides

Closes #176

## Validation

- `git diff --check`
- `python3 .github/scripts/validate_plugin_metadata.py`
- `python3 .github/scripts/validate_codex_skills.py`