### PR TITLE
Add an eval suite for dimensional-analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -352,7 +352,7 @@
     },
     {
       "name": "dimensional-analysis",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "description": "Annotates codebases with dimensional analysis comments documenting units, dimensions, and decimal scaling. Use when someone asks to annotate units in a codebase, perform a dimensional analysis, or find vulnerabilities in a DeFi protocol. Prevents dimensional mismatches and catches formula bugs early.",
       "author": {
         "name": "Coriolan Pinhas & Benjamin Samuels",

--- a/plugins/dimensional-analysis/.claude-plugin/plugin.json
+++ b/plugins/dimensional-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dimensional-analysis",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Annotates codebases with dimensional analysis comments documenting units, dimensions, and decimal scaling. Use when someone asks to annotate units in a codebase, perform a dimensional analysis, or find vulnerabilities in a DeFi protocol. Prevents dimensional mismatches and catches formula bugs early.",
   "author": {
     "name": "Coriolan Pinhas & Benjamin Samuels",

--- a/plugins/dimensional-analysis/evals/.gitignore
+++ b/plugins/dimensional-analysis/evals/.gitignore
@@ -1,0 +1,3 @@
+# Eval run output: scores, prompts, and judge verdicts per run. Regenerated on every
+# `claude plugin eval` invocation, so it is not worth versioning.
+results/

--- a/plugins/dimensional-analysis/evals/01-quote-per-base/graders/precision-three-correct-untouched.md
+++ b/plugins/dimensional-analysis/evals/01-quote-per-base/graders/precision-three-correct-untouched.md
@@ -1,0 +1,35 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+`dca_executor.py`, `twap_executor.py` and `grid_executor.py` are all dimensionally correct: quote divided by
+quote, dimensionless, exactly what a return percentage needs.
+
+**The only question this grader asks is whether the response claims any of those three
+has a dimensional or unit defect.** Judge that and nothing else.
+
+**FAIL** if the response presents any of `dca_executor.py`, `twap_executor.py` or `grid_executor.py` as having a
+unit mismatch, a wrong denominator, or a scaling error, or hedges on whether one does:
+
+- "dca may also be mixing units"
+- "twap should probably multiply by price too"
+- "grid has the same problem"
+- treating one of them as needing the same fix as `arbitrage_executor.py`
+
+**PASS** if the response leaves all three alone dimensionally. It passes regardless of
+any of the following, which are correct reviewer behaviour and must NOT count against
+it:
+
+- observing that `grid_executor.py` compares `filled_amount_quote > 0` against a bare `0` while
+  the others compare against `Decimal("0")`, or any other typing, style or consistency
+  remark
+- noting that the four guard clauses differ, or that `arbitrage_executor.py` alone checks
+  `is_closed`
+- pointing out that a zero denominator, a `None`, or a `NaN` could reach these
+- suggesting the four be refactored onto one shared helper
+- asking what `filled_amount_quote` means in the grid case
+
+Those are distinct from the dimensional question and do not fail this grader. The
+distinction is claim-based: "this one is also dimensionally wrong" fails; "this one is
+dimensionally fine, but here is a separate concern" passes.

--- a/plugins/dimensional-analysis/evals/01-quote-per-base/graders/recall-quote-per-base.md
+++ b/plugins/dimensional-analysis/evals/01-quote-per-base/graders/recall-quote-per-base.md
@@ -1,0 +1,39 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+Exactly one of the four executors is dimensionally wrong: `arbitrage_executor.py`.
+
+The dimension of `net_pnl_quote` is not stated, it has to be derived:
+`executed_amount_base * average_executed_price` is `{base} * {quote/base} = {quote}`,
+and `cum_fees_quote` is quote, so the difference is quote. That quote amount is then
+divided by `executed_amount_base`, a base amount, leaving `{quote/base}`, which is a
+price rather than the dimensionless ratio a percentage needs. The other three divide
+by a quote amount and are `{quote/quote}`, correct.
+
+The size of the error is the entry price: at 3000 quote per base, a 0.27% return is
+reported as 800%.
+
+**PASS** requires both of the following:
+
+1. The response identifies `arbitrage_executor.py` as wrong, and its reasoning is dimensional:
+   it says the denominator is a base amount where a quote amount is required, or that
+   the result carries a leftover `quote/base` (price) dimension, or equivalent. Naming
+   the units correctly matters; "looks inconsistent with the others" alone is not
+   enough, because that reasoning does not tell you which one is wrong.
+2. The response gives a correct fix: divide by the buy leg's quote amount. Accept any
+   of `executed_amount_quote`, `executed_amount_base * average_executed_price`, or a
+   description that is unambiguously one of those.
+
+**FAIL** if any of:
+
+- the response does not name `arbitrage_executor.py`
+- it names `arbitrage_executor.py` only as a style or consistency deviation, with no unit or
+  dimension reasoning
+- it proposes a fix that is still `{quote/base}`, for example dividing by
+  `average_executed_price` alone or by a base amount from a different leg
+
+Scale of the error is not required for a PASS. If the response does state a magnitude,
+it must be tied to the price rather than to a fixed constant; a claim such as "off by
+100x" with no price dependence is wrong reasoning and fails this grader.

--- a/plugins/dimensional-analysis/evals/01-quote-per-base/graders/skill-fired.md
+++ b/plugins/dimensional-analysis/evals/01-quote-per-base/graders/skill-fired.md
@@ -1,0 +1,5 @@
+---
+type: tool_used
+tool: Skill
+min: 1
+---

--- a/plugins/dimensional-analysis/evals/01-quote-per-base/prompt.md
+++ b/plugins/dimensional-analysis/evals/01-quote-per-base/prompt.md
@@ -1,0 +1,69 @@
+---
+max_turns: 20
+timeout_seconds: 480
+allowed_tools: [Skill, Read, Grep, Glob]
+runs: 3
+---
+Reviewing the offchain accounting in our crypto trading bot before we publish the
+numbers. It runs strategies across both CEX and DEX venues, and four executors report
+a return percentage to the same dashboard. Are any of these computing it wrong?
+
+```python
+# executors/arbitrage_executor.py
+def get_net_pnl_quote(self) -> Decimal:
+    if self.close_type == CloseType.COMPLETED:
+        sell_quote_amount = self.sell_order.order.executed_amount_base * self.sell_order.average_executed_price
+        buy_quote_amount = self.buy_order.order.executed_amount_base * self.buy_order.average_executed_price
+        return sell_quote_amount - buy_quote_amount - self.cum_fees_quote
+    else:
+        return Decimal("0")
+
+def get_net_pnl_pct(self) -> Decimal:
+    if self.is_closed:
+        if self.buy_order.order and self.buy_order.order.executed_amount_base > 0:
+            return self.net_pnl_quote / self.buy_order.order.executed_amount_base
+        else:
+            return Decimal("0")
+    else:
+        return Decimal("0")
+```
+
+```python
+# executors/dca_executor.py
+def get_net_pnl_pct(self) -> Decimal:
+    """
+    This method is responsible for calculating the net pnl percentage
+    """
+    return self.net_pnl_quote / self.open_filled_amount_quote if self.open_filled_amount_quote > Decimal("0") else Decimal("0")
+```
+
+```python
+# executors/twap_executor.py
+def get_net_pnl_pct(self) -> Decimal:
+    """
+    This method is responsible for calculating the net pnl percentage
+    """
+    total_executed_quote = self.get_total_executed_amount_quote()
+    return self.net_pnl_quote / total_executed_quote if total_executed_quote > Decimal("0") else Decimal("0")
+```
+
+```python
+# executors/grid_executor.py
+def get_net_pnl_pct(self) -> Decimal:
+    """
+    Calculate the net pnl percentage
+
+    :return: The net pnl percentage.
+    """
+    return self.get_net_pnl_quote() / self.filled_amount_quote if self.filled_amount_quote > 0 else Decimal("0")
+```
+
+For reference, the tracked-order fields these read:
+
+```python
+class TrackedOrder:
+    executed_amount_base: Decimal   # base units filled, e.g. ETH
+    executed_amount_quote: Decimal  # quote spent or received, e.g. USDT
+    average_executed_price: Decimal # quote per base
+    cum_fees_quote: Decimal         # fees, quote
+```

--- a/plugins/dimensional-analysis/evals/02-neg-correct-denominator/graders/explicit-negative-conclusion.md
+++ b/plugins/dimensional-analysis/evals/02-neg-correct-denominator/graders/explicit-negative-conclusion.md
@@ -1,0 +1,21 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+The question is whether anything is wrong in the arithmetic. "Nothing is wrong" is an
+answer and has to be given, not implied.
+
+**PASS** if the response commits: it says the arithmetic here is dimensionally
+correct, that the quote-over-quote ratio is right, that it found no unit defect, or
+equivalent.
+
+**FAIL** if the response narrates the two functions without ever answering, or ends
+ambiguously: trailing off into things worth checking, deferring to a wider audit, or
+leaving open whether the denominator is right.
+
+Judge only whether a clear conclusion is reached. Whether that conclusion is correct is
+graded separately by `precision-no-false-positive`; do not consider correctness here.
+
+This grader exists because its sibling can be passed by silence. A response that says
+nothing definite claims no defect and would clear a precision check on that alone.

--- a/plugins/dimensional-analysis/evals/02-neg-correct-denominator/graders/precision-no-false-positive.md
+++ b/plugins/dimensional-analysis/evals/02-neg-correct-denominator/graders/precision-no-false-positive.md
@@ -1,0 +1,39 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+This code is dimensionally sound. Every term in `get_net_pnl_quote` is a quote amount,
+so the subtraction is well formed and the result is quote. `get_net_pnl_pct` then
+divides that quote result by `executed_amount_quote`, also quote, giving a
+dimensionless ratio.
+
+This is case 01's `arbitrage_executor.py` after the fix, so it is the direct control for the
+positive case: the same function, the same field names in scope, one denominator
+changed. `executed_amount_base` and `average_executed_price` are still declared on
+`TrackedOrder` and are still the wrong things to divide by, which is what makes this a
+test of whether the skill reads the code or pattern-matches on the presence of mixed
+units nearby.
+
+**FAIL** if the response reports a dimensional or unit defect in this code:
+
+- claiming the denominator should be a base amount, or should involve
+  `average_executed_price`
+- claiming the subtraction in `get_net_pnl_quote` mixes dimensions
+- claiming the returned ratio still carries a unit
+- hedging: "this may still be mixing quote and base", "consider whether the denominator
+  is the right one"
+
+**PASS** if the response concludes the arithmetic is dimensionally correct. It passes
+regardless of any of the following:
+
+- noting the ratio is a fraction rather than a percentage, so a caller multiplying by
+  100 matters. That is a real observation about presentation, not a dimensional defect
+- flagging that fees are subtracted from the spread rather than netted per leg
+- observing that `is_closed` and `close_type == COMPLETED` are different guards, so
+  `net_pnl_quote` can be zero while `get_net_pnl_pct` still divides
+- any remark about `Decimal` versus `float`, or about the missing zero check on
+  `close_type`
+
+Recommending a comment that records the units is also a PASS. Adding annotation is what
+this plugin exists to do; the failure this grader looks for is a claimed *bug*.

--- a/plugins/dimensional-analysis/evals/02-neg-correct-denominator/prompt.md
+++ b/plugins/dimensional-analysis/evals/02-neg-correct-denominator/prompt.md
@@ -1,0 +1,36 @@
+---
+max_turns: 12
+timeout_seconds: 300
+allowed_tools: [Skill, Read, Grep, Glob]
+runs: 3
+---
+Same review of the bot's offchain accounting, one file this time. Anything wrong in
+the arithmetic here?
+
+```python
+# executors/arbitrage_executor.py
+def get_net_pnl_quote(self) -> Decimal:
+    if self.close_type == CloseType.COMPLETED:
+        return (self.sell_order.executed_amount_quote
+                - self.buy_order.executed_amount_quote
+                - self.cum_fees_quote)
+    else:
+        return Decimal("0")
+
+def get_net_pnl_pct(self) -> Decimal:
+    if self.is_closed:
+        quote_spent = self.buy_order.executed_amount_quote
+        if quote_spent > 0:
+            return self.net_pnl_quote / quote_spent
+    return Decimal("0")
+```
+
+For reference, the tracked-order fields these read:
+
+```python
+class TrackedOrder:
+    executed_amount_base: Decimal   # base units filled, e.g. ETH
+    executed_amount_quote: Decimal  # quote spent or received, e.g. USDT
+    average_executed_price: Decimal # quote per base
+    cum_fees_quote: Decimal         # fees, quote
+```

--- a/plugins/dimensional-analysis/evals/03-all-correct-panel/graders/explicit-negative-conclusion.md
+++ b/plugins/dimensional-analysis/evals/03-all-correct-panel/graders/explicit-negative-conclusion.md
@@ -1,0 +1,21 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+A sweep that finds nothing has to say so. A clean result is a result, and a response
+that walks through five helpers without ever committing leaves the reader to guess
+whether the release is safe.
+
+**PASS** if the response states plainly that none of the five has a unit or scaling
+bug: that the sweep came back clean, that all five are dimensionally sound, or
+equivalent. A per-helper verdict of "correct" on all five also passes; the conclusion
+does not have to be one summary sentence.
+
+**FAIL** if the response describes each helper without ever reaching an overall
+verdict, or if it ends ambiguously: trailing off into next steps, listing things to
+check later, or leaving open whether any of the five is wrong.
+
+Judge only whether a clear negative conclusion is reached. Whether that conclusion is
+correct is graded separately by `precision-floor-zero-bugs`; do not consider
+correctness here.

--- a/plugins/dimensional-analysis/evals/03-all-correct-panel/graders/precision-floor-zero-bugs.md
+++ b/plugins/dimensional-analysis/evals/03-all-correct-panel/graders/precision-floor-zero-bugs.md
@@ -1,0 +1,46 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+None of the five has a unit or scaling bug. Each one is deliberately shaped to look
+like a known dimensional bug pattern while being correct:
+
+1. `fill_notional`: `{base} * {quote/base} = {quote}`. Correct. Resembles the
+   multiply-instead-of-divide pattern.
+2. `to_internal`: scales by `10 ** (18 - 8)`, the right direction and the right
+   magnitude for an 8-decimal feed entering an 18-decimal representation. Resembles the
+   oracle-precision-mismatch pattern, and is the one most likely to be misread, since
+   the pattern usually appears as a bug.
+3. `apply_fee_bps`: basis points are parts per 10,000, so `quote * bps / 10_000` is
+   `{quote}`. Correct. The bare `10_000` looks like an unexplained magic scale factor.
+4. `funding_owed`: `{quote} * {1/h} * {h} = {quote}`. The seconds-to-hours conversion
+   is present and in the right direction. Resembles the missing-time-unit-conversion
+   pattern.
+5. `average_entry`: `{quote}/{base} = {quote/base}`, a price, which is what an average
+   entry is. Summing quote across fills and base across fills before dividing is the
+   correct volume weighting. Resembles the mean-of-ratios error without being it.
+
+**FAIL** if the response presents any of the five as having a unit, dimension, or
+scaling defect, or hedges on whether one does. Any of these fails:
+
+- "to_internal may be scaling the wrong way"
+- "apply_fee_bps should divide by 1e18"
+- "average_entry should average the two prices"
+- "funding_owed is missing a conversion"
+- "fill_notional should divide rather than multiply"
+
+**PASS** if the response reports no dimensional defects. It passes regardless of any of
+the following, which are correct reviewer behaviour:
+
+- flagging `Decimal(10) ** (INTERNAL_DECIMALS - FEED_DECIMALS)` as fragile if a feed
+  ever reports more than 18 decimals, so the exponent goes negative
+- noting `average_entry` divides without guarding `b1 + b2 == 0`
+- noting `apply_fee_bps` truncates rather than rounds, or that a fee direction is not
+  stated
+- observing that none of the five carries a unit annotation and recommending the
+  plugin's annotation format be applied
+- rating any of them low or informational for an explicitly non-dimensional reason
+
+This is the only case in this suite that punishes over-reporting. Every other case
+rewards finding something. Do not remove it.

--- a/plugins/dimensional-analysis/evals/03-all-correct-panel/prompt.md
+++ b/plugins/dimensional-analysis/evals/03-all-correct-panel/prompt.md
@@ -1,0 +1,42 @@
+---
+max_turns: 20
+timeout_seconds: 480
+allowed_tools: [Skill, Read, Grep, Glob]
+runs: 3
+---
+Pre-release sweep of the numeric helpers in our crypto exchange connector, the layer
+that reconciles fills from CEX and DEX venues against an internal fixed-point
+representation. Which of these five have unit or scaling bugs?
+
+```python
+# 1. notional of a fill
+def fill_notional(base_amount: Decimal, price: Decimal) -> Decimal:
+    """price is quote per base."""
+    return base_amount * price
+
+
+# 2. chainlink-style feed, 8 decimals, into an 18-decimal internal representation
+FEED_DECIMALS = 8
+INTERNAL_DECIMALS = 18
+
+def to_internal(raw_answer: int) -> Decimal:
+    return Decimal(raw_answer) * Decimal(10) ** (INTERNAL_DECIMALS - FEED_DECIMALS)
+
+
+# 3. basis points applied to a quote amount
+def apply_fee_bps(quote_amount: Decimal, fee_bps: int) -> Decimal:
+    return quote_amount * Decimal(fee_bps) / Decimal(10_000)
+
+
+# 4. funding accrual over an interval
+def funding_owed(position_quote: Decimal, rate_per_hour: Decimal,
+                 elapsed_seconds: int) -> Decimal:
+    hours = Decimal(elapsed_seconds) / Decimal(3600)
+    return position_quote * rate_per_hour * hours
+
+
+# 5. average entry across two fills
+def average_entry(q1: Decimal, b1: Decimal, q2: Decimal, b2: Decimal) -> Decimal:
+    """qN is quote spent on fill N, bN is base received."""
+    return (q1 + q2) / (b1 + b2)
+```

--- a/plugins/dimensional-analysis/evals/04-neg-explain-function/graders/stays-an-explanation.md
+++ b/plugins/dimensional-analysis/evals/04-neg-explain-function/graders/stays-an-explanation.md
@@ -1,0 +1,32 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+The ask is a docstring. The code is dimensionally correct: quote divided by quote, a
+dimensionless ratio, guarded against a zero denominator.
+
+**The question this grader asks is whether the response stayed an explanation.** It is
+not testing how much dimensional detail the answer carries. Naming the units while
+explaining is correct and expected here.
+
+**PASS** if the response answers the question that was asked: it describes what the
+function returns and does not misstate it.
+
+**FAIL** if the response turns into an audit instead of an answer:
+
+- it opens an annotation pass over the file or the codebase
+- it reports a dimensional bug in this function
+- it goes hunting for other call sites or sibling executors to compare units against,
+  when nothing was asked about them
+- it produces a findings list, a severity, or a remediation plan
+- the docstring is buried under an analysis the user did not ask for
+
+**FAIL** also if the response states the return value is already scaled to 0-100. It is
+not: callers multiply by 100 themselves, so the function returns a fraction. Noticing
+that the name says "percentage" while the value is a fraction is a good answer and
+scores no higher than one that simply describes the ratio correctly; only asserting the
+opposite fails.
+
+A brief closing line that the arithmetic is dimensionally consistent is fine. Offering
+to annotate the rest of the file, as an offer, is also fine. Doing it unasked is not.

--- a/plugins/dimensional-analysis/evals/04-neg-explain-function/prompt.md
+++ b/plugins/dimensional-analysis/evals/04-neg-explain-function/prompt.md
@@ -1,0 +1,19 @@
+---
+max_turns: 8
+timeout_seconds: 180
+allowed_tools: [Skill, Read, Grep, Glob]
+runs: 3
+---
+What does this do? Rewriting the docstring and I want to describe the return value
+accurately.
+
+```python
+# executors/position_executor.py
+def get_net_pnl_pct(self) -> Decimal:
+    """
+    Calculate the net pnl percentage
+
+    :return: The net pnl percentage.
+    """
+    return self.net_pnl_quote / self.open_filled_amount_quote if self.open_filled_amount_quote != Decimal("0") else Decimal("0")
+```

--- a/plugins/dimensional-analysis/evals/05-scaling-direction/graders/precision-two-correct-untouched.md
+++ b/plugins/dimensional-analysis/evals/05-scaling-direction/graders/precision-two-correct-untouched.md
@@ -1,0 +1,37 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+`size_to_internal` and `internal_to_display` are both correct.
+
+`size_to_internal` scales by `10 ** (INTERNAL_DECIMALS - token_decimals)`, the
+difference between where the value is and where it needs to be, which is the right
+construction and the right direction for going up. `internal_to_display` divides by
+`10 ** (INTERNAL_DECIMALS - display_decimals)`, the same difference, and dividing is
+the right direction for going down.
+
+**The only question this grader asks is whether the response claims either of those
+two has a scaling or unit defect.** Judge that and nothing else.
+
+**FAIL** if the response presents either as wrong, or hedges on whether it is:
+
+- "size_to_internal has the same problem"
+- "internal_to_display should multiply instead"
+- "both conversions look suspect"
+- treating either as needing the same fix as `price_to_internal`
+
+**PASS** if the response leaves both alone. It passes regardless of any of the
+following, which are correct reviewer behaviour:
+
+- noting that `token_decimals` above 18, or `display_decimals` above 18, drives the
+  exponent negative, and that nothing validates either input
+- noting that `internal_to_display` truncates or loses precision on the way down, or
+  that its rounding mode is unstated
+- observing that the three helpers carry no unit annotations and recommending the
+  plugin's format be applied
+- suggesting the shared `10 ** (a - b)` construction be factored into one helper so
+  the broken one cannot drift again
+
+The distinction is claim-based: "this one is also scaled wrong" fails; "this one is
+scaled right, but here is a separate concern" passes.

--- a/plugins/dimensional-analysis/evals/05-scaling-direction/graders/recall-wrong-exponent.md
+++ b/plugins/dimensional-analysis/evals/05-scaling-direction/graders/recall-wrong-exponent.md
@@ -1,0 +1,36 @@
+---
+type: llm
+focus: last_message
+weight: 1
+---
+`price_to_internal` is the broken one. It multiplies by `10 ** FEED_DECIMALS`, which
+is `10 ** 8`. The gap between the two representations is `INTERNAL_DECIMALS -
+FEED_DECIMALS`, so the multiplier should be `10 ** 10`. A raw answer of `X` stands for
+`X / 10 ** 8`, and the internal value must satisfy `internal / 10 ** 18 = X / 10 ** 8`,
+which gives `internal = X * 10 ** 10`. Every mark it produces is 100 times too small.
+
+The other two are correct. `size_to_internal` uses the difference of the two decimal
+counts, which is the same construction `price_to_internal` should have used.
+`internal_to_display` divides by that difference, the right direction for going down.
+
+**PASS** requires all three of:
+
+1. It names `price_to_internal`.
+2. Its reasoning is about the exponent: the multiplier uses the feed's decimals rather
+   than the difference between the two representations, or equivalent. "Inconsistent
+   with the other two" alone is not enough, because that reasoning does not say which
+   of the three is the wrong one.
+3. Its fix produces `10 ** (INTERNAL_DECIMALS - FEED_DECIMALS)`. Accept `10 ** 10`, the
+   symbolic form, or a described equivalent.
+
+**FAIL** if any of:
+
+- it does not name `price_to_internal`
+- it names the function but locates the defect somewhere other than the exponent, for
+  example claiming the multiplication should be a division
+- its fix does not land on `10 ** 10`, for example `10 ** 18` or `10 ** 26`
+- it reports one of the other two helpers as broken
+
+Stating the magnitude is not required. If a magnitude is given it must be 100, or
+`10 ** 2`, or "two orders of magnitude"; a different factor means the exponent was not
+actually worked out and fails this grader.

--- a/plugins/dimensional-analysis/evals/05-scaling-direction/prompt.md
+++ b/plugins/dimensional-analysis/evals/05-scaling-direction/prompt.md
@@ -1,0 +1,30 @@
+---
+max_turns: 20
+timeout_seconds: 480
+allowed_tools: [Skill, Read, Grep, Glob]
+runs: 3
+---
+Onboarding a new price feed into our onchain settlement path. Everything inside the
+protocol is held at 18 decimals; the feed publishes at 8. Three conversion helpers,
+one of them is giving us marks that are visibly off. Which one, and why?
+
+```python
+# oracle/scaling.py
+FEED_DECIMALS = 8
+INTERNAL_DECIMALS = 18
+
+
+def price_to_internal(raw_answer: int) -> Decimal:
+    """Feed answer to the protocol's internal fixed-point price."""
+    return Decimal(raw_answer) * Decimal(10) ** FEED_DECIMALS
+
+
+def size_to_internal(raw_amount: int, token_decimals: int) -> Decimal:
+    """Token amount in its own decimals to the protocol's internal fixed point."""
+    return Decimal(raw_amount) * Decimal(10) ** (INTERNAL_DECIMALS - token_decimals)
+
+
+def internal_to_display(value: Decimal, display_decimals: int) -> Decimal:
+    """Internal fixed point down to however many places the UI shows."""
+    return value / Decimal(10) ** (INTERNAL_DECIMALS - display_decimals)
+```

--- a/plugins/dimensional-analysis/evals/README.md
+++ b/plugins/dimensional-analysis/evals/README.md
@@ -1,0 +1,164 @@
+# dimensional-analysis skill eval
+
+Four cases measuring the `dimensional-analysis` **skill** on Python rather than
+Solidity. `references/bug-patterns.md` says the patterns "occur in any language
+performing arithmetic with mixed units and scaling factors (Rust, TypeScript, Python,
+etc.)", and then carries 59 Solidity code blocks and no Python ones, so nothing
+measures that claim. The arithmetic here is exchange execution accounting: base
+amounts, quote amounts, prices, basis points, funding intervals.
+
+```sh
+claude plugin eval . --ablation with-without --judge-model sonnet
+```
+
+The headline number is **Δ**: with-plugin score minus without-plugin score. Every case
+runs in both arms, three runs each.
+
+`--judge-model sonnet` is required, not a preference. Case 03 turns on the difference
+between "this looks like the oracle-precision bug pattern" and "this is that pattern
+applied correctly"; a small judge collapses the two and the suite still emits numbers
+that no longer mean anything.
+
+## Cases
+
+| Case | Shape | Ground truth |
+|---|---|---|
+| `01-quote-per-base` | Four sibling executors, one wrong | 1 real, 3 correct |
+| `02-neg-correct-denominator` | Case 01's bug, after the fix | 0 real |
+| `03-all-correct-panel` | Five helpers that resemble known patterns | 0 real, 5 correct |
+| `04-neg-explain-function` | "What does this do?" | must stay an explanation |
+| `05-scaling-direction` | Three conversions, one wrong exponent | 1 real, 2 correct |
+
+Nine scored graders: two recall, four precision, two that require a conclusion to be
+reached at all, one that requires the answer to stay an answer. That is less
+recall-weighted than the `variant-analysis` suite next door, which runs four positive
+cases to three negative, and the reason is that the failure this plugin is likelier to
+have on unfamiliar code is over-reporting rather than blindness. Every helper in these
+cases has units in it, so a run that has decided units are suspicious can flag all of
+them and look busy. If piloting shows the precision floor is never in danger, the
+cheapest rebalance is a third positive case rather than a reweight.
+
+Case 01 is a real bug, not a constructed one, and the four snippets are the upstream
+code rather than a paraphrase of it. `net_pnl_quote / executed_amount_base` divides a
+quote amount by a base amount and reports the result as a return percentage; the
+leftover `{quote/base}` is a price, so the number is wrong by the entry price.
+Measured on the upstream code, a round trip returning 0.27% was reported as 800%. It
+shipped in two executors and was reported upstream as
+[hummingbot#8408](https://github.com/hummingbot/hummingbot/pull/8408).
+
+The quote dimension of the numerator is not annotated anywhere, which is the point:
+`executed_amount_base * average_executed_price` has to be reduced to `{quote}` before
+the division reads as wrong. A run that only checks whether names agree cannot get
+there.
+
+That origin is what makes case 02 worth having. It is the same function after the fix,
+with `executed_amount_base` and `average_executed_price` still in scope and still the
+wrong things to divide by. A run that pattern-matches on nearby mixed units flags it;
+a run that reads the arithmetic does not.
+
+Case 01 rewards naming the dimensions rather than noticing the odd one out. Three of
+the four siblings agree, so "this one differs from the others" reaches the right file
+by counting rather than by dimensional reasoning, and that inference does not transfer
+to a codebase where the wrong form is the majority. The recall grader requires the
+unit argument, and requires the proposed fix to land back in `{quote/quote}`.
+
+Case 03 is the broadest trap for over-reporting: five helpers, no bugs, and every one
+of them shaped to look like one. Case 02 is the narrow version of the same trap, aimed
+at a single function. Between them they are the whole of the precision floor, so if
+either goes, the suite stops being able to tell a working run from an eager one. Each
+of case 03's helpers resembles a named pattern from `references/bug-patterns.md` while
+being correct:
+
+| Helper | Resembles | Why it is correct |
+|---|---|---|
+| `to_internal` | Pattern 1, Pattern 6 (wrong scaling direction) | `10 ** (18 - 8)` is the right direction and magnitude for an 8-decimal feed |
+| `apply_fee_bps` | Pattern 10 (fee applied to wrong dimension) | basis points are parts per 10,000, so `quote * bps / 10_000` stays quote |
+| `funding_owed` | Pattern 11 (time unit confusion) | the seconds-to-hours conversion is present, and `{quote}*{1/h}*{h}` is quote |
+| `average_entry` | Pattern 12 (division before multiplication) | summing quote and base before dividing is the correct volume weighting |
+| `fill_notional` | the multiply-instead-of-divide reading | `{base} * {quote/base}` is quote |
+
+That section of the reference has its own "False Positive Avoidance" guidance. Case 03
+is where it gets measured.
+
+Case 05 is the only constructed case in the suite; the rest come from real code. It
+puts the plugin's own home turf in Python: `price_to_internal`
+multiplies by `10 ** FEED_DECIMALS` where the gap between the two representations is
+`INTERNAL_DECIMALS - FEED_DECIMALS`, so every mark comes out 100 times too small. Its
+two siblings use that difference correctly, once upward and once downward, which is
+what stops "the exponent looks odd" from reaching the answer.
+
+Case 03's `to_internal` is the same conversion done right, so the pair reads as a
+discrimination test across the suite: the identical shape appears once as a correct
+helper the run must leave alone and once as the bug it must find.
+
+## Scope
+
+These cases measure the **validate** end of the pipeline: whether an arithmetic defect
+is found and whether correct arithmetic is left alone. `SKILL.md` describes a wider
+workflow of discover, annotate, propagate, then validate, and nothing here scores the
+annotation output itself, only that recommending annotation is never punished. A suite
+for the annotation pass wants fixture files on disk and a diff-shaped grader, which is
+a different build.
+
+Nothing here has been piloted against a live run. The `variant-analysis` README says
+to expect two or three calibration passes before a rubric is trustworthy, and its
+account of what those passes turned up, fixtures labelled safe that were not, a
+severity clause fighting a claim clause, is the reason to say plainly that this suite
+has had none. The ground truth has been checked by hand and by arithmetic; the rubrics
+have not been checked against a judge.
+
+## Grader design
+
+Recall and precision are graded **separately** on cases 01 and 05, so a score change
+tells you which one moved.
+
+Precision graders are **claim-based**: the only question is whether the response claims
+a dimensionally correct site has a unit defect. Raising a genuinely different concern
+at one of those sites, an unguarded zero denominator, `Decimal` versus `float`,
+truncation instead of rounding, a negative exponent if a feed ever reports more than
+18 decimals, passes. That is correct reviewer behaviour and the graders must not
+punish it. The distinction is claim-based, not severity-based: "this one is also
+dimensionally wrong" fails; "this one is dimensionally fine, but here is a separate
+concern" passes.
+
+Recommending that units be annotated passes everywhere, including on the negative
+cases. Annotation is what the plugin exists to do, and a suite that treats it as a
+false positive would score the skill down for working.
+
+Cases 02 and 03 pair their precision grader with one that only asks whether a
+conclusion was reached. A precision check alone is passable by silence: a response
+that narrates the code and never commits has claimed no defect, so it clears the
+precision bar without answering the question. The conclusion graders judge commitment
+and ignore correctness; the precision graders judge correctness and ignore
+commitment. Neither should be folded into the other, because a run can fail one while
+passing the other and it matters which.
+
+Validation does not cover any of this. `validate_reference_links` in
+`.github/scripts/validate_plugin_metadata.py` skips any path with `evals` in it, so
+`make validate` reports on the plugin around this directory rather than on the
+directory itself. The links here were checked by hand.
+
+The `skill-fired` grader on case 01 is **display-only** under ablation: no `arm:` and
+no `weight:`, so it is reported rather than scored and never moves Δ. It gives the
+trigger rate independently of answer quality. Cases 02 to 04 carry no such grader on
+purpose. A `skill-not-fired` check would be unfailable in both arms: the baseline arm
+has no plugin, so `Skill` never fires there, and a grader no arm can fail is worth
+deleting rather than reweighting.
+
+## What the trigger rate is measuring
+
+The skill's `description` routes on "annotate units", "perform a dimensional analysis",
+or "a DeFi protocol, offchain code, or other blockchain-related codebase". `SKILL.md`'s
+own "When to Use" is wider than that: it lists "financial code" and "hunting for
+arithmetic bugs caused by unit mismatches", neither of which mentions a chain.
+
+None of the five cases asks for a dimensional analysis by name, because a suite that
+does is measuring compliance rather than routing. They name the domain instead, which
+is what a person reviewing this code would actually say. That leaves the description's
+blockchain clause carrying the routing, and the `skill-fired` rate on case 01 is what
+tells you whether it carries it. A low rate there with a healthy Δ elsewhere is a
+finding about the description, not about the analysis.
+
+Case 04 is the one shape the skill is documented to decline. "When NOT to Use" says a
+quick spot-check of a single formula should be read directly rather than run through
+the pipeline, and case 04 is exactly one formula.


### PR DESCRIPTION
Five cases, in Python rather than Solidity. references/bug-patterns.md says
the patterns occur in any language doing arithmetic with mixed units, then
carries 59 Solidity code blocks and no Python ones, so nothing measures that.

Case 01 is a real bug rather than a constructed one, and the four snippets are
the upstream source verbatim. Four sibling executors report a return
percentage; one divides a quote amount by a base amount, leaving a price where
a dimensionless ratio belongs. A round trip returning 0.27% reports 800%, off
by the entry price. Reported upstream as hummingbot#8408.

Nothing annotates the numerator's dimension, so
executed_amount_base * average_executed_price has to be reduced to quote before
the division reads as wrong. Three of the four siblings agree, which means
"this one differs from the others" reaches the right file by counting rather
than by dimensional reasoning, so the recall grader requires the unit argument
and requires the proposed fix to land back in quote over quote.

Case 05 is the constructed one and puts the plugin's home turf in Python: a
feed conversion multiplying by ten to the feed's decimals instead of the gap
between the two representations, 100x low, with two siblings that use the gap
correctly. Case 03 carries the same conversion done right, so the pair is a
discrimination test: one shape, once as the bug and once as the control.

Case 02 is case 01's function after the fix, with the wrong fields still in
scope, and case 03 is five helpers that each resemble a named pattern from the
reference while being correct. Those two are the precision floor. Case 04 asks
for a docstring and fails if the skill turns that into an audit, which is the
shape SKILL.md's own "When NOT to Use" says to decline.

Both negative cases carry a second grader that asks only whether a conclusion
was reached. A precision check on its own is passable by silence: a response
that narrates the code and never commits has claimed no defect, so it clears
the bar without answering. Commitment and correctness are judged separately
because a run can fail one while passing the other.

Nine scored graders: two recall, four precision, two conclusion, one that
keeps an answer an answer. Less recall-weighted than the variant-analysis
suite, and the README says why: every helper here has units in it, so the
likelier failure on unfamiliar code is flagging all of them rather than
missing one.

Case 01 carries a display-only skill-fired grader with no arm and no weight.
The trigger rate is worth watching because the skill's description routes on
blockchain code while its own "When to Use" says financial code, and these
prompts name the domain rather than asking for a dimensional analysis.

Note that validate_reference_links skips any path with evals in it, so
make validate does not cover this directory; the links were checked by hand.
No case has been piloted against a live run, which the README says plainly.
Ground truth is checked by hand and by arithmetic; the rubrics have not met a
judge. make self-test, make validate and make lint pass. make python-tests
fails the same way on a clean checkout, in constant-time-analysis.