### PR TITLE
fix(modern-python): python shim's suggested `uv run` command fails outside a project

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -262,7 +262,7 @@
     },
     {
       "name": "modern-python",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "description": "Modern Python best practices. Use when creating new Python projects, and writing Python scripts, or migrating existing projects from legacy tools.",
       "author": {
         "name": "William Tan",

--- a/plugins/modern-python/.claude-plugin/plugin.json
+++ b/plugins/modern-python/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-python",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Modern Python best practices. Use when creating new Python projects, and writing Python scripts, or migrating existing projects from legacy tools.",
   "author": {
     "name": "William Tan",

--- a/plugins/modern-python/README.md
+++ b/plugins/modern-python/README.md
@@ -37,7 +37,7 @@ Modern Python tooling and best practices using uv, ruff, ty, and pytest. Based o
 
 ## Hook: Legacy Command Interception
 
-This plugin includes a `SessionStart` hook that prepends PATH shims for `python`, `pip`, `pipx`, and `uv`. When Claude runs a bare `python`, `pip`, or `pipx` command, the shell resolves to the shim, which prints an error with the correct `uv` alternative and exits non-zero. `uv run` is unaffected because it prepends its managed virtualenv's `bin/` to PATH, shadowing the shims.
+This plugin includes a `SessionStart` hook that prepends PATH shims for `python`, `pip`, `pipx`, and `uv`. When Claude runs a bare `python`, `pip`, or `pipx` command, the shell resolves to the shim, which prints an error with the correct `uv` alternative and exits non-zero. `uv run` is unaffected: inside a project it prepends its managed virtualenv's `bin/` to PATH, shadowing the shims; outside a project (where no venv `bin/` exists and `uv run python` resolves via PATH) the python shim detects the `uv run` context via the `UV` environment variable that uv (>= 0.6.0) sets for its subprocesses and passes through to the real interpreter. `python -m pip` stays blocked everywhere.
 
 | Intercepted Command | Suggested Alternative |
 |---------------------|----------------------|

--- a/plugins/modern-python/hooks/setup-shims.sh
+++ b/plugins/modern-python/hooks/setup-shims.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 # SessionStart hook: prepend shims directory to PATH so that bare
 # python/pip/pipx/uv-pip invocations are intercepted with uv suggestions.
 #
-# `uv run` is unaffected because it prepends its managed virtualenv's
-# bin/ to PATH, shadowing the shims.
+# `uv run` is unaffected: inside a project it prepends its managed
+# virtualenv's bin/ to PATH, shadowing the shims; outside a project the
+# python shim detects the `uv run` context via the UV environment variable
+# (set by uv >= 0.6.0 for its subprocesses) and execs the real interpreter.
 
 # Guard: only activate when uv is available
 command -v uv &>/dev/null || exit 0

--- a/plugins/modern-python/hooks/shims/python
+++ b/plugins/modern-python/hooks/shims/python
@@ -5,18 +5,44 @@ set -euo pipefail
 # suggests the uv equivalent.  Works for both names via $0.
 cmd="$(basename "$0")"
 
+# pip via -m is blocked even under `uv run` (canonical `-m pip` spelling
+# only — best-effort interception, not an enforcement boundary).
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" ]]; then
+  echo "ERROR: \`$cmd -m pip\` is not supported. Use:" >&2
+  echo "  uv add <package>       # add a dependency" >&2
+  echo "  uv remove <package>    # remove a dependency" >&2
+  exit 1
+fi
+
+# Under `uv run`, pass through to the real interpreter.  uv >= 0.6.0 sets
+# UV= in the environment of every subprocess it spawns.  Inside a project,
+# uv's venv bin/ shadows this shim, but OUTSIDE a project `uv run python`
+# resolves the interpreter via PATH — there is no venv bin/ in the way —
+# so without this passthrough the very command this shim suggests resolves
+# right back to the shim and can never succeed.
+if [[ -n "${UV:-}" ]]; then
+  # exec() preserves the PID, so finding our own PID here means this shim
+  # exec'd another copy of itself (two shim installs on PATH) — error out
+  # instead of exec-looping.
+  if [[ "${MODERN_PYTHON_SHIM_PID:-}" != "$$" ]]; then
+    export MODERN_PYTHON_SHIM_PID="$$"
+    IFS=: read -ra path_entries <<<"${PATH:-}"
+    for dir in "${path_entries[@]}"; do
+      [[ -z "$dir" ]] && dir=.               # empty PATH entry means cwd in execvp semantics
+      [[ "$dir/$cmd" -ef "$0" ]] && continue # skip this shim itself (any spelling/symlink)
+      if [[ -x "$dir/$cmd" ]]; then
+        exec "$dir/$cmd" "$@"
+      fi
+    done
+  fi
+  echo "ERROR: running under \`uv run\` but no real $cmd was found on PATH." >&2
+  echo "Try \`uv run <script>.py\` or install one with \`uv python install\`." >&2
+  exit 127
+fi
+
 case "${1:-}" in
   -m)
-    case "${2:-}" in
-      pip)
-        echo "ERROR: \`$cmd -m pip\` is not supported. Use:" >&2
-        echo "  uv add <package>       # add a dependency" >&2
-        echo "  uv remove <package>    # remove a dependency" >&2
-        ;;
-      *)
-        echo "ERROR: Use \`uv run $cmd -m ${2:-<module>}\` instead of \`$cmd -m ${2:-<module>}\`" >&2
-        ;;
-    esac
+    echo "ERROR: Use \`uv run $cmd -m ${2:-<module>}\` instead of \`$cmd -m ${2:-<module>}\`" >&2
     ;;
   *)
     echo "ERROR: Use \`uv run $cmd ${*:-}\` instead of \`$cmd ${*:-}\`" >&2

--- a/plugins/modern-python/hooks/shims/python-shim.bats
+++ b/plugins/modern-python/hooks/shims/python-shim.bats
@@ -3,6 +3,34 @@
 
 SHIM="${BATS_TEST_DIRNAME}/python"
 
+setup() {
+  # `uv run` sets UV in the environment of commands it launches, and the shim
+  # keys its passthrough off that variable.  Unset it (and the shim's exec
+  # guard) so these tests behave the same whether or not the suite itself is
+  # running under uv.
+  unset UV MODERN_PYTHON_SHIM_PID
+}
+
+teardown() {
+  [[ -z "${workdir:-}" ]] || rm -rf "$workdir"
+}
+
+# Create a fake interpreter named $1 inside $workdir and echo its dir.
+# The fake prints its own name and arguments, then exits 42, so tests can
+# verify argument forwarding and exit-code propagation.
+make_fake_interpreter() {
+  local dir
+  dir="$workdir/real"
+  mkdir -p "$dir"
+  cat >"$dir/$1" <<'EOF'
+#!/usr/bin/env bash
+echo "FAKE ${0##*/}: $*"
+exit 42
+EOF
+  chmod +x "$dir/$1"
+  echo "$dir"
+}
+
 @test "exits non-zero for bare python" {
   run "$SHIM"
   [[ $status -ne 0 ]]
@@ -50,4 +78,75 @@ SHIM="${BATS_TEST_DIRNAME}/python"
   run "${BATS_TEST_DIRNAME}/python3" -m pip install foo
   [[ $status -ne 0 ]]
   [[ "$output" == *"uv add"* ]]
+}
+
+@test "passes through to real python when UV is set (uv run context)" {
+  workdir="$(mktemp -d)"
+  fakedir="$(make_fake_interpreter python)"
+  # Shims dir stays first on PATH to prove the shim skips its own directory.
+  run env UV=/usr/local/bin/uv PATH="${BATS_TEST_DIRNAME}:${fakedir}:/usr/bin:/bin" \
+    "$SHIM" script.py --flag
+  [[ $status -eq 42 ]]
+  [[ "$output" == "FAKE python: script.py --flag" ]]
+}
+
+@test "passes through when invoked as python3 via symlink with UV set" {
+  workdir="$(mktemp -d)"
+  fakedir="$(make_fake_interpreter python3)"
+  run env UV=/usr/local/bin/uv PATH="${BATS_TEST_DIRNAME}:${fakedir}:/usr/bin:/bin" \
+    "${BATS_TEST_DIRNAME}/python3" -c 'print(1)'
+  [[ $status -eq 42 ]]
+  [[ "$output" == "FAKE python3: -c print(1)" ]]
+}
+
+@test "skips its own directory under an aliased spelling (symlinked PATH entry)" {
+  workdir="$(mktemp -d)"
+  fakedir="$(make_fake_interpreter python)"
+  ln -s "$BATS_TEST_DIRNAME" "$workdir/alias"
+  run env UV=/usr/local/bin/uv \
+    PATH="$workdir/alias:${BATS_TEST_DIRNAME}:${fakedir}:/usr/bin:/bin" \
+    "$SHIM" script.py
+  [[ $status -eq 42 ]]
+  [[ "$output" == "FAKE python: script.py" ]]
+}
+
+@test "errors distinctly when UV is set but no real interpreter is on PATH" {
+  # PATH holds only the shims dir plus the tools the shim itself needs
+  # (bash for its `env bash` shebang, basename from coreutils); /usr/bin
+  # must stay off PATH because CI runners ship /usr/bin/python3.
+  workdir="$(mktemp -d)"
+  mkdir -p "$workdir/tools"
+  ln -s "$(command -v bash)" "$workdir/tools/bash"
+  ln -s "$(command -v basename)" "$workdir/tools/basename"
+  run env UV=/usr/local/bin/uv PATH="${BATS_TEST_DIRNAME}:$workdir/tools" \
+    "$SHIM" script.py
+  [[ $status -eq 127 ]]
+  [[ "$output" == *"no real python was found on PATH"* ]]
+}
+
+@test "does not exec-loop when a second shim copy is on PATH" {
+  # Two distinct copies of the shim (e.g. two plugin cache versions) used to
+  # be able to exec each other forever; the PID guard must break the cycle.
+  workdir="$(mktemp -d)"
+  mkdir -p "$workdir/copy" "$workdir/tools"
+  cp "$SHIM" "$workdir/copy/python"
+  chmod +x "$workdir/copy/python"
+  ln -s "$(command -v bash)" "$workdir/tools/bash"
+  ln -s "$(command -v basename)" "$workdir/tools/basename"
+  run timeout 5 env UV=/usr/local/bin/uv \
+    PATH="${BATS_TEST_DIRNAME}:$workdir/copy:$workdir/tools" \
+    "$SHIM" script.py
+  [[ $status -eq 127 ]]
+  [[ "$output" == *"no real python was found on PATH"* ]]
+}
+
+@test "python -m pip stays blocked even when UV is set" {
+  workdir="$(mktemp -d)"
+  fakedir="$(make_fake_interpreter python)"
+  run env UV=/usr/local/bin/uv PATH="${BATS_TEST_DIRNAME}:${fakedir}:/usr/bin:/bin" \
+    "$SHIM" -m pip install requests
+  [[ $status -eq 1 ]]
+  [[ "$output" == *"uv add"* ]]
+  [[ "$output" == *"uv remove"* ]]
+  [[ "$output" != *"FAKE"* ]]
 }


### PR DESCRIPTION
## Bug

The `python`/`python3` PATH shim suggests `uv run python ...` — but outside a uv project that command **can never succeed**. `uv run` only shadows the shims with a managed venv `bin/` when a project environment exists; outside a project, `uv run python` resolves the interpreter via ordinary PATH lookup, hits the shim again, and errors with the same suggestion:

```console
$ cd ~   # no pyproject.toml anywhere above
$ uv run python3 script.py
ERROR: Use `uv run python3 script.py` instead of `python3 script.py`
```

The claim in README.md / `setup-shims.sh` ("`uv run` is unaffected because it prepends its managed virtualenv's `bin/` to PATH") only holds *inside* a project. For a coding agent this is a hard dead end: the shim's own advice loops.

## Fix

The python shim now detects the `uv run` context and passes through to the real interpreter:

- **Detection:** uv ≥ 0.6.0 sets `UV=<path-to-uv>` in the environment of every subprocess it spawns. This is documented, public API ([env-var reference](https://docs.astral.sh/uv/reference/environment/); added in [astral-sh/uv#11326](https://github.com/astral-sh/uv/pull/11326), listed in the 0.6.0 changelog as uv-owned — uv overwrites user-set values). On uv < 0.6.0 the shim degrades fail-safe to today's blocking behavior.
- **Resolution:** walk PATH, skip the shim itself with a same-file `-ef` test (robust to symlinked/aliased spellings of the shims dir — a naive `pwd` comparison can be tricked into an **infinite exec loop**, which we hit while testing), and `exec` the first real interpreter found. Empty PATH entries are normalized to `.` per execvp semantics.
- **Loop guard:** `exec` preserves the PID, so the shim exports its PID before exec'ing; a shim that finds its own PID already recorded knows a second shim copy on PATH exec'd it (e.g. two plugin cache versions) and exits 127 with a clear error instead of ping-ponging forever.
- **Not-found:** if `UV` is set but no real interpreter exists on PATH, the shim emits a *distinct* error (exit 127, mirroring the uv shim) instead of re-suggesting the command that just failed.
- **pip:** `python -m pip` stays blocked everywhere, including under `uv run` (the block is hoisted above the passthrough).

Bare `python`/`python3` invocations outside `uv run` behave exactly as before.

## Design tradeoffs

- **`UV=1 python3 evil.py` bypasses the shim.** Accepted: the shims are behavioral nudges for an agent, not a security boundary (absolute-path invocation always bypassed them), and the passthrough is silent, so no error text teaches the bypass.
- **Gating on a uv-managed interpreter instead** would break the fix: outside a project uv resolves the *system* interpreter via PATH.
- **Changing the suggestion text to `uv run script.py`** alone is insufficient: that form works today (uv provisions the interpreter itself), but `python -c ...`, bare REPL, and `-m module` invocations have no script-form equivalent.
- **The `-m pip` block matches the canonical spelling only** (`-mpip` / options-before-`-m` reach the interpreter). Same argv-level matching the shims already use; once a real interpreter can be exec'd, argv matching is inherently best-effort.
- **`UV` is inherited by descendants** of any uv-launched process (including uvx / `uv tool run`), so the nudge is disabled in those subtrees — passthrough there is correct/harmless.
- The sibling `uv` shim's PATH walk has the same latent aliased-spelling loop issue; happy to port the `-ef` fix in a follow-up if wanted.

## Tests

`python-shim.bats`: existing 8 tests kept but made hermetic against ambient `UV` (previously, running the suite via `uv run bats` failed 5 tests and **hung** on the `-m http.server` case once the passthrough existed); 6 new tests cover passthrough with arg/exit-code forwarding (via both `python` and the `python3` symlink), aliased-spelling skip, the two-copies loop guard (with `timeout` as a hang backstop), the distinct not-found error, and `-m pip` precedence under `UV`.

Verified locally: all 14 pass with bats 1.13 in a clean env **and** with `UV` leaked into the ambient env; full shims suite (37 tests) green; `shellcheck -x` (0.10.0) clean; `shfmt -i 2 -ci` (v3.12.0, the pre-commit pin) produces no diff; shim behavior exercised end-to-end on Ubuntu with uv 0.11.18 (bare → blocked; `uv run python3 script.py` / `uv run python -c` → run; `uv pip` → still blocked). Constructs also validated against bash 3.2.57 for macOS default-shell compatibility.

Version bumped 1.5.2 → 1.5.3 in `plugin.json` and the root `marketplace.json` per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)