### PR TITLE
fix(fp-check): scope hooks and make Stop path-aware

### DIFF
--- a/plugins/fp-check/hooks/hooks.json
+++ b/plugins/fp-check/hooks/hooks.json
@@ -1,21 +1,9 @@
 {
-  "description": "Enforce fp-check verification completeness — prevent premature verdicts and incomplete agent output",
+  "description": "Enforce per-worker output completeness for fp-check deep-path analysis agents. Scoped by agent type name so it fires only for fp-check's own workers.",
   "hooks": {
-    "Stop": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "You are a verification completeness checker for the fp-check false positive analysis skill. The agent is about to stop. Check whether the verification process was completed properly.\n\nScan the conversation for evidence of ALL of the following for EVERY bug that was being verified:\n\n1. Phase 1 (Data Flow Analysis): Trust boundaries mapped, API contracts checked, environment protections analyzed, cross-references checked\n2. Phase 2 (Exploitability Verification): Attacker control confirmed or denied, mathematical bounds analyzed (or marked N/A), race conditions analyzed (or marked N/A), adversarial analysis completed\n3. Phase 3 (Impact Assessment): Real security impact vs operational robustness distinguished, primary controls vs defense-in-depth distinguished\n4. Phase 4 (PoC Creation): Pseudocode PoC created, executable/unit test PoCs created or explicitly skipped with justification, negative PoC created, PoC verification completed\n5. Phase 5 (Devil's Advocate): All 13 challenge questions addressed\n6. Gate Review: All 6 gates (Process, Reachability, Real Impact, PoC Validation, Math Bounds, Environment) evaluated with pass/fail\n7. Verdict: Each bug has a TRUE POSITIVE or FALSE POSITIVE verdict with evidence\n\nIf ANY bug is missing ANY of these phases or the gate review, respond with JSON: {\"ok\": false, \"reason\": \"<specific gaps>\"}\nIf all bugs have complete verification with verdicts, respond with JSON: {\"ok\": true}\nIf the conversation is not about fp-check verification at all, respond with JSON: {\"ok\": true}",
-            "timeout": 30
-          }
-        ]
-      }
-    ],
     "SubagentStop": [
       {
-        "matcher": "*",
+        "matcher": "data-flow-analyzer|exploitability-verifier|poc-builder",
         "hooks": [
           {
             "type": "prompt",

--- a/plugins/fp-check/skills/fp-check/SKILL.md
+++ b/plugins/fp-check/skills/fp-check/SKILL.md
@@ -2,6 +2,35 @@
 name: fp-check
 description: "Systematically verifies suspected security bugs to eliminate false positives, producing a TRUE POSITIVE or FALSE POSITIVE verdict with documented evidence for each. Use when asked whether a specific finding is real, exploitable, or a false positive, or to verify or validate a suspected vulnerability — not for hunting or discovering new bugs."
 allowed-tools: Read Grep Glob LSP Bash Task Write Edit AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet
+hooks:
+  Stop:
+    - matcher: "*"
+      hooks:
+        - type: prompt
+          timeout: 30
+          prompt: |
+            You are a verification completeness checker for the fp-check false positive analysis skill. The agent is about to stop. Decide whether to allow the stop by applying these rules IN ORDER:
+
+            1. If the conversation is not about fp-check verification at all, respond with JSON: {"ok": true}.
+
+            2. If the fp-check verification was delegated to subagents or a workflow (the transcript shows the Task tool was used to spawn verification workers such as data-flow-analyzer, exploitability-verifier, or poc-builder, or general verification subagents), respond with JSON: {"ok": true}. The orchestrator is not the verifier; completeness is enforced by the worker agents' own instructions, not by this hook.
+
+            3. Otherwise the main agent performed the verification inline. Determine which path it used by inference: DEEP shows Phase 1-5 work and spawned analysis agents; STANDARD is a linear inline Steps 1-6 checklist. Then verify the requirements for THAT path.
+
+            COMMON to both paths (always required):
+            - Data flow traced: source to sink, trust boundaries, validation points
+            - Exploitability assessed: attacker control; mathematical bounds and race feasibility where applicable (or N/A)
+            - Impact assessed: real security impact vs operational robustness
+            - A pseudocode PoC is present
+            - Devil's advocate review performed
+            - All 6 gates (Process, Reachability, Real Impact, PoC Validation, Math Bounds, Environment) evaluated with pass/fail
+            - A TRUE POSITIVE or FALSE POSITIVE verdict with evidence
+
+            STANDARD path only (Steps 1-6): devil's advocate = the 7 spot-check questions (5 against + 2 for); PoC = pseudocode sketch only (executable, unit test, and negative PoCs are NOT required).
+
+            DEEP path only (Phases 1-5): devil's advocate = all 13 challenge questions (11 against + 2 for); PoC = pseudocode (4.1) + executable/unit-test PoCs created or explicitly skipped with justification (4.2/4.3) + negative PoC (4.4) + PoC verification (4.5).
+
+            Block ONLY on a concrete, actionable gap the agent can fill from its own context. If a defensible verdict with evidence already exists for the path used, respond {"ok": true}. Otherwise respond {"ok": false, "reason": "<specific gaps, naming the bug and its path>"}.
 ---
 
 # False Positive Check


### PR DESCRIPTION
Fixes #143. Supersedes #188.

## Problems (in `main`)

1. `Stop` and `SubagentStop` both use `matcher: "*"`, so they run on every subagent/agent stop in any session where fp-check is installed.
2. The `Stop` prompt demands the full deep-path output (5 phases, 13 questions, full PoC) for every bug. Standard-path verifications are rejected as "incomplete".
3. Hook loops in the main agent when running fp-check using subagents/ultracode.

## Changes
1. `Stop` hook moved into skill frontmatter.  This way, the stop hooks will be executed only when the skill is loaded, avoiding the firing in unrelated sessions.
2.  Changed the `Stop` hook prompt as ordered rules: (1) skip if not fp-check (2) skip if delegated to subagents/workflow, (3) check only the path actually used (standard vs deep)
3. `SubagentStop` remains in `hooks.json`, narrowing the matcher to only support specific subagents `data-flow-analyzer|exploitability-verifier|poc-builder` 
