### PR TITLE
Drop the "When to Use" / "When NOT to Use" requirement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -374,7 +374,7 @@
     },
     {
       "name": "skill-improver",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "description": "Automatically reviews and fixes Claude Code skills through iterative refinement until they meet quality standards. Requires plugin-dev plugin.",
       "author": {
         "name": "Pawe\u0142 P\u0142atek",

--- a/.github/scripts/validate_plugin_metadata.py
+++ b/.github/scripts/validate_plugin_metadata.py
@@ -77,7 +77,6 @@ FORBIDDEN_PLUGIN_SIDECARS = (".codex-plugin", ".opencode-plugin")
 SKILL_LINE_LIMIT = 500
 KEBAB_CASE_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 PLUGIN_NAME_MAX_LENGTH = 64
-REQUIRED_SKILL_SECTIONS = ("## When to Use", "## When NOT to Use")
 SEMVER_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
 
 # Floor for --self-test. Raise it when you add fixtures; see the check in self_test().
@@ -532,19 +531,6 @@ def validate_version_increment(
 # -------------------------------------------------------------------------- warnings
 
 
-def check_required_sections(plugin_path: Path) -> list[str]:
-    """Skills should say when to use them and when not to."""
-    warnings = []
-    for skill in skill_files(plugin_path):
-        text = skill.read_text(encoding="utf-8", errors="replace")
-        rel = skill.relative_to(plugin_path)
-        for section in REQUIRED_SKILL_SECTIONS:
-            # Tolerate trailing words, e.g. "## When to Use This Skill".
-            if not re.search(rf"^{re.escape(section)}\b", text, re.MULTILINE):
-                warnings.append(f"{rel} missing '{section}' section")
-    return warnings
-
-
 def check_skill_length(plugin_path: Path) -> list[str]:
     """Long skills should be split into references/."""
     warnings = []
@@ -670,8 +656,6 @@ def validate_plugins(
         if plugin_name not in readme_plugins:
             result.add(plugin_name, "not found in README.md")
 
-        for msg in check_required_sections(plugin_path):
-            result.add(plugin_name, msg, WARNING)
         for msg in check_skill_length(plugin_path):
             result.add(plugin_name, msg, WARNING)
 
@@ -938,26 +922,6 @@ def _self_test_errors(ran: list[str]) -> None:
 
 def _self_test_warnings(ran: list[str]) -> None:
     """Each warning-level checker fires on a known-bad fixture, and does not block."""
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        plugin = _build_demo(root)
-        skill = plugin / "skills" / "demo" / "SKILL.md"
-        skill.write_text(skill.read_text().replace("## When NOT to Use", "## Notes"))
-        warnings = _warnings_for(root)
-        _check(ran, "missing When NOT to Use", any("When NOT to Use" in w for w in warnings))
-        _check(ran, "required sections are warnings only", not _errors_for(root))
-
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        plugin = _build_demo(root)
-        skill = plugin / "skills" / "demo" / "SKILL.md"
-        skill.write_text(skill.read_text().replace("## When to Use", "## When to Use This Skill"))
-        _check(
-            ran,
-            "trailing words on section heading tolerated",
-            not any("When to Use" in w for w in _warnings_for(root)),
-        )
-
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         plugin = _build_demo(root)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,10 +258,10 @@ Each of these fails the build. There is no value in checking any of it by hand:
 - No `.codex/`, `.opencode/`, `.agents/`, or `plugins/*/.codex-plugin/` sidecars
 - Both loadability checks pass under the real Claude Code and Codex CLIs
 
-Three more are reported as **warnings**, so they will not stop a merge and do still
-need your eye: missing `## When to Use` / `## When NOT to Use`, `SKILL.md` over 500
-lines, and references that do not resolve. A dangling `references/setup.md` link 404s
-for every user of the skill, and CI will not stop you shipping it.
+Two more are reported as **warnings**, so they will not stop a merge and do still
+need your eye: `SKILL.md` over 500 lines, and references that do not resolve. A dangling
+`references/setup.md` link 404s for every user of the skill, and CI will not stop you
+shipping it.
 
 ### What no tool can check — this is the part that needs you
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,18 +179,6 @@ Prescriptiveness should match task risk:
 - **Strict for fragile tasks** - Security audits, crypto implementations, compliance checks need rigid step-by-step enforcement
 - **Flexible for variable tasks** - Code exploration, documentation, refactoring can offer options and judgment calls
 
-### Required Sections
-
-Every SKILL.md must include:
-
-```markdown
-## When to Use
-[Specific scenarios where this skill applies]
-
-## When NOT to Use
-[Scenarios where another approach is better]
-```
-
 ### Security Skills
 
 For audit/security skills, also include:

--- a/plugins/skill-improver/.claude-plugin/plugin.json
+++ b/plugins/skill-improver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-improver",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Automatically reviews and fixes Claude Code skills through iterative refinement until they meet quality standards. Requires plugin-dev plugin.",
   "author": {
     "name": "Paweł Płatek",

--- a/plugins/skill-improver/skills/skill-improver/SKILL.md
+++ b/plugins/skill-improver/skills/skill-improver/SKILL.md
@@ -54,7 +54,6 @@ These significantly degrade skill effectiveness:
 - Weak or vague trigger descriptions — Claude may not recognize when to use the skill
 - Wrong writing voice (second person "you" instead of imperative) — Inconsistent with Claude's execution model
 - SKILL.md exceeds 500 lines without using references/ — Overloads context, reduces comprehension
-- Missing "When to Use" or "When NOT to Use" sections — Required by project quality standards
 - Description doesn't specify when to trigger — Skill may never be selected
 
 ### Minor Issues (Evaluate before fixing)
@@ -90,14 +89,12 @@ Replace `[SKILL_PATH]` with the absolute path to the skill directory (e.g., `/pa
 ```text
 Critical: SKILL.md:1 - Missing required 'name' field in frontmatter
 Major: SKILL.md:3 - Description uses second person ("you should use")
-Major: Missing "When NOT to Use" section
 Minor: Line 45 is verbose
 ```
 
 **Fixes applied:**
 - Added name field to frontmatter
 - Rewrote description in third person
-- Added "When NOT to Use" section
 
 **Iteration 2 — run skill-reviewer again to verify fixes:**
 ```text


### PR DESCRIPTION
AGENTS.md required every SKILL.md to carry `## When to Use` and `## When NOT to Use`
sections, the validator warned when either was missing, and skill-improver treated a
missing section as a major issue to fix. Neither section can do the job the requirement
implied, so the requirement and its check are removed.

Skill selection is progressive disclosure: only a skill's `name` and `description` are in
context when the model picks between skills, and the body is not read until after the
choice is made. A trigger cue placed under `## When to Use` is therefore read too late to
have triggered anything — the `description` is the only field the selector sees. For a
skill invoked by an explicit command there is no selection step at all.

## Changes

**AGENTS.md** — removes the `### Required Sections` block. Nothing replaces it; the
adjacent `### Description Quality` section already covers putting trigger phrases where
selection can see them. The warnings paragraph under "What the validator enforces" drops
the sections item and now lists two warnings rather than three.

**.github/scripts/validate_plugin_metadata.py** — removes `REQUIRED_SKILL_SECTIONS`,
`check_required_sections()`, its call site, and the two `_self_test_warnings` fixture
blocks covering it. A full scan previously emitted 46 of these warnings; leaving them
would have meant the tooling still stated the rule the PR deletes, training contributors
either to add sections back or to ignore validator warnings — the same bucket that
carries the unresolved-reference warning.

**plugins/skill-improver** — removes `Missing "When to Use" or "When NOT to Use" sections`
from Major Issues, whose stated justification was the AGENTS.md rule. The worked example
no longer shows skill-reviewer reporting the missing section or the loop adding one in
response; that output was illustrative, and `plugin-dev`'s skill-reviewer agent does not
check for either heading. Version 1.0.4 → 1.0.5 in `plugin.json` and `marketplace.json`.

## Testing

- `validate_plugin_metadata.py --self-test` — passes, 31 assertions against a floor of 20
- `validate_plugin_metadata.py` — no errors, 359 references resolved, 9 warnings remaining
  (down from 55; the 46 sections warnings are gone)
- `prek run -a` — all 15 hooks pass repo-wide, and no auto-fixing hook modified a file

Not run locally: the two loadability checks, which need the Claude Code and Codex CLIs. No
plugin metadata structure changed, only a version field.