### PR TITLE
Add an eval suite for entry-point-analyzer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "entry-point-analyzer",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "description": "Analyzes smart contract codebases to identify state-changing entry points for security auditing. Detects externally callable functions that modify state, categorizes them by access level, and generates structured audit reports.",
       "author": {
         "name": "Nicolas Donboly",

--- a/plugins/entry-point-analyzer/.claude-plugin/plugin.json
+++ b/plugins/entry-point-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "entry-point-analyzer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Analyzes smart contract codebases to identify state-changing entry points for security auditing. Detects externally callable functions that modify state, categorizes them by access level, and generates structured audit reports.",
   "author": {
     "name": "Nicolas Donboly",

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/case.yaml
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/case.yaml
@@ -1,0 +1,34 @@
+schema_version: "1.1"
+name: inherited-and-unnamed
+description: >
+  The attack surface of StakingVault is not all in StakingVault.sol. Four of its eleven
+  state-changing entry points are declared two files away, in AccessBase and Pausable, and two more
+  are receive() and fallback(), which carry no name to grep for. Six of its nine read-only ABI
+  members are generated getters for public variables, which read like functions but cannot change
+  state. Entry points here are the ABI members that are neither view nor pure.
+tags: [solidity, inheritance, access-control]
+
+context:
+  add_dirs: [fixture]
+
+execution:
+  prompt: |
+    We're scoping an audit of the vault in the fixture directory. StakingVault is the deployed
+    contract.
+
+    Map the attack surface for me: which functions can an outside caller reach that change state,
+    and who is allowed to call each one? I want the entry point list before anyone starts hunting
+    for bugs.
+  max_turns: 30
+  timeout_seconds: 900
+  allowed_tools: [Read, Glob, Grep, Skill, Task]
+
+runs: 3
+
+expected_outcome: >
+  The report lists all eleven state-changing entry points of StakingVault, including
+  transferOwnership, setKeeper, pause and unpause, which are inherited from AccessBase and Pausable
+  rather than declared in StakingVault.sol, and receive(). It does not present the public state
+  variable getters, previewWithdraw, pauseStatus or quoteFee as entry points. Access is classified:
+  uniswapV3SwapCallback is callable only by the pool, pause only by a keeper, and
+  transferOwnership, setKeeper, unpause and sweep only by the owner.

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/fixture/AccessBase.sol
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/fixture/AccessBase.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/// @notice Ownership and keeper registry.
+abstract contract AccessBase {
+    address public owner;
+    mapping(address => bool) public keepers;
+
+    event OwnerChanged(address indexed from, address indexed to);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    modifier onlyKeeper() {
+        require(keepers[msg.sender], "not keeper");
+        _;
+    }
+
+    function transferOwnership(address to) external onlyOwner {
+        require(to != address(0), "zero owner");
+        emit OwnerChanged(owner, to);
+        owner = to;
+    }
+
+    function setKeeper(address k, bool allowed) external onlyOwner {
+        keepers[k] = allowed;
+    }
+
+    function _requireOwner() internal view {
+        require(msg.sender == owner, "not owner");
+    }
+}

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/fixture/Pausable.sol
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/fixture/Pausable.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {AccessBase} from "./AccessBase.sol";
+
+/// @notice Pause switch for deposits and withdrawals.
+abstract contract Pausable is AccessBase {
+    bool public paused;
+
+    event Paused(address indexed by);
+    event Unpaused(address indexed by);
+
+    modifier whenNotPaused() {
+        require(!paused, "paused");
+        _;
+    }
+
+    function pause() external onlyKeeper {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function pauseStatus() external view returns (bool, address) {
+        return (paused, owner);
+    }
+}

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/fixture/StakingVault.sol
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/fixture/StakingVault.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Pausable} from "./Pausable.sol";
+
+interface IPool {
+    function swap(address recipient, int256 amount, bytes calldata data) external;
+}
+
+/// @notice Holds staked ETH and pays it back on withdrawal.
+contract StakingVault is Pausable {
+    mapping(address => uint256) public balances;
+    uint256 public totalStaked;
+    address public immutable pool;
+
+    event Staked(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
+
+    constructor(address _pool) {
+        owner = msg.sender;
+        pool = _pool;
+    }
+
+    function stake() external payable whenNotPaused {
+        _credit(msg.sender, msg.value);
+        emit Staked(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 amount) external whenNotPaused {
+        require(balances[msg.sender] >= amount, "insufficient");
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+        (bool ok, ) = msg.sender.call{value: amount}("");
+        require(ok, "transfer failed");
+        emit Withdrawn(msg.sender, amount);
+    }
+
+    function sweep(address to, uint256 amount) external onlyOwner {
+        (bool ok, ) = to.call{value: amount}("");
+        require(ok, "sweep failed");
+    }
+
+    function rebalance(bytes calldata data) external {
+        require(keepers[msg.sender] || msg.sender == owner, "not authorised");
+        IPool(pool).swap(address(this), int256(totalStaked), data);
+    }
+
+    function uniswapV3SwapCallback(
+        int256 amount0Delta,
+        int256 amount1Delta,
+        bytes calldata
+    ) external {
+        require(msg.sender == pool, "not pool");
+        totalStaked = uint256(amount0Delta > 0 ? amount0Delta : amount1Delta);
+    }
+
+    function previewWithdraw(address user, uint256 amount)
+        external
+        view
+        returns (uint256)
+    {
+        uint256 bal = balances[user];
+        return amount > bal ? bal : amount;
+    }
+
+    function quoteFee(uint256 amount) external pure returns (uint256) {
+        return amount / 1000;
+    }
+
+    function _credit(address user, uint256 amount) internal {
+        balances[user] += amount;
+        totalStaked += amount;
+    }
+
+    receive() external payable {
+        _credit(msg.sender, msg.value);
+    }
+
+    fallback() external payable {
+        revert("unsupported call");
+    }
+}

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/access-classified.md
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/access-classified.md
@@ -1,0 +1,34 @@
+---
+type: llm
+weight: 1
+---
+
+The question asked who may call each entry point, so the report has to group by access level rather
+than hand back one flat list.
+
+Pass only if all four of the following hold:
+
+- `stake` and `withdraw` are presented as callable by anyone, with no restriction claimed;
+- `uniswapV3SwapCallback` is presented as reachable only by the pool, on the strength of its
+  require on `msg.sender` against the stored `pool` address. Calling this contract-only, pool-only,
+  or an integration point with the named expected caller all count;
+- `pause` is separated from the owner-gated functions by its `onlyKeeper` modifier. It is enough
+  that the report shows a keeper may call it and does not describe it as owner-only;
+- `transferOwnership`, `setKeeper`, `unpause` and `sweep` are all shown as owner-restricted.
+
+`rebalance` checks the `keepers` mapping or the `owner` inline rather than through a modifier, so
+keeper-or-owner, role-restricted and restricted pending review are all acceptable for it. Only
+calling it unrestricted fails.
+
+These fail it:
+
+- one undifferentiated list of entry points, with no access level attached;
+- `stake` or `withdraw` called restricted on the strength of `whenNotPaused`, which is a state
+  check and not access control;
+- `uniswapV3SwapCallback` treated as callable by anyone, or the `msg.sender == pool` check left
+  out of the statement of who can call it;
+- `pause` collapsed into the owner-only group;
+- `rebalance` claimed to be unrestricted.
+
+Naming a role the fixture does not use, for example calling the owner a governance or admin role,
+is fine so long as the grouping is right.

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/inherited-entry-points.md
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/inherited-entry-points.md
@@ -1,0 +1,26 @@
+---
+type: llm
+weight: 1
+---
+
+Four of StakingVault's entry points are not written in StakingVault.sol. `transferOwnership` and
+`setKeeper` are declared in `AccessBase`, and `pause` and `unpause` in `Pausable`. They reach the
+deployed surface through `contract StakingVault is Pausable` and `abstract contract Pausable is
+AccessBase`. Reading only the file named after the contract loses all four.
+
+Pass only if the report presents all four of `transferOwnership`, `setKeeper`, `pause` and
+`unpause` as entry points of StakingVault. Naming the declaring contract or file next to them is
+good practice but is not required to pass, and neither is any particular table layout.
+
+Fail if the response:
+
+- omits any of the four;
+- lists them only as members of `AccessBase` or `Pausable` while presenting StakingVault's own
+  surface as `stake`, `withdraw`, `sweep`, `rebalance` and the callback alone, so that a reader
+  scoping the audit would not know the four are reachable on the deployed contract;
+- states that StakingVault has no inherited entry points, or that the base contracts are out of
+  scope, without having listed the four somewhere as reachable;
+- mentions `AccessBase` or `Pausable` only as names in an inheritance diagram.
+
+Nothing here depends on the count being stated as eleven. A report that lists all four and never
+totals anything passes this grader.

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/read-only-members-excluded.md
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/read-only-members-excluded.md
@@ -1,0 +1,28 @@
+---
+type: llm
+weight: 1
+---
+
+Nine ABI members of StakingVault cannot change state and must not be presented as attack
+surface: the compiler-generated getters for the public
+variables `owner`, `keepers`, `paused`, `balances`, `totalStaked` and `pool`; the `view` functions
+`previewWithdraw` and `pauseStatus`; and the `pure` function `quoteFee`. The skill's own scope
+section excludes `view` and `pure`.
+
+None of those nine may appear in the report as a state-changing entry point. Elsewhere they can be
+named freely. An explicit "excluded, read-only" list, a note that `previewWithdraw` is a view
+helper, and a sentence explaining that public variables generate getters are all correct
+behaviour, and must not be counted against the response.
+
+The internal functions `_credit` and `_requireOwner`, and the constructor, are likewise not entry
+points. Listing any of them as externally reachable also fails.
+
+Fail if the response:
+
+- puts any of the six getters, `previewWithdraw`, `pauseStatus` or `quoteFee` in a table or list of
+  entry points, including a table of read-only entry points presented as part of the attack surface;
+- lists `_credit`, `_requireOwner` or the constructor as externally callable;
+- gives a total entry point count that can only be reached by including read-only members.
+
+A response that lists exactly the state-changing set and says nothing at all about the read-only
+members passes. Silence is not over-reporting.

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/skill-fired.md
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/skill-fired.md
@@ -1,0 +1,6 @@
+---
+type: tool_used
+tool: Skill
+input_match: entry-point-analyzer
+min: 1
+---

--- a/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/unnamed-entry-points.md
+++ b/plugins/entry-point-analyzer/evals/inherited-and-unnamed/graders/unnamed-entry-points.md
@@ -1,0 +1,22 @@
+---
+type: llm
+weight: 1
+---
+
+`receive()` credits the sender through `_credit`, so a bare value transfer to the vault changes
+`balances` and `totalStaked` without any named function being called. It carries no name, so a
+search for `function ` in the source does not return it.
+
+`receive` has to appear in the surface being mapped, as a state-changing entry point anyone can
+reach. Wording is free: "receive()", "the receive function", "plain ETH transfers" and "sending
+value with empty calldata" all count. Naming it only in prose about the contract does not.
+
+`fallback()` is not scored. It is externally reachable and payable but its body reverts, so
+listing it, omitting it, or noting that it always reverts are all acceptable.
+
+Four ways to fail it:
+
+- `receive` omitted from the entry point list;
+- `receive` shown only inside a code excerpt or a file description, never as reachable surface;
+- the vault claimed to be fundable only through `stake`;
+- `receive` treated as read-only, or excluded because it has no name.

--- a/plugins/entry-point-analyzer/evals/no-state-changing-surface/case.yaml
+++ b/plugins/entry-point-analyzer/evals/no-state-changing-surface/case.yaml
@@ -1,0 +1,29 @@
+schema_version: "1.1"
+name: no-state-changing-surface
+description: >
+  FeeQuoter has no state-changing entry points. Its ABI holds eight members and every one is view
+  or pure. It does not look inert: the constructor writes tierOf in a loop, the mapping stays in
+  storage, and quote and quoteBatch read it. The report has to say the surface is empty rather
+  than list what it found.
+tags: [solidity, negative, precision]
+
+context:
+  add_dirs: [fixture]
+
+execution:
+  prompt: |
+    FeeQuoter in the fixture directory is going into the same audit as the router.
+
+    Give me its entry points and who can call them, so I know how much of the review budget this
+    one needs.
+  max_turns: 30
+  timeout_seconds: 900
+  allowed_tools: [Read, Glob, Grep, Skill, Task]
+
+runs: 3
+
+expected_outcome: >
+  The report states plainly that FeeQuoter has no state-changing entry points, so there is nothing
+  to map as attack surface. It does not present quote, quoteBatch, isRouter, bpsToWad or the
+  immutable and mapping getters as entry points, and it does not present the constructor's write to
+  tierOf as one either.

--- a/plugins/entry-point-analyzer/evals/no-state-changing-surface/fixture/FeeQuoter.sol
+++ b/plugins/entry-point-analyzer/evals/no-state-changing-surface/fixture/FeeQuoter.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/// @notice Quotes the fee charged on a swap, by user tier.
+contract FeeQuoter {
+    uint256 public immutable baseFeeBps;
+    uint256 public immutable maxFeeBps;
+    address public immutable router;
+
+    mapping(address => uint256) public tierOf;
+
+    constructor(uint256 _baseFeeBps, uint256 _maxFeeBps, address _router, address[] memory tier1) {
+        require(_baseFeeBps <= _maxFeeBps, "base above max");
+        baseFeeBps = _baseFeeBps;
+        maxFeeBps = _maxFeeBps;
+        router = _router;
+        for (uint256 i = 0; i < tier1.length; i++) {
+            tierOf[tier1[i]] = 1;
+        }
+    }
+
+    function quote(address user, uint256 amount) public view returns (uint256) {
+        uint256 bps = baseFeeBps;
+        if (tierOf[user] == 1) {
+            bps = bps / 2;
+        }
+        if (bps > maxFeeBps) {
+            bps = maxFeeBps;
+        }
+        return (amount * bps) / 10_000;
+    }
+
+    function quoteBatch(address user, uint256[] calldata amounts)
+        external
+        view
+        returns (uint256 total)
+    {
+        for (uint256 i = 0; i < amounts.length; i++) {
+            total += quote(user, amounts[i]);
+        }
+    }
+
+    function isRouter(address who) external view returns (bool) {
+        return who == router;
+    }
+
+    function bpsToWad(uint256 bps) external pure returns (uint256) {
+        return (bps * 1e18) / 10_000;
+    }
+
+    function _clamp(uint256 v, uint256 hi) internal pure returns (uint256) {
+        return v > hi ? hi : v;
+    }
+}

--- a/plugins/entry-point-analyzer/evals/no-state-changing-surface/graders/no-invented-entry-points.md
+++ b/plugins/entry-point-analyzer/evals/no-state-changing-surface/graders/no-invented-entry-points.md
@@ -1,0 +1,22 @@
+---
+type: llm
+weight: 1
+---
+
+The eight ABI members are `quote`, `quoteBatch`, `isRouter`, `bpsToWad` and the generated getters
+`baseFeeBps`, `maxFeeBps`, `router` and `tierOf`. All are `view` or `pure`. `_clamp` is internal
+and the constructor is not reachable after deployment.
+
+None of them may be presented as a state-changing entry point. Naming them as read-only, listing
+them under an explicit exclusions heading, or explaining that `tierOf` is written once in the
+constructor and never again are all correct and must not be counted against the response.
+
+Fail if the response:
+
+- lists any of the eight in a table or list of entry points, including one headed "read-only entry
+  points" or "view entry points" and presented as part of the attack surface;
+- lists `_clamp` or the constructor as externally callable;
+- calls `quoteBatch` state-changing because it accumulates into `total`, which is a local variable;
+- calls `quote` state-changing because it reads the `tierOf` mapping.
+
+Saying nothing at all is not scored here. That is `states-surface-is-empty`.

--- a/plugins/entry-point-analyzer/evals/no-state-changing-surface/graders/skill-fired.md
+++ b/plugins/entry-point-analyzer/evals/no-state-changing-surface/graders/skill-fired.md
@@ -1,0 +1,6 @@
+---
+type: tool_used
+tool: Skill
+input_match: entry-point-analyzer
+min: 1
+---

--- a/plugins/entry-point-analyzer/evals/no-state-changing-surface/graders/states-surface-is-empty.md
+++ b/plugins/entry-point-analyzer/evals/no-state-changing-surface/graders/states-surface-is-empty.md
@@ -1,0 +1,27 @@
+---
+type: llm
+weight: 1
+---
+
+Every one of FeeQuoter's eight ABI members is `view` or `pure`, so the state-changing entry point
+set is empty.
+
+Pass only if the response commits to that conclusion in words a reader scoping an audit would act
+on: that FeeQuoter has no state-changing entry points, that its post-deployment attack surface is
+empty, that there is nothing here to map, or that it needs little or no review budget because
+nothing external can write its storage. A count stated as zero counts. Recommending the contract
+still be read for correctness of its arithmetic is fine and does not affect this grader.
+
+Fail if the response:
+
+- never states the conclusion, and instead only describes what the functions do, so a reader is
+  left to infer the surface is empty from the absence of a list;
+- hedges the conclusion away, for example by saying the surface is "mostly" or "largely" read-only,
+  or that it "appears" to have no entry points, without ever committing;
+- reports entry points that do not exist;
+- treats the constructor's write to `tierOf` as evidence that the deployed contract has a
+  state-changing surface;
+- declines to answer, or asks for the router before saying anything about FeeQuoter.
+
+Silence fails this grader. A response that lists nothing and concludes nothing has not done the
+work, and would be indistinguishable from a run that never read the file.


### PR DESCRIPTION
`entry-point-analyzer` had no evals. Two Solidity cases.

Ground truth is the solc ABI rather than my reading of the source: an entry point is an ABI member that is neither `view` nor `pure`. That caught a fixture of mine that did not compile, and it is what the counts below come from.

**`inherited-and-unnamed`** covers the entry points that are not in the file named after the contract. Four of the eleven on `StakingVault` are declared in `AccessBase` and `Pausable`, and `receive()` has no name to grep for. Against those, six of the nine read-only members are compiler-generated getters, which read like functions in a report but cannot change state. Four scored graders: the inherited four, `receive`, the read-only exclusions, and the access classification. `fallback()` reverts, so it is outside every gate.

**`no-state-changing-surface`** is the control. `FeeQuoter` has none, though the constructor writes `tierOf` in a loop and two view functions read it back. Its two graders fail on opposite mistakes, one on padding the report with read-only members and one on never stating the conclusion, so neither is satisfied by an empty answer.

`case.yaml` rather than `prompt.md` because the fixtures span three files and `context.add_dirs` is how `audit-context-building` and `spec-to-code-compliance` already do that. Version 1.0.1 to 1.1.0 in both places.

## What I have not done

**No ablation.** I have not run these against a judge, with or without the plugin, so I cannot tell you the suite detects a broken skill. After reading #229 I think that is the bar, and this does not clear it yet. Ground truth is verified by the compiler and the rubrics are checked by hand, which is a different and weaker claim. Happy to run it if you can point me at how you produce the numbers in #229, or to hold this until I can.

One thing worth flagging either way: the skill routes on a description that says smart contracts, and these prompts are phrased as an auditor scoping work rather than as a request for entry point analysis. Both cases carry a display-only `skill-fired` grader so the trigger rate is visible.

`make self-test`, `make lint` and `make validate` pass. Note that `validate_reference_links` skips any path with `evals` in it, so validate does not actually cover this directory. `make python-tests` fails the same way on a clean checkout, in `constant-time-analysis`.

Written with Claude Code, reviewed and verified by me.
