### PR TITLE
feat: add OpenCode native plugin support

### DIFF
--- a/.github/scripts/check_opencode_loadability.py
+++ b/.github/scripts/check_opencode_loadability.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Check that this marketplace's skills load through OpenCode.
+
+Runs `opencode debug skill` from the repo root and verifies that every
+expected skill is present and has valid frontmatter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def discover_expected_skills(repo: Path) -> dict[str, Path]:
+    """Walk plugins/*/skills/*/SKILL.md and return {skill_name: path}."""
+    skills: dict[str, Path] = {}
+    plugins_dir = repo / "plugins"
+
+    if not plugins_dir.is_dir():
+        return skills
+
+    for plugin_dir in sorted(plugins_dir.iterdir()):
+        if not plugin_dir.is_dir():
+            continue
+
+        skills_dir = plugin_dir / "skills"
+        if not skills_dir.is_dir():
+            continue
+
+        for skill_dir in sorted(skills_dir.iterdir()):
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+
+            # Validate frontmatter
+            content = skill_md.read_text(encoding="utf-8")
+            if not content.startswith("---"):
+                continue
+
+            match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+            if not match:
+                continue
+
+            frontmatter_text = match.group(1)
+            name = None
+            description = None
+
+            for line in frontmatter_text.split("\n"):
+                if ":" not in line:
+                    continue
+                key, _, value = line.partition(":")
+                key = key.strip()
+                value = value.strip().strip('"').strip("'")
+
+                if key == "name":
+                    name = value
+                elif key == "description":
+                    description = value
+
+            if name and description:
+                skills[name] = skill_md
+
+    return skills
+
+
+def validate_skill_names(skills: dict[str, Path], errors: list[str]) -> None:
+    """Validate that skill names match OpenCode naming rules."""
+    name_pattern = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+    for name, path in skills.items():
+        if len(name) > 64:
+            errors.append(f"{path}: name exceeds 64 characters ({len(name)})")
+        if not name_pattern.match(name):
+            errors.append(
+                f"{path}: name '{name}' must be lowercase alphanumeric "
+                "with single hyphen separators"
+            )
+
+        # Verify name matches parent directory
+        expected_name = path.parent.name
+        if name != expected_name:
+            errors.append(
+                f"{path}: frontmatter name '{name}' does not match directory name '{expected_name}'"
+            )
+
+
+def run_opencode_debug_skill(repo: Path, timeout: float) -> list[dict[str, Any]]:
+    """Run `opencode debug skill` and parse JSON output."""
+    import tempfile
+
+    # Write directly to file to avoid pipe buffer limits (64KB on Linux)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    ) as tmp:
+        tmp_path = tmp.name
+
+    stderr_path = tmp_path + ".stderr"
+
+    try:
+        with (
+            open(tmp_path, "w", encoding="utf-8") as stdout,
+            open(stderr_path, "w", encoding="utf-8") as stderr,
+        ):
+            result = subprocess.run(
+                ["opencode", "debug", "skill"],
+                cwd=str(repo),
+                stdout=stdout,
+                stderr=stderr,
+                timeout=int(timeout),
+            )
+
+        if result.returncode != 0:
+            with open(stderr_path, encoding="utf-8") as fh:
+                stderr_text = fh.read()
+            print(
+                f"ERROR: opencode debug skill exited with code {result.returncode}",
+                file=sys.stderr,
+            )
+            if stderr_text:
+                print(stderr_text, file=sys.stderr)
+            sys.exit(1)
+
+        with open(tmp_path, encoding="utf-8") as fh:
+            return json.load(fh)
+
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: failed to parse opencode debug skill output: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        if os.path.exists(stderr_path):
+            os.unlink(stderr_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo", nargs="?", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument(
+        "--skip-cli",
+        action="store_true",
+        help="Skip `opencode debug skill` and only validate file structure",
+    )
+    args = parser.parse_args()
+
+    repo = args.repo.resolve()
+    errors: list[str] = []
+
+    expected = discover_expected_skills(repo)
+    if not expected:
+        print("ERROR: no skills found in plugins/", file=sys.stderr)
+        return 1
+
+    validate_skill_names(expected, errors)
+
+    if args.skip_cli:
+        print(f"found {len(expected)} skills with valid frontmatter (CLI check skipped)")
+        if errors:
+            print(f"\nFound {len(errors)} error(s):", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            return 1
+        print("All OpenCode loadability checks passed (static)")
+        return 0
+
+    # Check that opencode is available
+    opencode_bin = shutil.which("opencode")
+    if opencode_bin is None:
+        print("ERROR: opencode binary not found in PATH", file=sys.stderr)
+        return 1
+
+    loaded = run_opencode_debug_skill(repo, args.timeout)
+    loaded_names = {skill["name"] for skill in loaded if "name" in skill}
+
+    missing = sorted(set(expected.keys()) - loaded_names)
+    if missing:
+        errors.append(f"{len(missing)} skills not discovered by OpenCode: " + ", ".join(missing))
+
+    extra = sorted(loaded_names - set(expected.keys()))
+    if extra:
+        print(f"note: OpenCode discovered {len(extra)} additional built-in skills")
+
+    print(f"loaded {len(expected)} Trail of Bits skills through OpenCode")
+
+    if errors:
+        print(f"\nFound {len(errors)} OpenCode loadability error(s):", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("All OpenCode loadability checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -107,3 +107,12 @@ jobs:
 
       - name: Check Codex loadability
         run: python3 .github/scripts/check_codex_loadability.py
+
+      - name: Install OpenCode CLI
+        run: |
+          npm install --global --prefix "$RUNNER_TEMP/opencode-cli" opencode-ai@latest
+          echo "$RUNNER_TEMP/opencode-cli/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/opencode-cli/bin/opencode" --version
+
+      - name: Check OpenCode loadability
+        run: python3 .github/scripts/check_opencode_loadability.py

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,57 @@
+# Installing Trail of Bits Skills for OpenCode
+
+## Prerequisites
+
+- [OpenCode.ai](https://opencode.ai) installed
+
+## Installation
+
+Add `trailofbits-skills` to the `plugin` array in your `opencode.json` (global or project-level):
+
+```json
+{
+  "plugin": ["trailofbits-skills@git+https://github.com/trailofbits/skills.git"]
+}
+```
+
+Restart OpenCode. The plugin installs through OpenCode's plugin manager and
+registers all skills from the marketplace.
+
+Verify by asking: "list your skills" and checking that Trail of Bits skills appear.
+
+OpenCode uses its own plugin install. If you also use Claude Code, Codex, or
+another harness, install separately for each one.
+
+## Local Development
+
+To test a local checkout without installing via git spec, run OpenCode from
+within the cloned repository — the plugin at `.opencode/plugins/` loads
+automatically.
+
+## Updating
+
+OpenCode installs through a git-backed package spec. Some OpenCode and Bun
+versions pin that resolved git dependency in a lockfile or cache, so a restart
+may not pick up the newest commit. If updates do not appear, clear OpenCode's
+package cache or reinstall the plugin.
+
+To pin a specific version:
+
+```json
+{
+  "plugin": ["trailofbits-skills@git+https://github.com/trailofbits/skills.git#v1.0.0"]
+}
+```
+
+## Troubleshooting
+
+### Plugin not loading
+
+1. Check logs: `opencode run --print-logs "hello" 2>&1 | grep -i trailofbits`
+2. Verify the plugin line in your `opencode.json`
+3. Make sure you're running a recent version of OpenCode
+
+### Skills not found
+
+1. Use the `skill` tool to list what's discovered
+2. Check that the plugin is loading (see above)

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,382 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.16.2"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.16.2.tgz",
+      "integrity": "sha512-FaZhVXrbz93xsdGLCtarRDTeqFt8AkLfh8B34tFBj6G4HXVmKSgBwVXmtELKKC+08xMtawBC9hshiMbXryv6cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.16.2",
+        "effect": "4.0.0-beta.74",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.3.2",
+        "@opentui/keymap": ">=0.3.2",
+        "@opentui/solid": ">=0.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.16.2.tgz",
+      "integrity": "sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
+      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@opencode-ai/plugin": "1.16.2"
+  }
+}

--- a/.opencode/plugins/trailofbits-skills.js
+++ b/.opencode/plugins/trailofbits-skills.js
@@ -1,0 +1,44 @@
+/**
+ * Trail of Bits Skills plugin for OpenCode
+ *
+ * Auto-registers all skill directories from each plugin
+ * so OpenCode discovers them without manual configuration.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pluginsRoot = path.resolve(__dirname, '../../plugins');
+
+function discoverSkillDirs() {
+  const dirs = [];
+  if (!fs.existsSync(pluginsRoot)) return dirs;
+
+  for (const plugin of fs.readdirSync(pluginsRoot)) {
+    const skillsDir = path.join(pluginsRoot, plugin, 'skills');
+    if (fs.existsSync(skillsDir) && fs.statSync(skillsDir).isDirectory()) {
+      dirs.push(skillsDir);
+    }
+  }
+
+  return dirs;
+}
+
+export const TrailOfBitsSkills = async () => {
+  return {
+    // Inject skills paths into live config so OpenCode discovers
+    // all Trail of Bits skills without requiring manual symlinks.
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+
+      for (const dir of discoverSkillDirs()) {
+        if (!config.skills.paths.includes(dir)) {
+          config.skills.paths.push(dir);
+        }
+      }
+    },
+  };
+};

--- a/.opencode/plugins/trailofbits-skills.js
+++ b/.opencode/plugins/trailofbits-skills.js
@@ -10,7 +10,8 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const pluginsRoot = path.resolve(__dirname, '../../plugins');
+const packageRoot = path.resolve(__dirname, '../..');
+const pluginsRoot = path.join(packageRoot, 'plugins');
 
 function discoverSkillDirs() {
   const dirs = [];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,26 +29,29 @@
 - [getsentry/skills](https://github.com/getsentry/skills) — Production Sentry skills; `security-review` is a standout routing + progressive disclosure example
 
 **For Claude:** Use the `claude-code-guide` subagent for plugin/skill questions - it has access to official documentation.
+**For OpenCode:** Use the built-in `customize-opencode` skill — it covers plugin structure, config schema, and skill frontmatter rules.
 
 ## Technical Reference
 
-### Codex Compatibility
+### Cross-Platform Compatibility
 
-This repository uses Claude plugin marketplace metadata as the canonical source for both Claude Code and Codex. Codex supports `.claude-plugin/marketplace.json` and `plugins/<name>/.claude-plugin/plugin.json` directly, so do not add duplicate Codex-only sidecar metadata.
+This repository uses Claude plugin marketplace metadata as the canonical source for Claude Code and Codex. Codex supports `.claude-plugin/marketplace.json` and `plugins/<name>/.claude-plugin/plugin.json` directly. OpenCode loads skills natively via `.opencode/plugins/trailofbits-skills.js`, which auto-registers all `plugins/*/skills/` directories.
 
 Rules:
 
 - Do not add `.agents/plugins/marketplace.json`, `.codex/`, or `plugins/<name>/.codex-plugin/`.
 - Keep plugin components at the plugin root using Codex-compatible default paths: `skills/`, `hooks/hooks.json`, `.mcp.json`, and `.app.json`.
 - If a plugin needs MCP configuration, put it in `.mcp.json` at the plugin root rather than embedding an object in `.claude-plugin/plugin.json`.
+- The OpenCode plugin at `.opencode/plugins/trailofbits-skills.js` requires no manual updates — it auto-discovers all skills.
 - Before submitting, run:
 
 ```sh
 python3 .github/scripts/check_claude_loadability.py
 python3 .github/scripts/check_codex_loadability.py
+python3 .github/scripts/check_opencode_loadability.py
 ```
 
-- If this check fails in CI, update the canonical Claude marketplace or plugin root components so Codex can load them through Claude marketplace compatibility.
+- If a check fails in CI, update the canonical Claude marketplace or plugin root components so all platforms can load them.
 
 ### Plugin Structure
 
@@ -70,6 +73,8 @@ plugins/
 ```
 
 **Important**: Component directories (`skills/`, `commands/`, `agents/`, `hooks/`) must be at the plugin root, NOT inside `.claude-plugin/`. Only `plugin.json` belongs in `.claude-plugin/`.
+
+**Note for OpenCode:** The bundled `.opencode/plugins/trailofbits-skills.js` auto-discovers all `plugins/*/skills/` directories — no per-plugin metadata file is needed for OpenCode. OpenCode reads the SKILL.md frontmatter directly.
 
 ### Frontmatter
 
@@ -207,6 +212,7 @@ Before submitting:
 - [ ] No hardcoded paths (`/Users/...`, `/home/...`)
 - [ ] `python3 .github/scripts/check_claude_loadability.py` passes
 - [ ] `python3 .github/scripts/check_codex_loadability.py` passes
+- [ ] `python3 .github/scripts/check_opencode_loadability.py` passes
 
 **Quality (reviewers check these):**
 - [ ] Description triggers correctly (third-person, specific)
@@ -218,6 +224,7 @@ Before submitting:
 - [ ] Plugin has README.md
 - [ ] Added to root README.md table
 - [ ] Registered in root `.claude-plugin/marketplace.json` (repo-level, not the plugin's own `.claude-plugin/`)
+- [ ] Skills auto-discovered by OpenCode (no extra step needed — `.opencode/plugins/trailofbits-skills.js` picks up new `plugins/*/skills/` dirs)
 - [ ] Added to CODEOWNERS with plugin-specific ownership (`/plugins/<name>/ @gh-username @dguido`)
   - To find the GitHub username: run `gh api user --jq .login` (most reliable — uses authenticated GitHub identity)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trail of Bits Skills Marketplace
 
-A Claude Code plugin marketplace from Trail of Bits providing skills to enhance AI-assisted security analysis, testing, and development workflows. Codex can load this marketplace through its Claude marketplace compatibility.
+A Claude Code plugin marketplace from Trail of Bits providing skills to enhance AI-assisted security analysis, testing, and development workflows. Codex can load this marketplace through its Claude marketplace compatibility. OpenCode loads the skills natively via a bundled JS plugin.
 
 > Also see: [claude-code-config](https://github.com/trailofbits/claude-code-config) · [skills-curated](https://github.com/trailofbits/skills-curated) · [claude-code-devcontainer](https://github.com/trailofbits/claude-code-devcontainer) · [dropkit](https://github.com/trailofbits/dropkit)
 
@@ -29,6 +29,18 @@ codex plugin marketplace add trailofbits/skills
 codex plugin list
 codex plugin add <plugin-name>@trailofbits
 ```
+
+### OpenCode
+
+OpenCode discovers skills natively via the bundled `.opencode/plugins/` JS plugin.
+
+- Tell OpenCode:
+
+  ```
+  Fetch and follow instructions from https://raw.githubusercontent.com/trailofbits/skills/main/.opencode/INSTALL.md
+  ```
+
+- Or read the install guide directly: [.opencode/INSTALL.md](.opencode/INSTALL.md)
 
 ### Local Development
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Trail of Bits skills marketplace for OpenCode",
   "type": "module",
+  "files": [
+    ".opencode",
+    "plugins"
+  ],
   "exports": {
     "./server": "./.opencode/plugins/trailofbits-skills.js"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "trailofbits-skills",
+  "version": "1.0.0",
+  "description": "Trail of Bits skills marketplace for OpenCode",
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "name": "trailofbits-skills",
   "version": "1.0.0",
   "description": "Trail of Bits skills marketplace for OpenCode",
-  "type": "module"
+  "type": "module",
+  "exports": {
+    "./server": "./.opencode/plugins/trailofbits-skills.js"
+  }
 }


### PR DESCRIPTION
## Summary

Add native OpenCode plugin support via `.opencode/plugins/trailofbits-skills.js` which automatically discovers skills from `plugins/*/skills/` directories.

## Changes

- **`.opencode/plugins/trailofbits-skills.js`** — ES module plugin that auto-discovers all `plugins/*/skills/` directories and injects them into OpenCode's config
- **`package.json`** — root-level `{"type": "module"}` required by Node.js v26 for ES module support
- **`.opencode/.gitignore`** — ignores `node_modules/`
- **`.github/scripts/check_opencode_loadability.py`** — end-to-end CI validation: runs `opencode debug skill`, verifies all skills load with valid frontmatter
- **`.github/workflows/validate.yml`** — installs OpenCode CLI, runs loadability check
- **`README.md`** — adds OpenCode installation section
- **`AGENTS.md`** — updates cross-platform compatibility section, adds OpenCode to PR checklist

## Testing

- All 74 Trail of Bits skills load through OpenCode
- Python script passes ruff check + format
- End-to-end `opencode debug skill` validation passes
- All existing Claude Code and Codex loadability checks continue to pass

## Notes

- This is purely additive — no changes to existing Claude Code or Codex behavior
- The `.opencode/` directory is inert for all other platforms
- OpenCode auto-discovers skills, so no per-plugin metadata is needed