### PR TITLE
fix(semgrep-rule-creator): correct 404ing semgrep-docs links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
     },
     {
       "name": "semgrep-rule-creator",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "description": "Create custom Semgrep rules for detecting bug patterns and security vulnerabilities",
       "author": {
         "name": "Maciej Domanski"

--- a/plugins/semgrep-rule-creator/.claude-plugin/plugin.json
+++ b/plugins/semgrep-rule-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semgrep-rule-creator",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Create custom Semgrep rules for detecting bug patterns and security vulnerabilities",
   "author": {
     "name": "Maciej Domanski"

--- a/plugins/semgrep-rule-creator/skills/semgrep-rule-creator/SKILL.md
+++ b/plugins/semgrep-rule-creator/skills/semgrep-rule-creator/SKILL.md
@@ -156,10 +156,10 @@ Semgrep Rule Progress:
 
 **REQUIRED**: Before writing any rule, use WebFetch to read **all** of these 7 links with Semgrep documentation:
 
-1. [Rule Syntax](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/rule-syntax.md)
+1. [Rule Syntax](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/rule-syntax.mdx)
 2. [Pattern Syntax](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/pattern-syntax.mdx)
-3. [Testing Rules](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/testing-rules.md)
-4. [Taint analysis](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/data-flow/taint-mode/overview.md)
-5. [Advanced techniques for taint analysis](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/data-flow/taint-mode/advanced.md)
-6. [Constant propagation](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/data-flow/constant-propagation.md)
+3. [Testing Rules](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/testing-rules.mdx)
+4. [Taint analysis](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/data-flow/taint-mode/overview.mdx)
+5. [Advanced techniques for taint analysis](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/data-flow/taint-mode/advanced.mdx)
+6. [Constant propagation](https://raw.githubusercontent.com/semgrep/semgrep-docs/refs/heads/main/docs/writing-rules/data-flow/constant-propagation.mdx)
 7. [Trail of Bits Testing Handbook - Semgrep chapter](https://raw.githubusercontent.com/trailofbits/testing-handbook/refs/heads/main/content/docs/static-analysis/semgrep/10-advanced.md)


### PR DESCRIPTION
## Summary

The `semgrep-rule-creator` skill instructs the model to `WebFetch` seven documentation links before writing a rule. Five of the `semgrep-docs` links were 404ing because the repo migrated those `writing-rules` pages from `.md` to `.mdx`.

## Changes

Updated the five broken links in `SKILL.md` to their `.mdx` paths:

| Page | Old | New |
|------|-----|-----|
| Rule Syntax | `.md` | `.mdx` |
| Testing Rules | `.md` | `.mdx` |
| Taint analysis (overview) | `.md` | `.mdx` |
| Advanced taint analysis | `.md` | `.mdx` |
| Constant propagation | `.md` | `.mdx` |

`pattern-syntax.mdx` and the Trail of Bits Testing Handbook link were already valid and are unchanged.

## Verification

Confirmed each old `.md` URL returns HTTP 404 and each replacement returns HTTP 200. Paths cross-checked against a local clone of `semgrep/semgrep-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)