### PR TITLE
Pin the node test reporter in semgrep-rule-variant-creator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -156,7 +156,7 @@
     },
     {
       "name": "semgrep-rule-variant-creator",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Creates language variants of existing Semgrep rules with proper applicability analysis and test-driven validation",
       "author": {
         "name": "Maciej Domanski",

--- a/plugins/semgrep-rule-variant-creator/.claude-plugin/plugin.json
+++ b/plugins/semgrep-rule-variant-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semgrep-rule-variant-creator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Creates language variants of existing Semgrep rules with proper applicability analysis and test-driven validation",
   "author": {
     "name": "Maciej Domanski",

--- a/plugins/semgrep-rule-variant-creator/tests/test_workflow_contract.py
+++ b/plugins/semgrep-rule-variant-creator/tests/test_workflow_contract.py
@@ -26,6 +26,11 @@ WORKFLOW = PLUGIN_ROOT / "workflows" / "port-rule-to-languages.js"
 FAILURE_PATH_SUITE = TESTS_DIR / "workflow-failure-paths.test.mjs"
 NODE_SUITES = (TESTS_DIR / "workflow-functions.test.mjs", FAILURE_PATH_SUITE)
 
+# Floor for how many tests a node suite must report having run. Well below the 26 and 38
+# the two suites run today, so ordinary churn does not trip it, and well above the 1 that
+# node reports for a file containing no tests at all.
+MIN_NODE_SUITE_TESTS = 10
+
 SCRIPT = WORKFLOW.read_text(encoding="utf-8")
 
 AGENT_CALL_RE = re.compile(r"\bagent\(")
@@ -416,7 +421,12 @@ def node_test(suite: Path, script: Path | None = None) -> tuple[int, str]:
     if script:
         env["WORKFLOW_SCRIPT"] = str(script)
     completed = subprocess.run(
-        ["node", "--test", str(suite)],
+        # The reporter is pinned because callers below read `# pass N` out of this
+        # output. Node's default is version-dependent and not a TTY-independent
+        # contract: node 22 defaults to tap when stdout is not a terminal, node 23+
+        # defaults to spec, which prints `ℹ pass N` instead. Left unpinned, every
+        # assertion on that text fails on a newer node while CI stays green.
+        ["node", "--test", "--test-reporter=tap", str(suite)],
         capture_output=True,
         text=True,
         check=False,
@@ -433,7 +443,18 @@ def test_node_suites_pass(suite: Path) -> None:
     assert suite.is_file(), f"missing node suite at {suite}"
     code, output = node_test(suite)
     assert code == 0, f"node --test failed:\n{output}"
-    assert "# fail 0" in output, f"node --test reported failures:\n{output}"
+
+    # `# fail 0` only restated the exit code. What it could not see is a suite that
+    # stopped running its tests and passed anyway. Node makes that harder to detect
+    # than it looks: a file containing NO tests still reports `# tests 1 # pass 1`,
+    # counting the file itself, which is indistinguishable from a file holding one
+    # test. So a floor, not a non-zero check. These two suites run 26 and 38.
+    passed = re.search(r"^# pass (\d+)", output, re.MULTILINE)
+    assert passed, f"no TAP summary in output; did the reporter change?\n{output}"
+    assert int(passed.group(1)) >= MIN_NODE_SUITE_TESTS, (
+        f"{suite.name} ran only {passed.group(1)} tests, below the floor of "
+        f"{MIN_NODE_SUITE_TESTS} — the suite is not running what it used to:\n{output}"
+    )
 
 
 # Each mutation breaks one failure-handling behaviour the node suite claims to cover.


### PR DESCRIPTION
`make check` fails 28 tests on any current Node while CI stays green. The suites are fine; the harness reads reporter-specific text.

## The bug

`node_test()` invoked `node --test` with no `--test-reporter`, then asserted on `# fail 0` and `# pass N`. Those are **TAP** markers, and node's default reporter is not a stable contract:

- node 22 (what `lint.yml` pins) defaults to `tap` when stdout is not a TTY
- node 23+ defaults to `spec`, which prints `ℹ pass N` instead

So every assertion that scrapes that text fails locally on node 23+ and passes in CI. Running the suites directly has always reported 38/38.

Fix is `--test-reporter=tap`. Verified load-bearing by reverting just that flag: **28 failed, 54 passed** — exactly the reported symptom — and **82 passed, 2 skipped** with it in place.

## Second change: a guard that was not guarding

`test_node_suites_pass` asserted:

```python
assert code == 0
assert "# fail 0" in output
```

The second line only restates the first. Neither notices the failure that matters here: a suite that stopped running its tests and passed anyway.

Node makes that case less obvious than expected. A `.mjs` file containing **no tests at all** still reports `# tests 1 # pass 1`, counting the file itself, which is indistinguishable from a file holding exactly one test. So a `# pass [1-9]` check would not have caught an empty suite either — I wrote that first and the probe disproved it.

Replaced with a floor on the parsed pass count (`MIN_NODE_SUITE_TESTS = 10`), set well below the 26 and 38 these suites run so ordinary churn does not trip it, and well above the 1 that node reports for an empty file. Verified against a gutted suite: reports 1, fails as intended.

## Scope

A repo-wide sweep found no other place with this coupling. The other `# pass` / `# fail` matches in the repo are prose comments in shell and Python, not TAP parsing.

Version bumped 1.1.0 → 1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)