### PR TITLE
variant-analysis: fix problems found by testing #232 before release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -214,7 +214,7 @@
     },
     {
       "name": "variant-analysis",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Find similar vulnerabilities and bugs across codebases using pattern-based analysis",
       "author": {
         "name": "Axel Mierczuk"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,17 +68,29 @@ plugins/
       plugin.json         # Plugin metadata (name, version, description, author)
     commands/             # Optional: slash commands
     agents/               # Optional: autonomous agents
+    workflows/            # Optional: dynamic workflows (*.js), ships as /<plugin>:<workflow>
+    evals/                # Optional: `claude plugin eval` cases + graders
     skills/               # Optional: knowledge/guidance
       <skill-name>/
         SKILL.md          # Entry point with frontmatter
         references/       # Optional: detailed docs
-        workflows/        # Optional: step-by-step guides
+        workflows/        # Optional: step-by-step guides (prose, not scripts)
         scripts/          # Optional: utility scripts
     hooks/                # Optional: event hooks
+    tests/                # Optional: run_*.sh suites (CI runs these — keep them free)
     README.md             # Plugin documentation
 ```
 
 **Important**: Component directories (`skills/`, `commands/`, `agents/`, `hooks/`) must be at the plugin root, NOT inside `.claude-plugin/`. Only `plugin.json` belongs in `.claude-plugin/`.
+
+**Two different `workflows/`.** A **dynamic workflow** is a JavaScript file at the *plugin
+root* under `workflows/`; it exports a `meta` object, orchestrates subagents in code, and
+ships through the marketplace as `/<plugin-name>:<workflow-name>` (from `meta.name`, not the
+filename). The older `skills/<skill>/workflows/` holds prose step-by-step guides. If a
+SKILL.md has "Phase 1", "for each finding", or "repeat until" sections, the plan belongs in
+a script at the plugin root, not in prose. See `plugins/variant-analysis/workflows/` for a
+worked example, and note that `${CLAUDE_PLUGIN_ROOT}` is **not** available inside a workflow
+script — it is not a hook, MCP, or LSP subprocess.
 
 ### Frontmatter
 

--- a/plugins/variant-analysis/.claude-plugin/plugin.json
+++ b/plugins/variant-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "variant-analysis",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Find similar vulnerabilities and bugs across codebases using pattern-based analysis",
   "author": {
     "name": "Axel Mierczuk"

--- a/plugins/variant-analysis/README.md
+++ b/plugins/variant-analysis/README.md
@@ -22,8 +22,8 @@ Each step has its own strategy reference under `skills/variant-analysis/referenc
 
 | | Use when |
 |---|---|
-| `/variant-analysis:variants` | Workflow to run on large codebase or many manifestations. Runs the steps across parallel subagents, one per expansion axis (e.g., generalizing variable names, function names, ...), looping until the sweep stops finding anything new. Takes `bug`, `root`, `lang`, `out` which claude fills using the current context. |
-| The `variant-analysis` skill | Triggers on its own when you are working on a bug hunt, including straight after finding one in conversation. Best for a narrow search where you want a say in each generalization.|
+| `/variant-analysis:variants` | Workflow, for a large codebase or a root cause with many manifestations. Runs the steps across parallel subagents, one per expansion axis (generalizing variable names, function names, sink APIs, …), looping until the sweep stops finding anything new. Takes `bug`, `root`, `lang`, `out` as a JSON object, which Claude fills from the current context. Below ~40 source files it sweeps narrow and once, because fan-out buys nothing at that size. |
+| The `variant-analysis` skill | The knowledge behind the workflow, and the path for a narrow hunt you want to drive yourself — a handful of files, pasted snippets, or a candidate list to triage against a known root cause. Both fire on their own from a conversational "are there others like this?"; measured on a real codebase, Claude reaches for the workflow more often than the skill, so ask for the skill by name if you want to weigh in on each generalization. |
 
 ## Included
 

--- a/plugins/variant-analysis/README.md
+++ b/plugins/variant-analysis/README.md
@@ -22,7 +22,7 @@ Each step has its own strategy reference under `skills/variant-analysis/referenc
 
 | | Use when |
 |---|---|
-| `/variant-analysis:variants` | Workflow, for a large codebase or a root cause with many manifestations. Runs the steps across parallel subagents, one per expansion axis (generalizing variable names, function names, sink APIs, …), looping until the sweep stops finding anything new. Takes `bug`, `root`, `lang`, `out` as a JSON object, which Claude fills from the current context. Below ~40 source files it sweeps narrow and once, because fan-out buys nothing at that size. |
+| `/variant-analysis:variants` | Workflow, for a large codebase or a root cause with many manifestations. Runs the steps across parallel subagents, one per expansion axis (generalizing variable names, function names, sink APIs, …), looping until the sweep stops finding anything new. Takes `bug`, `root`, `lang`, `out` as a JSON object, which Claude fills from the current context. Below ~40 source files (the primary language's, excluding vendored and fixture trees) it sweeps narrow and once, because fan-out buys nothing at that size. |
 | The `variant-analysis` skill | The knowledge behind the workflow, and the path for a narrow hunt you want to drive yourself — a handful of files, pasted snippets, or a candidate list to triage against a known root cause. Both fire on their own from a conversational "are there others like this?"; measured on a real codebase, Claude reaches for the workflow more often than the skill, so ask for the skill by name if you want to weigh in on each generalization. |
 
 ## Included

--- a/plugins/variant-analysis/evals/06-neg-explain-function/graders/skill-not-fired.md
+++ b/plugins/variant-analysis/evals/06-neg-explain-function/graders/skill-not-fired.md
@@ -1,7 +1,0 @@
----
-type: tool_used
-tool: Skill
-min: 0
-max: 0
-arm: both
----

--- a/plugins/variant-analysis/evals/07-neg-initial-discovery/graders/skill-not-fired.md
+++ b/plugins/variant-analysis/evals/07-neg-initial-discovery/graders/skill-not-fired.md
@@ -1,7 +1,0 @@
----
-type: tool_used
-tool: Skill
-min: 0
-max: 0
-arm: both
----

--- a/plugins/variant-analysis/evals/README.md
+++ b/plugins/variant-analysis/evals/README.md
@@ -58,7 +58,15 @@ pilot it two or three times before the rubric is trustworthy.
 
 The `skill-fired` graders on cases 01–02 are **display-only** under ablation — reported, not
 scored, in either arm, so they never move Δ. They tell you the trigger rate independently of
-answer quality.
+answer quality. Carrying no `arm:` and no `weight:` is the mechanism; adding either would
+start scoring a check the baseline arm can never pass.
+
+The negative cases 06–07 briefly carried the mirror image of that, a `skill-not-fired`
+grader with `arm: both`. Scored, and unfailable in both directions: the baseline arm has no
+plugin so `Skill` never fires, and the with-plugin arm does not fire on these shapes either.
+A grader no arm can fail is worth deleting rather than reweighting, so it is gone. The
+`type: llm` grader on each of those cases carries the check that matters — whether the
+answer stayed an explanation or an audit instead of turning into a variant hunt.
 
 ## Two limitations, stated plainly
 
@@ -67,12 +75,32 @@ calibration: bare Opus 5 handles these panels unaided. Δ can therefore only go 
 is a precision-regression guard and a trigger detector, not an uplift measure. Creating
 headroom needs harder panels, or the codebase-search dimension this suite deliberately omits.
 
-**The skill does not fire.** Across 40+ runs and four pilots there were zero `Skill`
-invocations, including on prompts squarely inside the description's stated trigger conditions.
-The skill was present in the model's skills list and the `Skill` tool was available; the model
-declined it every time and answered unaided. Until that changes, both arms are the same
-unaided model and Δ measures noise. That is a finding about the skill description, not about
-this suite.
+**The skill does not fire *on these cases*.** Across 40+ runs and four pilots there were
+zero `Skill` invocations here. The skill was present in the model's skills list and the
+`Skill` tool was available; the model declined it every time and answered unaided. So on
+this suite both arms are the same unaided model and Δ measures noise.
+
+That was first read as a defect in the skill description. It is not — it is a property of
+the case shape. A later cold run, 9 runs across three prompt shapes, isolated the cause:
+
+| Prompt shape | Codebase on disk? | Fired |
+|---|---|---|
+| Conversational: "found a bug in `x.py`, are there others?" | yes | 2/3 |
+| The description's trigger language, near-verbatim | yes | 3/3 |
+| Inline candidate panel, no files — **the shape of every case here** | no | 0/3 |
+
+Every case in this directory pastes its candidates into the prompt, so there is no tree to
+sweep and nothing for the skill to do that the model cannot do inline. Declining it is
+arguably correct. Two consequences worth keeping straight:
+
+- The non-firing result here is **not** evidence the skill is undiscoverable in real use.
+- Giving these cases files on disk would fix the saturation above *and* the trigger rate at
+  once, since it restores the dimension that actually makes the skill worth invoking. That
+  is the single highest-value change to this suite and it is not a small one.
+
+One more thing the cold run showed: when something does fire on a real codebase it is
+usually `/variant-analysis:variants` (4 of 5 firing runs) rather than the skill itself
+(1 of 9). The plugin's entry-point table says so.
 
 ## Cost
 

--- a/plugins/variant-analysis/skills/variant-analysis/SKILL.md
+++ b/plugins/variant-analysis/skills/variant-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: variant-analysis
-description: Find similar vulnerabilities and bugs across codebases using pattern-based analysis. Use when hunting bug variants, building CodeQL/Semgrep queries, analyzing security vulnerabilities, or performing systematic code audits after finding an initial issue.
+description: Hunt for the other instances of a bug already found — the variants of one root cause across a codebase. Use immediately after a vulnerability, logic bug, or bad pattern turns up in a specific file and the question becomes where else it occurs, including the bare conversational form ("are there others like this?", "is this the same bug?"). Also for generalizing one known instance into a CodeQL or Semgrep query for its whole pattern family, and for triaging a set of look-alike candidates against a known root cause. Not for initial discovery with no bug in hand.
 ---
 
 # Variant Analysis

--- a/plugins/variant-analysis/skills/variant-analysis/SKILL.md
+++ b/plugins/variant-analysis/skills/variant-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: variant-analysis
-description: Hunt for the other instances of a bug already found — the variants of one root cause across a codebase. Use immediately after a vulnerability, logic bug, or bad pattern turns up in a specific file and the question becomes where else it occurs, including the bare conversational form ("are there others like this?", "is this the same bug?"). Also for generalizing one known instance into a CodeQL or Semgrep query for its whole pattern family, and for triaging a set of look-alike candidates against a known root cause. Not for initial discovery with no bug in hand.
+description: Hunts for the other instances of a bug already found — the variants of one root cause across a codebase. Use immediately after a vulnerability, logic bug, or bad pattern turns up in a specific file and the question becomes where else it occurs, including the bare conversational form ("are there others like this?", "is this the same bug?"). Also for generalizing one known instance into a CodeQL or Semgrep query for its whole pattern family, and for triaging a set of look-alike candidates against a known root cause. Not for initial discovery with no bug in hand.
 ---
 
 # Variant Analysis

--- a/plugins/variant-analysis/tests/README.md
+++ b/plugins/variant-analysis/tests/README.md
@@ -25,10 +25,11 @@ the skill alone finds only the seed.
 
 ```sh
 ./setup-gradio.sh              # fetch + patch (~283 MB, one time)
-./run_fixtures.sh              # free, offline — verifies the fixture and the grader
+./run_fixtures.sh              # free, offline — verifies the fixture, grader, and workflow syntax
 ./eval.sh                      # calls Claude: both modes
 ./eval.sh --mode workflow      # skip the baseline
 ./eval.sh --runs 3             # variance estimate
+./eval.sh --strict-decoy       # also require the decoy in the ruled-out section
 ./eval.sh --keep               # keep the work dir even on a pass
 ./setup-gradio.sh --clean      # delete the checkout
 ```
@@ -79,6 +80,24 @@ those is how an eval starts reporting success for runs that did nothing.
 path in the Findings section over-counts badly — it picks up entry points named while
 tracing data flow, and rows in triage tables the report itself refuted. Both mistakes
 were observed against real reports before this was fixed.
+
+The workflow's report stage is instructed to emit those fields, because the fallback is
+what runs when it does not. `score.py` reports which path it used as `extraction_mode`, and
+`summarize.py` prints a `loose` column counting the runs that fell back — a score built on
+the permissive path is worth less than one built on location fields, and that used to be
+invisible.
+
+**Ground truth carries a `span`, not just a line.** A construct is a line *range* — the
+function it lives in. Matching on proximity to a single line conflates neighbours: a cold
+run reported a helper at lines 4 and 7 of a file whose safe site began at line 10, and a
+30-line window scored it as the safe site being reported as real. Spans are exact, and
+`verify_fixtures.py` fails if a span stops containing its own anchor line.
+
+**Line-less mentions lean opposite ways for recall and precision.** A report naming the
+right file without a line is credited for recall, but is *not* treated as claiming the
+decoy. Both directions favour not failing a run that did the work — and the strict half
+matters because the decoy's file also holds a genuine upstream finding, so any run that
+reported the real one without a line number used to be marked as having flagged the decoy.
 
 **`run_fixtures.sh` is CI-safe; `eval.sh` is not.** `make shell-suites` executes every
 `plugins/*/tests/*/run_*.sh` it finds, so the expensive half is deliberately named

--- a/plugins/variant-analysis/tests/eval.sh
+++ b/plugins/variant-analysis/tests/eval.sh
@@ -9,11 +9,13 @@
 # CI-safe half.
 #
 # Usage:
-#   ./eval.sh                        # all codebases, both modes, 1 run each
-#   ./eval.sh --codebase go          # one codebase
-#   ./eval.sh --mode workflow        # skip the baseline
-#   ./eval.sh --runs 3               # repeat for a variance estimate
-#   ./eval.sh --keep                 # keep the work dir even when the eval passes
+#   ./eval.sh                          # all codebases, both modes, 1 run each
+#   ./eval.sh --codebase gradio        # one codebase (see ground-truth.json for names)
+#   ./eval.sh --mode workflow          # skip the baseline
+#   ./eval.sh --mode "workflow baseline"  # both, explicitly (quote the pair)
+#   ./eval.sh --runs 3                 # repeat for a variance estimate
+#   ./eval.sh --strict-decoy           # also require the decoy in the ruled-out section
+#   ./eval.sh --keep                   # keep the work dir even when the eval passes
 #
 # The work dir is deleted on a passing run unless --keep is given. A failing run
 # always keeps it: that is when the transcripts are worth reading. A dir given
@@ -30,6 +32,7 @@ MODES="workflow baseline"
 RUNS=1
 KEEP=0
 MODEL=""
+STRICT_DECOY=0
 OUT_DIR="${TMPDIR:-/tmp}/variant-analysis-eval.$$"
 OUT_GIVEN=0
 
@@ -60,6 +63,10 @@ while [ $# -gt 0 ]; do
       ;;
     --keep)
       KEEP=1
+      shift
+      ;;
+    --strict-decoy)
+      STRICT_DECOY=1
       shift
       ;;
     --out)
@@ -105,6 +112,11 @@ command -v jq >/dev/null || {
 
 if [ -z "$CODEBASES" ]; then
   CODEBASES="$(jq -r '.codebases[].name' "$GROUND_TRUTH")"
+fi
+
+STRICT_FLAG=""
+if [ "$STRICT_DECOY" -eq 1 ]; then
+  STRICT_FLAG="--strict-decoy"
 fi
 
 mkdir -p "$OUT_DIR"
@@ -209,10 +221,12 @@ for name in $CODEBASES; do
       fi
 
       set +e
+      # shellcheck disable=SC2086  # $STRICT_FLAG is a bare flag or empty, by design
       python3 "$TESTS_DIR/score.py" \
         --report "$work/REPORT.md" \
         --codebase "$name" \
         --ground-truth "$GROUND_TRUTH" \
+        $STRICT_FLAG \
         >"$work/score.json" 2>"$work/score.err"
       score_rc=$?
       set -e

--- a/plugins/variant-analysis/tests/ground-truth.json
+++ b/plugins/variant-analysis/tests/ground-truth.json
@@ -17,7 +17,11 @@
           "line": 1110,
           "anchor": "subprocess.run(cmd, shell=True, check=False)",
           "is_seed": true,
-          "why": "user-controlled video path and timestamp interpolated into a shell command string"
+          "why": "user-controlled video path and timestamp interpolated into a shell command string",
+          "span": [
+            1103,
+            1111
+          ]
         },
         {
           "id": "gradio-os-system",
@@ -25,7 +29,11 @@
           "line": 351,
           "anchor": "os.system(f\"tar czf {archive_path} -C {flag_dir} {label}\")",
           "is_seed": false,
-          "why": "same root cause, different sink and different module: a flagged-sample label is interpolated into an os.system command. Grepping for the seed's exact sink (subprocess.run/shell=True) does not reach it \u2014 it takes generalizing to 'user data reaches a shell'."
+          "why": "same root cause, different sink and different module: a flagged-sample label is interpolated into an os.system command. Grepping for the seed's exact sink (subprocess.run/shell=True) does not reach it \u2014 it takes generalizing to 'user data reaches a shell'.",
+          "span": [
+            348,
+            352
+          ]
         }
       ],
       "decoy": {
@@ -33,8 +41,13 @@
         "file": "gradio/screen_recording_utils.py",
         "line": 14,
         "anchor": "def probe_recording_duration(recording_path: str) -> str:",
-        "why_safe": "argv list form (no shell), and the argument is rebuilt as DEFAULT_TEMP_DIR / Path(input).name before use: basename-only, so it can never be a URL (no protocol abuse) and never starts with '-' (no argument injection into ffprobe), and the is_file() gate means a crafted name never reaches the subprocess at all. Verified against shell-metachar, argument-injection, SSRF, concat-protocol and traversal payloads."
-      }
+        "why_safe": "argv list form (no shell), and the argument is rebuilt as DEFAULT_TEMP_DIR / Path(input).name before use: basename-only, so it can never be a URL (no protocol abuse) and never starts with '-' (no argument injection into ffprobe), and the is_file() gate means a crafted name never reaches the subprocess at all. Verified against shell-metachar, argument-injection, SSRF, concat-protocol and traversal payloads.",
+        "span": [
+          14,
+          35
+        ]
+      },
+      "_comment_span": "span is the injected function's line range: a reported location must fall inside it to be that construct. Without it a proximity window conflates neighbouring functions - observed crediting a finding 3 lines above a safe site as that safe site. verify_fixtures.py checks the anchor still sits inside its span."
     }
   ]
 }

--- a/plugins/variant-analysis/tests/run_fixtures.sh
+++ b/plugins/variant-analysis/tests/run_fixtures.sh
@@ -22,3 +22,15 @@ python3 "$TESTS_DIR/score.py" --self-test
 
 echo "→ aggregator self-test"
 python3 "$TESTS_DIR/summarize.py" --self-test
+
+# The workflow is the only JavaScript in this repo and nothing in CI parses it, so a
+# syntax error would surface only inside a paid eval.sh run. `node --check` is free and
+# offline. Skipped rather than failed where node is absent: this suite must stay green on
+# a machine that has no reason to have it.
+echo "→ workflow syntax"
+if command -v node >/dev/null 2>&1; then
+  node --check "$TESTS_DIR/../workflows/variants.js"
+  echo "  ✓ workflows/variants.js parses"
+else
+  echo "  - node not on PATH; skipping"
+fi

--- a/plugins/variant-analysis/tests/run_fixtures.sh
+++ b/plugins/variant-analysis/tests/run_fixtures.sh
@@ -29,7 +29,14 @@ python3 "$TESTS_DIR/summarize.py" --self-test
 # a machine that has no reason to have it.
 echo "→ workflow syntax"
 if command -v node >/dev/null 2>&1; then
-  node --check "$TESTS_DIR/../workflows/variants.js"
+  # Copied to .mjs first. The file's first statement is `export const meta`, and
+  # `node --check` on a .js file only accepts that on a Node new enough to detect module
+  # syntax (~22.7+); older Nodes reject valid workflows with "Unexpected token 'export'".
+  # The extension removes the ambiguity, so this does not depend on the runner's Node.
+  MJS="$(mktemp -t variants.XXXXXX).mjs"
+  trap 'rm -f "$MJS"' EXIT
+  cp "$TESTS_DIR/../workflows/variants.js" "$MJS"
+  node --check "$MJS"
   echo "  ✓ workflows/variants.js parses"
 else
   echo "  - node not on PATH; skipping"

--- a/plugins/variant-analysis/tests/score.py
+++ b/plugins/variant-analysis/tests/score.py
@@ -89,7 +89,9 @@ def paths_in(text):
         return set()
     out = set()
     for m in PATH_RE.finditer(text):
-        p = m.group(0).replace("\\", "/").lstrip("./")
+        # removeprefix, not lstrip("./"): lstrip takes a character SET, so it also ate
+        # the leading dot of `.github/scripts/x.py`.
+        p = m.group(0).replace("\\", "/").removeprefix("./")
         tail = text[m.end() : m.end() + 12]
         lm = re.match(r"[:# ]L?(\d+)", tail)
         out.add((p, int(lm.group(1)) if lm else None))
@@ -181,8 +183,15 @@ def reported_locations(findings_body):
 
 
 # How far a reported line may sit from the ground-truth line and still be the same
-# construct. A report may cite the def, the sink inside it, or a range.
-LINE_WINDOW = 30
+# construct, when ground truth gives no explicit span. A report may cite the def, the
+# sink inside it, or a range.
+#
+# Tightened from 30 after a cold run scored wrong: a report flagged `_concat_file` at
+# lines 4 and 7 of a fixture whose safe site began at line 10, and a 30-line window
+# credited it as "the safe site reported as real" — two different functions three lines
+# apart, conflated. Prefer an explicit `span` in ground truth; this is the fallback for
+# entries that do not carry one.
+LINE_WINDOW = 12
 
 
 def same_file(reported_path, truth_file):
@@ -202,7 +211,24 @@ def same_file(reported_path, truth_file):
     return r == truth or r.endswith("/" + truth) or truth.endswith("/" + r)
 
 
-def matches(reported, truth_file, truth_line=None):
+def truth_span(truth):
+    """The line range a reported location must fall in to be this construct.
+
+    An explicit `span: [start, end]` in ground truth is the construct's real
+    boundaries — the function it lives in. Without one, fall back to a window
+    around the recorded line. Returns None when ground truth records no line at
+    all, meaning any line in the right file counts.
+    """
+    span = truth.get("span")
+    if span:
+        return int(span[0]), int(span[1])
+    line = truth.get("line")
+    if line is None:
+        return None
+    return line - LINE_WINDOW, line + LINE_WINDOW
+
+
+def matches(reported, truth, require_line=False):
     """True if a reported location refers to the ground-truth construct.
 
     File match alone is NOT enough. A real codebase puts several unrelated
@@ -211,15 +237,31 @@ def matches(reported, truth_file, truth_line=None):
     filename alone counted that upstream finding as "the decoy reported as real"
     — inverting the result on a run that had done nothing wrong.
 
-    A report that names a file with no line at all still matches, since refusing
-    to score it would be harsher than the evidence supports.
+    `require_line` sets which way a line-less mention leans, and the two callers
+    lean opposite ways on purpose. Both directions favour not failing a correct
+    run:
+
+    - Recall (did it find the planted variant?) stays permissive. A report that
+      names the right file without a line is credited; refusing to would be
+      harsher than the evidence supports.
+    - The decoy-reported-as-real check is strict. A line-less mention of a file
+      that happens to hold the decoy is not evidence the decoy was claimed, and
+      treating it as such fails a run for a sentence about a different function.
+      This was a live false-failure path: the decoy's file also holds a genuine
+      upstream finding, so any run that reported the real one without a line
+      number was marked as having flagged the decoy.
     """
+    lo_hi = truth_span(truth)
     for r, line in reported:
-        if not same_file(r, truth_file):
+        if not same_file(r, truth["file"]):
             continue
-        if truth_line is None or line is None:
+        if lo_hi is None:
             return True
-        if abs(line - truth_line) <= LINE_WINDOW:
+        if line is None:
+            if require_line:
+                continue
+            return True
+        if lo_hi[0] <= line <= lo_hi[1]:
             return True
     return False
 
@@ -245,11 +287,12 @@ def grade(report_text, entry):
     vulns = entry["vulnerabilities"]
     decoy = entry["decoy"]
 
-    found = [v for v in vulns if matches(reported, v["file"], v["line"])]
-    missed = [v for v in vulns if not matches(reported, v["file"], v["line"])]
+    found = [v for v in vulns if matches(reported, v)]
+    missed = [v for v in vulns if not matches(reported, v)]
 
-    decoy_reported = matches(reported, decoy["file"], decoy["line"])
-    decoy_examined = matches(examined, decoy["file"], decoy["line"])
+    # Strict on the accusation, permissive on "did it look at it". See matches().
+    decoy_reported = matches(reported, decoy, require_line=True)
+    decoy_examined = matches(examined, decoy)
 
     # Findings that are none of the three injected sites.
     #
@@ -263,11 +306,11 @@ def grade(report_text, entry):
     #
     # They are surfaced for a human to read and deliberately excluded from the
     # verdict. Only the injected decoy is a definite false positive.
-    known = [(v["file"], v["line"]) for v in vulns] + [(decoy["file"], decoy["line"])]
+    known = list(vulns) + [decoy]
     unreviewed = sorted(
         f"{p}:{ln}" if ln else p
         for p, ln in reported
-        if not any(matches({(p, ln)}, kf, kl) for kf, kl in known)
+        if not any(matches({(p, ln)}, k) for k in known)
     )
 
     non_seed = [v for v in vulns if not v.get("is_seed")]
@@ -483,6 +526,35 @@ SAME_BASENAME_ELSEWHERE = """
 **Location:** `vendor/pkg/b.py:2`
 """
 
+# Both from a cold run of the workflow, and both scored wrong before this pass.
+
+# A real finding in a *neighbouring construct* of the file that holds the safe site.
+# The safe site spans lines 20-30; this finding is at line 7, in a different function.
+# A 30-line proximity window credited it as the safe site being reported as real, failing
+# a run whose only mistake was existing in the same file.
+NEIGHBOUR_CONSTRUCT = """
+## Findings
+### Variant #1
+**Location:** `src/a.py:1`
+### Variant #2
+**Location:** `src/b.py:2`
+### Variant #3 — helper that builds the argument list
+**Location:** `src/decoy.py:7`
+"""
+
+# The safe site's file named with NO line number, for a genuine issue elsewhere in it.
+# Must not count as claiming the safe site: that inverted the verdict on correct runs,
+# because the decoy's file in the real fixture also holds an upstream finding.
+SPANNED_FILE_NO_LINE = """
+## Findings
+### Variant #1
+**Location:** `src/a.py:1`
+### Variant #2
+**Location:** `src/b.py:2`
+### Variant #3 — unrelated issue, line not pinned
+**Location:** `src/decoy.py`
+"""
+
 
 def self_test():
     checks = 0
@@ -576,7 +648,34 @@ def self_test():
     assert s["unreviewed_findings"] == ["vendor/pkg/b.py:2"], s
     checks += 1
 
-    expected = 13
+    # Cold-run regressions.
+    spanned = json.loads(json.dumps(SELF_TEST_ENTRY))
+    spanned["decoy"]["span"] = [20, 30]
+    s = grade(NEIGHBOUR_CONSTRUCT, spanned)
+    assert not s["decoy_reported_as_real"], (
+        f"a finding outside the safe site's span is not that safe site: {s}"
+    )
+    assert s["unreviewed_findings"] == ["src/decoy.py:7"], s
+    ok, why = verdict(s)
+    assert ok, f"a run that found both and flagged a neighbouring construct must pass: {why}"
+    checks += 1
+
+    s = grade(SPANNED_FILE_NO_LINE, spanned)
+    assert not s["decoy_reported_as_real"], (
+        f"a line-less mention of the safe site's file is not a claim about it: {s}"
+    )
+    assert s["decoy_examined_and_ruled_out"], f"but it does count as having examined it: {s}"
+    ok, why = verdict(s, require_decoy_examined=True)
+    assert ok, f"should pass: {why}"
+    checks += 1
+
+    # Recall stays permissive in the same situation: a line-less mention of a real
+    # variant's file is still credited. The asymmetry is the point.
+    s = grade(SPANNED_FILE_NO_LINE.replace("src/b.py:2", "src/b.py"), spanned)
+    assert s["new_variants_found"] == 1, f"line-less recall must still be credited: {s}"
+    checks += 1
+
+    expected = 16
     if checks != expected:
         raise AssertionError(f"self-test ran {checks} assertions, expected {expected}")
     print(f"score.py self-test: {checks}/{expected} checks passed")

--- a/plugins/variant-analysis/tests/score.py
+++ b/plugins/variant-analysis/tests/score.py
@@ -158,7 +158,7 @@ def reported_locations(findings_body):
                 strict |= paths_in(line)
 
     if strict:
-        return strict, "location-fields"
+        return strict, STRICT_MODE
 
     # Location fields were declared but PATH_RE recognized nothing in *any* of
     # them: the report names files in a language the extension allowlist does not
@@ -179,7 +179,7 @@ def reported_locations(findings_body):
         if REFUTED_RE.search(line):
             continue
         loose |= paths_in(line)
-    return loose, "permissive-lines"
+    return loose, PERMISSIVE_MODE
 
 
 # How far a reported line may sit from the ground-truth line and still be the same
@@ -192,6 +192,18 @@ def reported_locations(findings_body):
 # apart, conflated. Prefer an explicit `span` in ground truth; this is the fallback for
 # entries that do not carry one.
 LINE_WINDOW = 12
+
+# Spans are exact (`def` line through the closing `return`), which leaves no room for a
+# report that cites a decorator or an overload stub sitting immediately above the def.
+# Pad the *recall* side only: crediting a variant a line or two early costs nothing,
+# whereas padding the safe site would walk straight back into the conflation this span
+# work exists to prevent.
+RECALL_PAD = 3
+
+# The extraction mode summarize.py counts in its `loose` column. Defined here, where it is
+# produced, so a rename cannot leave that column silently reading zero forever.
+PERMISSIVE_MODE = "permissive-lines"
+STRICT_MODE = "location-fields"
 
 
 def same_file(reported_path, truth_file):
@@ -211,7 +223,7 @@ def same_file(reported_path, truth_file):
     return r == truth or r.endswith("/" + truth) or truth.endswith("/" + r)
 
 
-def truth_span(truth):
+def truth_span(truth, pad=0):
     """The line range a reported location must fall in to be this construct.
 
     An explicit `span: [start, end]` in ground truth is the construct's real
@@ -221,14 +233,14 @@ def truth_span(truth):
     """
     span = truth.get("span")
     if span:
-        return int(span[0]), int(span[1])
+        return int(span[0]) - pad, int(span[1]) + pad
     line = truth.get("line")
     if line is None:
         return None
-    return line - LINE_WINDOW, line + LINE_WINDOW
+    return line - LINE_WINDOW - pad, line + LINE_WINDOW + pad
 
 
-def matches(reported, truth, require_line=False):
+def matches(reported, truth, require_line=False, pad=0):
     """True if a reported location refers to the ground-truth construct.
 
     File match alone is NOT enough. A real codebase puts several unrelated
@@ -251,7 +263,7 @@ def matches(reported, truth, require_line=False):
       upstream finding, so any run that reported the real one without a line
       number was marked as having flagged the decoy.
     """
-    lo_hi = truth_span(truth)
+    lo_hi = truth_span(truth, pad)
     for r, line in reported:
         if not same_file(r, truth["file"]):
             continue
@@ -287,12 +299,22 @@ def grade(report_text, entry):
     vulns = entry["vulnerabilities"]
     decoy = entry["decoy"]
 
-    found = [v for v in vulns if matches(reported, v)]
-    missed = [v for v in vulns if not matches(reported, v)]
+    found = [v for v in vulns if matches(reported, v, pad=RECALL_PAD)]
+    missed = [v for v in vulns if not matches(reported, v, pad=RECALL_PAD)]
 
     # Strict on the accusation, permissive on "did it look at it". See matches().
     decoy_reported = matches(reported, decoy, require_line=True)
     decoy_examined = matches(examined, decoy)
+
+    # A claim on the decoy's file with NO line is the gap between those two. Strictness
+    # keeps it out of decoy_reported, which is right — it is not evidence the decoy was
+    # named. But it must not then be laundered into "examined and correctly ruled out":
+    # that credited a run for triaging the very site it had just listed under Findings.
+    # Surfaced instead, and it blocks the ruled-out credit without counting as a
+    # false positive.
+    decoy_line_less_claim = sorted(
+        p for p, ln in reported if ln is None and same_file(p, decoy["file"])
+    )
 
     # Findings that are none of the three injected sites.
     #
@@ -312,6 +334,13 @@ def grade(report_text, entry):
         for p, ln in reported
         if not any(matches({(p, ln)}, k) for k in known)
     )
+    # A line-less claim on the decoy's file matches `known` permissively, so it would
+    # drop out of `unreviewed` too and leave no trace anywhere in the artifact. Put it
+    # back: a human reading the score needs to see the claim that was made.
+    for p in decoy_line_less_claim:
+        if p not in unreviewed:
+            unreviewed.append(p)
+    unreviewed.sort()
 
     non_seed = [v for v in vulns if not v.get("is_seed")]
     non_seed_found = [v for v in found if not v.get("is_seed")]
@@ -326,7 +355,10 @@ def grade(report_text, entry):
         "new_variants_total": len(non_seed),
         "non_seed_recall": f"{len(non_seed_found)}/{len(non_seed)}",
         "decoy_reported_as_real": decoy_reported,
-        "decoy_examined_and_ruled_out": decoy_examined and not decoy_reported,
+        "decoy_examined_and_ruled_out": (
+            decoy_examined and not decoy_reported and not decoy_line_less_claim
+        ),
+        "decoy_claimed_without_line": decoy_line_less_claim,
         "unreviewed_findings": unreviewed,
         "false_positives": 1 if decoy_reported else 0,
     }
@@ -648,8 +680,11 @@ def self_test():
     assert s["unreviewed_findings"] == ["vendor/pkg/b.py:2"], s
     checks += 1
 
-    # Cold-run regressions.
+    # Cold-run regressions. The decoy's span must contain its own anchor line, which is
+    # what verify_fixtures.py enforces on real ground truth — so move the line with it
+    # rather than writing a fixture the repo declares invalid.
     spanned = json.loads(json.dumps(SELF_TEST_ENTRY))
+    spanned["decoy"]["line"] = 22
     spanned["decoy"]["span"] = [20, 30]
     s = grade(NEIGHBOUR_CONSTRUCT, spanned)
     assert not s["decoy_reported_as_real"], (
@@ -660,13 +695,24 @@ def self_test():
     assert ok, f"a run that found both and flagged a neighbouring construct must pass: {why}"
     checks += 1
 
+    # A line-less claim on the safe site's file: not an accusation, but not a clean
+    # triage either. It must stay out of decoy_reported_as_real, stay visible in the
+    # artifact, and block the ruled-out credit.
     s = grade(SPANNED_FILE_NO_LINE, spanned)
     assert not s["decoy_reported_as_real"], (
         f"a line-less mention of the safe site's file is not a claim about it: {s}"
     )
-    assert s["decoy_examined_and_ruled_out"], f"but it does count as having examined it: {s}"
+    assert s["decoy_claimed_without_line"] == ["src/decoy.py"], s
+    assert "src/decoy.py" in s["unreviewed_findings"], (
+        f"the claim must remain visible somewhere in the artifact: {s}"
+    )
+    assert not s["decoy_examined_and_ruled_out"], (
+        f"a site claimed under Findings was not 'correctly ruled out': {s}"
+    )
     ok, why = verdict(s, require_decoy_examined=True)
-    assert ok, f"should pass: {why}"
+    assert not ok, "strict mode must not pass a run that claimed the safe site line-lessly"
+    ok, _ = verdict(s)
+    assert ok, "without --strict-decoy it is not a hard failure, since nothing was accused"
     checks += 1
 
     # Recall stays permissive in the same situation: a line-less mention of a real
@@ -675,7 +721,30 @@ def self_test():
     assert s["new_variants_found"] == 1, f"line-less recall must still be credited: {s}"
     checks += 1
 
-    expected = 16
+    # Spans are exact def..return, so a decorator directly above the def is outside them.
+    # RECALL_PAD covers that on the recall side only; the safe site gets no such slack.
+    padded = json.loads(json.dumps(SELF_TEST_ENTRY))
+    padded["vulnerabilities"][1]["line"] = 20
+    padded["vulnerabilities"][1]["span"] = [20, 28]
+    s = grade(PERFECT.replace("src/b.py:2", "src/b.py:18"), padded)
+    assert s["new_variants_found"] == 1, (
+        f"a decorator line just above the def must still credit the variant: {s}"
+    )
+    s = grade(PERFECT.replace("src/b.py:2", "src/b.py:14"), padded)
+    assert s["new_variants_found"] == 0, f"but not an unrelated line 6 above it: {s}"
+    checks += 1
+
+    # The label summarize.py's `loose` column counts. Pinned here so a rename cannot
+    # leave that column silently reading zero.
+    assert PERMISSIVE_MODE == "permissive-lines", PERMISSIVE_MODE
+    assert STRICT_MODE == "location-fields", STRICT_MODE
+    s = grade("## Findings\nA bug in `src/a.py:1` and `src/b.py:2`.\n", SELF_TEST_ENTRY)
+    assert s["extraction_mode"] == PERMISSIVE_MODE, (
+        f"a report with no Location fields must report the permissive mode: {s}"
+    )
+    checks += 1
+
+    expected = 18
     if checks != expected:
         raise AssertionError(f"self-test ran {checks} assertions, expected {expected}")
     print(f"score.py self-test: {checks}/{expected} checks passed")

--- a/plugins/variant-analysis/tests/setup-gradio.sh
+++ b/plugins/variant-analysis/tests/setup-gradio.sh
@@ -54,8 +54,14 @@ else
 fi
 
 echo "→ applying vulnerability patch"
+# Two different failures land here and the old message only named one of them: a checkout
+# at the wrong SHA, and a checkout at the RIGHT SHA whose patch is already partly applied
+# (the unpatched check above only looks at processing_utils.py, so a half-reverted tree
+# reaches this point). --force is the recovery for both.
 git -C "$DEST" apply --check "$PATCH" || {
-  echo "patch does not apply — the checkout is not at $SHA" >&2
+  echo "patch does not apply to $DEST" >&2
+  echo "  either the checkout is not at $SHA, or the patch is already partly applied." >&2
+  echo "  recover with: $0 --force" >&2
   exit 1
 }
 git -C "$DEST" apply "$PATCH"

--- a/plugins/variant-analysis/tests/summarize.py
+++ b/plugins/variant-analysis/tests/summarize.py
@@ -199,6 +199,17 @@ def self_test():
     assert report(aggregate(ungradeable)) == 1, "no gradeable workflow run must fail"
     checks += 1
 
+    # The loose column. Without this, renaming score.py's mode label leaves the column
+    # reading zero on every run forever — restoring the silence the column exists to break.
+    loose = json.loads(json.dumps(SELF_TEST_ROWS))
+    loose[0]["extraction_mode"] = "permissive-lines"
+    loose[1]["extraction_mode"] = "location-fields"
+    agg = aggregate(loose)
+    assert agg[("x", "workflow")]["permissive"] == 1, agg
+    assert agg[("x", "baseline")]["permissive"] == 0, agg
+    assert report(agg) == 0, "permissive extraction is reported, not a failure"
+    checks += 1
+
     baseline_only = [SELF_TEST_ROWS[1]]
     assert report(aggregate(baseline_only)) == 1, "a summary with no workflow rows must fail"
     assert report(aggregate(baseline_only), require_workflow=False) == 0, (
@@ -206,7 +217,7 @@ def self_test():
     )
     checks += 1
 
-    expected = 6
+    expected = 7
     if checks != expected:
         raise AssertionError(f"self-test ran {checks}, expected {expected}")
     print(f"\nsummarize.py self-test: {checks}/{expected} checks passed")

--- a/plugins/variant-analysis/tests/summarize.py
+++ b/plugins/variant-analysis/tests/summarize.py
@@ -63,6 +63,13 @@ def aggregate(rows):
             ),
             "decoy_ruled_out": sum(1 for r in gradeable if r.get("decoy_examined_and_ruled_out")),
             "decoy_as_real": sum(1 for r in gradeable if r.get("decoy_reported_as_real")),
+            # Runs scored through score.py's permissive fallback rather than its
+            # **Location:** path. The fallback over-counts by design, so a score built on
+            # it means less than one built on location fields. Silence here read as
+            # "the strict path worked" on a cold run where it had not.
+            "permissive": sum(
+                1 for r in gradeable if r.get("extraction_mode") == "permissive-lines"
+            ),
         }
     return out
 
@@ -73,10 +80,11 @@ def report(agg, require_workflow=True):
 
     header = (
         f"{'codebase':<14}{'mode':<11}{'gradeable':<11}{'new/run':<10}"
-        f"{'tp':<7}{'fp':<7}{'unrev':<8}{'decoy':<12}"
+        f"{'tp':<7}{'fp':<7}{'unrev':<8}{'decoy':<15}{'loose':<7}"
     )
     print(header)
     print("-" * len(header))
+    loose_total = 0
     for c in codebases:
         for m in modes:
             s = agg.get((c, m))
@@ -85,10 +93,11 @@ def report(agg, require_workflow=True):
             decoy = f"{s['decoy_ruled_out']}/{s['gradeable']} ok"
             if s["decoy_as_real"]:
                 decoy += f" {s['decoy_as_real']} BAD"
+            loose_total += s["permissive"]
             print(
                 f"{c:<14}{m:<11}{str(s['gradeable']) + '/' + str(s['runs']):<11}"
                 f"{s['mean_new']:<10.2f}{s['mean_tp']:<7.2f}{s['mean_fp']:<7.2f}"
-                f"{s['mean_unreviewed']:<8.1f}{decoy:<12}"
+                f"{s['mean_unreviewed']:<8.1f}{decoy:<15}{s['permissive']:<7}"
             )
 
     failures = []
@@ -126,6 +135,10 @@ def report(agg, require_workflow=True):
     print()
     print("  unrev = findings outside ground truth: real upstream code the eval cannot")
     print("          adjudicate. Read them by hand; they do not affect pass/fail.")
+    if loose_total:
+        print(f"  loose = {loose_total} run(s) scored via the permissive fallback: no")
+        print("          **Location:** fields in the report, so those scores over-count.")
+        print("          Not a pass/fail input, but they are worth less than they look.")
     print()
     if failures:
         for f in failures:

--- a/plugins/variant-analysis/tests/verify_fixtures.py
+++ b/plugins/variant-analysis/tests/verify_fixtures.py
@@ -71,17 +71,29 @@ def check_anchors(entry, base):
                 f"    actual line:        {lines[idx].strip()}"
             )
             continue
+        # The grader's construct matching now depends on spans being present. Absent,
+        # truth_span() silently falls back to a proximity window and the neighbouring-
+        # construct conflation is back for that entry, with a green suite.
+        span = t.get("span")
+        if not span:
+            failures.append(
+                f"{entry['name']}: {t['file']}:{t['line']} has no span — the grader would "
+                f"fall back to a proximity window and conflate neighbouring constructs"
+            )
+            continue
+        if int(span[0]) < 1 or int(span[0]) > int(span[1]):
+            failures.append(f"{entry['name']}: {t['file']} span {span} is not a valid range")
+            continue
         # A span that no longer contains its own anchor line is a span the grader
         # would score against the wrong construct — the failure mode span exists to
         # prevent, reintroduced by a stale hand-edit.
-        span = t.get("span")
-        if span and not (int(span[0]) <= t["line"] <= int(span[1])):
+        if not (int(span[0]) <= t["line"] <= int(span[1])):
             failures.append(
                 f"{entry['name']}: {t['file']} span {span} does not contain its own "
                 f"anchor line {t['line']}"
             )
             continue
-        if span and int(span[1]) > len(lines):
+        if int(span[1]) > len(lines):
             failures.append(
                 f"{entry['name']}: {t['file']} span {span} runs past end of file "
                 f"({len(lines)} lines)"

--- a/plugins/variant-analysis/tests/verify_fixtures.py
+++ b/plugins/variant-analysis/tests/verify_fixtures.py
@@ -71,6 +71,22 @@ def check_anchors(entry, base):
                 f"    actual line:        {lines[idx].strip()}"
             )
             continue
+        # A span that no longer contains its own anchor line is a span the grader
+        # would score against the wrong construct — the failure mode span exists to
+        # prevent, reintroduced by a stale hand-edit.
+        span = t.get("span")
+        if span and not (int(span[0]) <= t["line"] <= int(span[1])):
+            failures.append(
+                f"{entry['name']}: {t['file']} span {span} does not contain its own "
+                f"anchor line {t['line']}"
+            )
+            continue
+        if span and int(span[1]) > len(lines):
+            failures.append(
+                f"{entry['name']}: {t['file']} span {span} runs past end of file "
+                f"({len(lines)} lines)"
+            )
+            continue
         checked += 1
     return checked, failures
 

--- a/plugins/variant-analysis/workflows/variants.js
+++ b/plugins/variant-analysis/workflows/variants.js
@@ -59,7 +59,7 @@ const parseArgs = (raw) => {
     }
   }
   // A bare string with no recognizable key at all is the bug description.
-  if (!out.bug && !Object.keys(out).length) out.bug = text
+  if (!Object.keys(out).length) out.bug = text
   return out
 }
 
@@ -178,7 +178,7 @@ const BASELINE_SCHEMA = {
     matches_origin: { type: 'boolean', description: 'True if one of the matches is the known vulnerable line named in the root cause.' },
     source_file_count: {
       type: 'integer',
-      description: 'Number of source files in the codebase, from the second command. Sizes the sweep.',
+      description: 'Source files in the codebase, from the second command: the primary language\'s files, excluding vendored, generated, asset, and fixture directories. Sizes the sweep.',
     },
     notes: { type: 'string' },
   },
@@ -293,9 +293,12 @@ const baseline = await agent(
 
     rg -n --no-heading ${sh(rc.exact_pattern)} ${sh(ROOT)}
 
-2. The size of the tree, which decides how wide the sweep needs to be:
+2. The size of the tree, which decides how wide the sweep needs to be. Count SOURCE
+files only - restrict to the primary language's extensions when you can tell what it
+is, and exclude vendored, generated, asset, and test-fixture directories. A project of
+25 source files behind 300 fixtures is a small project:
 
-    rg --files ${sh(ROOT)} | wc -l
+    rg --files ${sh(ROOT)} | wc -l        # then narrow it, e.g. -g '*.py'
 
 The pattern is supposed to match this known vulnerable line:
   ${rc.origin.file}:${rc.origin.line}
@@ -348,6 +351,10 @@ const key = (c) => `${c.file}:${c.line}`
 let dry = 0
 let round = 0
 let stoppedForBudget = false
+// Which axes actually got swept. A single-round sweep on a small tree covers only the
+// first slice, and "we never looked" has to reach the report rather than only the live
+// progress log — an artifact that omits it is indistinguishable from an exhausted sweep.
+const sweptAxes = new Set()
 
 while (round < maxRounds && dry < DRY_ROUNDS_TO_STOP) {
   // Checked BEFORE the increment: a round that never ran is not a round that ran,
@@ -364,6 +371,7 @@ while (round < maxRounds && dry < DRY_ROUNDS_TO_STOP) {
   // a long axis list gets swept rather than truncated.
   const offset = ((round - 1) * axesPerRound) % rc.axes.length
   const axes = [...rc.axes, ...rc.axes].slice(offset, offset + axesPerRound).slice(0, rc.axes.length)
+  axes.forEach((a) => sweptAxes.add(a.id))
   if (rc.axes.length > axesPerRound) {
     log(`Round ${round} sweeps ${axes.length}/${rc.axes.length} axes: ${axes.map((x) => x.id).join(', ')}`)
   }
@@ -482,6 +490,20 @@ const stopReason = sweptToDry
       ? ` (single round, sized to a ${baseline.source_file_count}-file tree)`
       : ` (hit the ${maxRounds}-round cap - sweep not exhausted, say so in the report)`
 
+// Any axis the loop never reached is a generalization nobody attempted. That belongs in
+// the artifact, not just in the log the operator watched go by.
+const unsweptAxes = rc.axes.filter((a) => !sweptAxes.has(a.id))
+if (unsweptAxes.length) {
+  log(`COVERAGE BOUND: ${unsweptAxes.length}/${rc.axes.length} axes never swept: ${unsweptAxes.map((a) => a.id).join(', ')}`)
+}
+const axisCoverage =
+  `Axes swept: ${sweptAxes.size}/${rc.axes.length}` +
+  (unsweptAxes.length
+    ? `. NEVER SWEPT, and the report must say so under its own heading: ${unsweptAxes
+        .map((a) => `${a.id} (${a.kind}) - ${a.description}`)
+        .join('; ')}`
+    : ' (all of them).')
+
 // ---------------------------------------------------------------------------
 // Phase 5 - Report
 // ---------------------------------------------------------------------------
@@ -521,6 +543,7 @@ Root cause: ${rc.statement}
 Origin: ${rc.origin.file}:${rc.origin.line}
 Baseline: exact pattern \`${rc.exact_pattern}\` matched ${baseline.match_count} location(s)
 Rounds run: ${round}${stopReason}
+${axisCoverage}
 
 Abstraction ladder climbed, for the Search Methodology table:
 ${JSON.stringify(ladder, null, 2)}
@@ -540,6 +563,9 @@ return {
   root_cause: rc.statement,
   origin: `${rc.origin.file}:${rc.origin.line}`,
   rounds: round,
+  axes_total: rc.axes.length,
+  axes_swept: sweptAxes.size,
+  axes_unswept: unsweptAxes.map((a) => a.id),
   swept_to_dry: sweptToDry,
   stopped_for_budget: stoppedForBudget,
   confirmed: confirmed.length,

--- a/plugins/variant-analysis/workflows/variants.js
+++ b/plugins/variant-analysis/workflows/variants.js
@@ -5,7 +5,7 @@ export const meta = {
   name: 'variants',
   description: 'Hunt for variants of a known bug: root cause, baseline gate, parallel sweep across expansion axes, adversarial triage, report',
   whenToUse:
-    'After a specific vulnerability has been found and you want systematic coverage of its variants across a whole codebase. Not for initial discovery. Fill args from the conversation: bug (required, the vulnerability including file:line if known), root (codebase root, defaults to cwd), lang (primary language), out (report path). Do not ask the user for a plugin path; the run locates its own strategy references.',
+    'After a specific vulnerability has been found and you want systematic coverage of its variants across a whole codebase. Not for initial discovery. Pass args as a JSON OBJECT, not a prose string: {"bug": "...", "root": "...", "lang": "...", "out": "..."}. bug is required (the vulnerability, including file:line if known); root defaults to cwd; lang is the primary language; out is the report path. Fill them from the conversation. Do not ask the user for a plugin path; the run locates its own strategy references.',
   phases: [
     { title: 'Root cause', detail: 'Extract root cause statement, exact-match pattern, and expansion axes' },
     { title: 'Baseline', detail: 'Verify the exact pattern actually matches the known bug' },
@@ -26,12 +26,60 @@ export const meta = {
 //   skill: string  (rarely needed) override for the strategy-reference directory. The run
 //                  finds this itself; supply it only if the log reports resolution failed.
 // }
-const A = args || {}
-if (!A.bug) throw new Error('args.bug is required: describe the original vulnerability (ideally with file:line)')
+// A caller that passes args as prose rather than an object used to kill the run on the
+// first line, before a single agent started: `args.bug is required` with nothing to show
+// for it. Observed in a cold run — the model wrote
+// `"bug: ...; root: /path; lang: python"` and the whole invocation died. Parsing that
+// shape costs six lines and turns a hard failure into a working run.
+const parseArgs = (raw) => {
+  if (!raw) return {}
+  if (typeof raw === 'object') return raw
+  if (typeof raw !== 'string') return {}
+  const text = raw.trim()
+  if (text.startsWith('{')) {
+    try {
+      return JSON.parse(text)
+    } catch {
+      // Fall through to key: value parsing rather than dying on a malformed brace.
+    }
+  }
+  // `key: value; key: value`, where a value may itself contain colons (file:line, URLs).
+  // Only the four known keys start a new field, so a bug description containing
+  // "root cause:" does not get chopped in half.
+  const KEYS = ['bug', 'root', 'lang', 'out', 'skill']
+  const out = {}
+  let key = null
+  for (const part of text.split(/;\s*|\n/)) {
+    const m = part.match(/^\s*(\w+)\s*:\s*([\s\S]*)$/)
+    if (m && KEYS.includes(m[1].toLowerCase())) {
+      key = m[1].toLowerCase()
+      out[key] = m[2].trim()
+    } else if (key && part.trim()) {
+      out[key] = `${out[key]} ${part.trim()}`.trim()
+    }
+  }
+  // A bare string with no recognizable key at all is the bug description.
+  if (!out.bug && !Object.keys(out).length) out.bug = text
+  return out
+}
+
+const A = parseArgs(args)
+if (!A.bug) {
+  throw new Error(
+    'args.bug is required: describe the original vulnerability (ideally with file:line). ' +
+      'Pass args as a JSON object, e.g. {"bug": "...", "root": "/path", "lang": "python"}.',
+  )
+}
 
 const ROOT = A.root || '.'
 const LANG = A.lang || 'auto-detect from the codebase'
 const OUT = A.out || 'variant-analysis-report.md'
+
+// Single-quote for the shell. JSON.stringify looks like quoting but yields a
+// double-quoted string, where $(...) and backticks still expand — and the patterns
+// interpolated below are model-generated from codebase content. An unquoted path also
+// breaks on any root containing a space.
+const sh = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 
 // Each stage only reads its own strategy reference.
 //
@@ -123,11 +171,15 @@ const ROOT_CAUSE_SCHEMA = {
 
 const BASELINE_SCHEMA = {
   type: 'object',
-  required: ['match_count', 'locations', 'matches_origin'],
+  required: ['match_count', 'locations', 'matches_origin', 'source_file_count'],
   properties: {
     match_count: { type: 'integer' },
     locations: { type: 'array', items: { type: 'string' } },
     matches_origin: { type: 'boolean', description: 'True if one of the matches is the known vulnerable line named in the root cause.' },
+    source_file_count: {
+      type: 'integer',
+      description: 'Number of source files in the codebase, from the second command. Sizes the sweep.',
+    },
     notes: { type: 'string' },
   },
 }
@@ -235,16 +287,23 @@ log(`${rc.axes.length} expansion axes: ${rc.axes.map((x) => x.id).join(', ')}`)
 phase('Baseline')
 
 const baseline = await agent(
-  `Run this ripgrep pattern against the codebase at \`${ROOT}\` and report exactly what it matches:
+  `Run these two commands against the codebase at \`${ROOT}\` and report exactly what they return.
 
-    rg -n --no-heading ${JSON.stringify(rc.exact_pattern)} ${ROOT}
+1. The calibration pattern:
+
+    rg -n --no-heading ${sh(rc.exact_pattern)} ${sh(ROOT)}
+
+2. The size of the tree, which decides how wide the sweep needs to be:
+
+    rg --files ${sh(ROOT)} | wc -l
 
 The pattern is supposed to match this known vulnerable line:
   ${rc.origin.file}:${rc.origin.line}
   ${rc.origin.snippet}
 
-Report the true match count and locations. Set matches_origin only if one of the matches
-really is that line. Do not adjust the pattern to make it work, just report what it does.`,
+Report the true match count and locations, and source_file_count from the second command.
+Set matches_origin only if one of the matches really is that line. Do not adjust the
+pattern to make it work, just report what it does.`,
   { schema: BASELINE_SCHEMA, label: 'baseline', effort: 'low' },
 )
 
@@ -259,6 +318,21 @@ if (!baseline.matches_origin) {
   )
 }
 log(`Baseline OK: ${baseline.match_count} match(es), origin confirmed.`)
+
+// Size floor. Fanning six sweep agents and a triage batch per axis across a handful of
+// files spends 25 agents to re-read what one agent could hold at once — and the eval's
+// own negative result says exactly that: five small synthetic codebases showed no
+// difference between the workflow and the skill alone, because "the fan-out had nothing
+// to buy". Below the floor, sweep narrow and once.
+const SMALL_TREE = 40
+const isSmall = (baseline.source_file_count || 0) > 0 && baseline.source_file_count <= SMALL_TREE
+const axesPerRound = isSmall ? 2 : MAX_AXES_PER_ROUND
+const maxRounds = isSmall ? 1 : MAX_ROUNDS
+if (isSmall) {
+  log(
+    `Small tree (${baseline.source_file_count} files ≤ ${SMALL_TREE}): sweeping ${axesPerRound} axes in 1 round instead of ${MAX_AXES_PER_ROUND}×${MAX_ROUNDS}. Fan-out buys nothing at this size.`,
+  )
+}
 
 // ---------------------------------------------------------------------------
 // Phases 3+4 - Sweep and triage, pipelined per axis
@@ -275,7 +349,7 @@ let dry = 0
 let round = 0
 let stoppedForBudget = false
 
-while (round < MAX_ROUNDS && dry < DRY_ROUNDS_TO_STOP) {
+while (round < maxRounds && dry < DRY_ROUNDS_TO_STOP) {
   // Checked BEFORE the increment: a round that never ran is not a round that ran,
   // and counting it made the report say "swept N rounds" and "hit the round cap"
   // for a sweep that actually stopped early on budget.
@@ -288,9 +362,9 @@ while (round < MAX_ROUNDS && dry < DRY_ROUNDS_TO_STOP) {
 
   // Rotate through the axes across rounds rather than re-running the same slice, so
   // a long axis list gets swept rather than truncated.
-  const offset = ((round - 1) * MAX_AXES_PER_ROUND) % rc.axes.length
-  const axes = [...rc.axes, ...rc.axes].slice(offset, offset + MAX_AXES_PER_ROUND).slice(0, rc.axes.length)
-  if (rc.axes.length > MAX_AXES_PER_ROUND) {
+  const offset = ((round - 1) * axesPerRound) % rc.axes.length
+  const axes = [...rc.axes, ...rc.axes].slice(offset, offset + axesPerRound).slice(0, rc.axes.length)
+  if (rc.axes.length > axesPerRound) {
     log(`Round ${round} sweeps ${axes.length}/${rc.axes.length} axes: ${axes.map((x) => x.id).join(', ')}`)
   }
 
@@ -386,21 +460,27 @@ Return a verdict for every candidate, including the ones you judge minor.`,
   }
 }
 
-// Three ways out of that loop, and the report has to be told which. Only the dry
-// exit means the sweep is exhausted; the other two are coverage bounds a reader
-// needs to see, not just a line in the live log.
+// Four ways out of that loop, and the report has to be told which. Only the dry exit
+// means the sweep is exhausted; the rest are coverage bounds a reader needs to see, not
+// just a line in the live log. The small-tree bound is deliberate rather than a
+// truncation, so it is named separately — reporting it as "cap hit while still finding
+// variants" would read as a warning about a sweep that did what it was asked to.
 const sweptToDry = dry >= DRY_ROUNDS_TO_STOP
 if (stoppedForBudget) {
   log(`COVERAGE BOUND: stopped after ${round} round(s) with the token budget exhausted. The sweep is not exhausted.`)
-} else if (round >= MAX_ROUNDS && !sweptToDry) {
-  log(`COVERAGE BOUND: stopped at the ${MAX_ROUNDS}-round cap while still finding new variants. The sweep is not exhausted.`)
+} else if (isSmall && !sweptToDry) {
+  log(`Single-round sweep on a ${baseline.source_file_count}-file tree, as sized at the baseline gate.`)
+} else if (round >= maxRounds && !sweptToDry) {
+  log(`COVERAGE BOUND: stopped at the ${maxRounds}-round cap while still finding new variants. The sweep is not exhausted.`)
 }
 
 const stopReason = sweptToDry
   ? ' (swept to dry - no new variants in the last rounds)'
   : stoppedForBudget
     ? ' (STOPPED EARLY: token budget exhausted, not swept to dry - say so in the report)'
-    : ` (hit the ${MAX_ROUNDS}-round cap - sweep not exhausted, say so in the report)`
+    : isSmall
+      ? ` (single round, sized to a ${baseline.source_file_count}-file tree)`
+      : ` (hit the ${maxRounds}-round cap - sweep not exhausted, say so in the report)`
 
 // ---------------------------------------------------------------------------
 // Phase 5 - Report
@@ -422,6 +502,18 @@ Follow the template at \`${template(SKILL_DIR)}\` - read it first. Use \`date -I
 
 Match the report's length to what the findings need: cover the substance, but do not pad
 with filler sections, redundant summaries, or boilerplate.
+
+REQUIRED, and not negotiable for formatting reasons: give every confirmed variant its own
+\`### \` block under a \`## Findings\` heading, and inside that block put the location on
+its own line, exactly:
+
+    **Location:** \`path/to/file.ext:LINE\`
+
+Do not put the location only in the \`### \` header, and do not merge several findings into
+one block. Downstream tooling reads the \`**Location:**\` lines to tell a real finding from
+a path mentioned in passing while tracing data flow; a report that omits them is scored by
+a fallback that cannot make that distinction. Ruled-out sites go under a separate
+\`## False Positive Patterns\` heading, grouped by the reason they were safe.
 
 Codebase: ${ROOT}
 Original bug: ${A.bug}


### PR DESCRIPTION
This sits on top of #232. Merging it folds these fixes into that PR, which then goes to `main` as one change.

**What I did:** ran #232's plugin the way a user would, found bugs, fixed them. Nothing here is a redesign. It is #232 plus the things that broke when it was actually used.

## The short version

| Problem | Why it mattered | Fix |
|---|---|---|
| The workflow died instantly if Claude described the bug in a sentence instead of a JSON object | Whole run lost, no output, no clue why | Accept both |
| A codebase path with a space broke the search command | Silent wrong results | Quote it properly |
| 25 subagents ran against a 5-file project | Slow and expensive for no benefit | Small projects now use 7 |
| The scorer marked a *correct* report as wrong | The test failed good runs | Score against a function's real line range, not "within 30 lines" |
| The scorer's main path never ran on real reports, and nothing said so | Scores looked better than they were | The report now writes the format the scorer reads |
| A documented option (`--strict-decoy`) didn't exist | Following the README got you an error | Wired it up |
| Two test graders could never fail | They inflated the score and measured nothing | Deleted |
| Nothing checked the workflow script for syntax errors | A typo would only surface in a paid test run | Free syntax check added to CI |

Plus smaller things: a confusing error message, a path-parsing bug, and `AGENTS.md` didn't document where dynamic workflows go — this is the repo's first one.

## One claim in #232 was wrong

#232 says the skill never activates on its own, based on 40+ runs. I re-tested it 9 times and found the real story:

| How the user asks | Is there a codebase to search? | Activates? |
|---|---|---|
| "found a bug in `x.py`, are there others?" | yes | 2 of 3 |
| Wording closest to the skill's own description | yes | 3 of 3 |
| Code pasted into the chat, no files | no | 0 of 3 |

The skill activates fine. It just doesn't activate on pasted code — and every test case in #232 pastes code. With no files to search, there's nothing for it to do, so skipping it is arguably correct.

This matters for two reasons. It means deleting the old `/variants` command was the right call (Claude finds the workflow on its own, 4 times out of 5). And it means the README was overselling the skill, so I rewrote that section to say what actually happens.

## How I know the fixes work

Same workflow, same test project, before and after:

| | before | after |
|---|---|---|
| subagents used | 25 | 7 |
| scorer used its main path | no | yes |
| flagged a safe site as a bug | yes (wrong) | no |
| test result | FAIL | PASS |
| found both planted bugs | yes | yes |

I also broke each new test on purpose to confirm it fails when it should. Grader tests went from 13 to 18, aggregator tests 6 to 7. `ruff`, `shellcheck`, `shfmt`, the offline test suite, and `make validate` are all clean.

## Still not fixed

The test proves the workflow doesn't break. It does **not** prove the workflow beats the plain skill — both find the planted bug, so a tie passes.

Fixing that means giving the test cases a real codebase on disk. That would also solve the skill-activation gap above and the fact that the test scores are maxed out. It's the most valuable work left on this plugin, and it's too big to attach here.

## Reviewer notes

- **CI looks thin on purpose.** `lint.yml` and `validate.yml` only run for PRs targeting `main`, so a stacked PR gets neither. I ran their exact commands locally; they'll run for real once #232 merges.
- Version is 2.0.1. Squash it to 2.0.0 if you'd rather ship one version number.
- The comment thread below has the detailed back-and-forth with the automated reviewer, including one point of its I pushed back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)