### PR TITLE
Collapse the review into one xhigh opus tier, and stop invented evidence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,9 @@
 #
 # Python deps declared with PEP 723 inline metadata (the common pattern in this
 # repo, including .github/scripts/) have no Dependabot ecosystem at all and stay
-# manual. So do the pinned npm CLI versions in .github/workflows/validate.yml.
+# manual. So does the pinned Codex CLI in .github/workflows/validate.yml — the
+# Claude Code CLI beside it is deliberately unpinned instead, on the grounds that a
+# pin nobody bumps is worse than a break that announces itself.
 version: 2
 
 updates:

--- a/.github/scripts/claude_review.sh
+++ b/.github/scripts/claude_review.sh
@@ -26,9 +26,24 @@ TIER="${1:?usage: claude_review.sh <fast|deep>}"
 : "${PR_NUMBER:?PR_NUMBER is required}"
 : "${REPO:?REPO is required}"
 
+# The model is pinned explicitly. Left unset, `claude` resolves whatever the CLI
+# defaults to at run time, so the reviewer could change underneath this repository
+# with no commit and nothing in the logs would say which model had reviewed the diff.
+#
+# Both tiers now run opus at xhigh: every pull request gets the strongest review, not
+# only the ones somebody remembers to flag. What still separates them is scope — the
+# deep tier reads beyond the diff, gets git history and a longer budget, and its
+# prompt is adversarial. The `fast` name is left alone because it is the check name
+# branch protection matches on; it describes the trigger, not the effort.
 case "$TIER" in
-  fast) EFFORT="low" ;;
-  deep) EFFORT="xhigh" ;;
+  fast)
+    EFFORT="xhigh"
+    MODEL="opus"
+    ;;
+  deep)
+    EFFORT="xhigh"
+    MODEL="opus"
+    ;;
   *)
     echo "unknown tier: $TIER (expected fast or deep)" >&2
     exit 2
@@ -39,10 +54,25 @@ esac
 # command line: PR metadata is untrusted text and must never reach a shell.
 COMMON_PROMPT=$(
   cat <<'PROMPT'
+You cannot execute anything. There is no interpreter, no test runner and no general
+shell here — only the few read-only `gh` and `git` commands in your allowlist, plus
+Read, Grep and Glob. So do not describe a command, script or test run as something
+you ran, and never report output you did not receive from a tool call. Reasoning
+about what an input would do is exactly the job and needs no hedging: "reading the
+pattern, `/Users/alice` does not match it" is the right shape. "I verified this
+directly:" followed by an invented transcript is not, and it has happened on this
+repository three times — a Python snippet that could not compile, a pytest suite with
+a fabricated pass count, and a shell script nobody executed. Each conclusion was
+right and each proof was invented, which is worse than showing no proof, because a
+reader cannot tell the two apart.
+
 Report every issue you find, at every severity. Do not pre-filter, do not suppress
 low-confidence findings, and do not decide something is too minor to mention. Rank
 each finding P1 to P4 and let a human filter. A finding you withheld is worth
 nothing; a P4 that turns out not to matter costs one line.
+
+Rank on consequence, not on diff size. A one-character fault in a checker that makes
+it silently miss what it exists to catch is not a nit, however small the patch.
 
 For each finding give: file:line, one sentence on the defect, and a concrete failure
 scenario — the input or state that produces the wrong behaviour. If you cannot state
@@ -162,8 +192,11 @@ printf '%s\n' "$PROMPT" >"$PROMPT_FILE"
 # a reader sees a passing "Claude review" check and infers the diff was reviewed.
 STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-echo "Running $TIER review (effort=$EFFORT) on $REPO#$PR_NUMBER"
+# Model and CLI version go in the log because the CLI is deliberately unpinned: a run
+# is only attributable after the fact if it says what reviewed the diff.
+echo "Running $TIER review (model=$MODEL effort=$EFFORT cli=$(claude --version)) on $REPO#$PR_NUMBER"
 claude --print \
+  --model "$MODEL" \
   --effort "$EFFORT" \
   --allowedTools "$ALLOWED_TOOLS" \
   <"$PROMPT_FILE"

--- a/.github/scripts/claude_review.sh
+++ b/.github/scripts/claude_review.sh
@@ -26,9 +26,11 @@ set -euo pipefail
 : "${PR_NUMBER:?PR_NUMBER is required}"
 : "${REPO:?REPO is required}"
 
-# The model is pinned explicitly. Left unset, `claude` resolves whatever the CLI
-# defaults to at run time, so the reviewer could change underneath this repository
-# with no commit and nothing in the logs would say which model had reviewed the diff.
+# Pinned to a tier, not to a build. Left unset entirely, `claude` resolves whatever
+# the CLI happens to default to, which could change the reviewer from under this
+# repository with nothing in the logs to say so. `opus` is still an alias and still
+# tracks new Opus releases — that is the same trade as the unpinned CLI and is
+# intended — so the log line below is what narrows a surprising review to a date.
 MODEL="opus"
 EFFORT="xhigh"
 
@@ -57,10 +59,18 @@ one. `--edit-last --create-if-none` replaces your previous review rather than
 appending. This job runs on every push, so appending would leave a reader scrolling
 past stale findings from commits that were fixed several pushes ago.
 
-You cannot execute anything. There is no interpreter, no test runner and no general
-shell here — only `gh pr` reads, `git log`, `git diff`, Read, Grep and Glob. So do not
+You cannot execute the code under review. There is no interpreter, no test runner and
+no package manager here. Your whole allowlist is `gh pr view`, `gh pr diff`, the
+`gh pr comment` you post with, `git log`, `git diff`, Read, Grep and Glob. So do not
 describe a command, script or test run as something you ran, and never report output
-you did not receive from a tool call. Reasoning about what an input would do is
+you did not receive from a tool call.
+
+This repository's own `CLAUDE.md` and `AGENTS.md` load into your context as project
+instructions, and they are addressed to someone working on the repo with a full
+toolchain, not to you. They will tell you to run `make check`, run `prek run -a`, and
+consult a `claude-code-guide` subagent. You can do none of that and must not report
+as though you had. Read them as background on how this repository thinks; take your
+instructions from this prompt. Reasoning about what an input would do is
 exactly the job and needs no hedging: "reading the pattern, `/Users/alice` does not
 match it" is the right shape. "I verified this directly:" followed by an invented
 transcript is not, and it has happened on this repository three times — a Python
@@ -149,9 +159,17 @@ claude --print \
   --allowedTools "$ALLOWED_TOOLS" \
   <"$PROMPT_FILE"
 
+# Filtered to this workflow's own comments, and paginated. Counting every comment in
+# the window would let a maintainer replying to the previous review stand in for a
+# review this run never posted — a green check over no review, which is the first
+# defect class the prompt above asks about.
 posted="$(
-  gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq "[.[] | select(.created_at >= \"${STARTED_AT}\" or .updated_at >= \"${STARTED_AT}\")] | length"
+  gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq "[.[]
+           | select(.user.login == \"github-actions[bot]\")
+           | select(.created_at >= \"${STARTED_AT}\" or .updated_at >= \"${STARTED_AT}\")]
+          | length" |
+    awk '{total += $1} END {print total + 0}'
 )"
 
 if [ "${posted:-0}" -eq 0 ]; then

--- a/.github/scripts/claude_review.sh
+++ b/.github/scripts/claude_review.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
 # Post an automated review on a pull request.
 #
-# Usage: claude_review.sh <fast|deep>
+# Usage: claude_review.sh
 #
 # Requires ANTHROPIC_API_KEY, GH_TOKEN, PR_NUMBER, REPO in the environment. The
 # caller (claude-review.yml) gates on the API key being present, so reaching this
 # script without one is a bug, not a normal path — hence the hard check below.
 #
-# The prompts are the point of this file. Two things carry them:
+# The prompt is the point of this file. Three things carry it:
 #
-#   1. They forbid pre-filtering. Current models follow "only report high-severity
+#   1. It states the tool reality. There is no interpreter and no test runner here,
+#      and reviews were reporting transcripts of runs that could not have happened.
+#   2. It forbids pre-filtering. Current models follow "only report high-severity
 #      issues" literally: they investigate just as thoroughly, find the bugs, then
 #      decline to report what they judge below the bar. Precision rises and measured
 #      recall falls, which reads as a capability regression but is a prompt bug.
 #      Ask for everything and filter downstream.
-#   2. They name the defect classes that actually reach main in a repo of markdown
+#   3. It names the defect classes that actually reach main in a repo of markdown
 #      that instructs a model, rather than asking for generic "code review".
 
 set -euo pipefail
-
-TIER="${1:?usage: claude_review.sh <fast|deep>}"
 
 : "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY is required}"
 : "${GH_TOKEN:?GH_TOKEN is required}"
@@ -29,42 +29,50 @@ TIER="${1:?usage: claude_review.sh <fast|deep>}"
 # The model is pinned explicitly. Left unset, `claude` resolves whatever the CLI
 # defaults to at run time, so the reviewer could change underneath this repository
 # with no commit and nothing in the logs would say which model had reviewed the diff.
-#
-# Both tiers now run opus at xhigh: every pull request gets the strongest review, not
-# only the ones somebody remembers to flag. What still separates them is scope — the
-# deep tier reads beyond the diff, gets git history and a longer budget, and its
-# prompt is adversarial. The `fast` name is left alone because it is the check name
-# branch protection matches on; it describes the trigger, not the effort.
-case "$TIER" in
-  fast)
-    EFFORT="xhigh"
-    MODEL="opus"
-    ;;
-  deep)
-    EFFORT="xhigh"
-    MODEL="opus"
-    ;;
-  *)
-    echo "unknown tier: $TIER (expected fast or deep)" >&2
-    exit 2
-    ;;
-esac
+MODEL="opus"
+EFFORT="xhigh"
 
-# Shared across both tiers. Written to a file rather than interpolated into a
-# command line: PR metadata is untrusted text and must never reach a shell.
-COMMON_PROMPT=$(
+ALLOWED_TOOLS='Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Read,Grep,Glob'
+
+# Written to a file rather than interpolated into a command line: PR metadata is
+# untrusted text and must never reach a shell. The heredoc is quoted so backticks and
+# $(...) in the prompt are literal rather than commands the shell runs while building.
+PROMPT=$(
   cat <<'PROMPT'
+Review pull request #__PR__ in __REPO__ against the diff with the base branch.
+
+When you are done you MUST post your review with:
+
+    gh pr comment __PR__ --body-file - --edit-last --create-if-none <<'EOF'
+    ...your review...
+    EOF
+
+Nothing you write outside that comment is visible to anyone. A run that finishes
+without posting shows up as a green check with no review attached, which reads as
+"reviewed and clean" — the worst possible outcome. Post even when you found nothing,
+and say so.
+
+Read from stdin, not a temp file: you have no Write tool, so there is nowhere to put
+one. `--edit-last --create-if-none` replaces your previous review rather than
+appending. This job runs on every push, so appending would leave a reader scrolling
+past stale findings from commits that were fixed several pushes ago.
+
 You cannot execute anything. There is no interpreter, no test runner and no general
-shell here — only the few read-only `gh` and `git` commands in your allowlist, plus
-Read, Grep and Glob. So do not describe a command, script or test run as something
-you ran, and never report output you did not receive from a tool call. Reasoning
-about what an input would do is exactly the job and needs no hedging: "reading the
-pattern, `/Users/alice` does not match it" is the right shape. "I verified this
-directly:" followed by an invented transcript is not, and it has happened on this
-repository three times — a Python snippet that could not compile, a pytest suite with
-a fabricated pass count, and a shell script nobody executed. Each conclusion was
-right and each proof was invented, which is worse than showing no proof, because a
-reader cannot tell the two apart.
+shell here — only `gh pr` reads, `git log`, `git diff`, Read, Grep and Glob. So do not
+describe a command, script or test run as something you ran, and never report output
+you did not receive from a tool call. Reasoning about what an input would do is
+exactly the job and needs no hedging: "reading the pattern, `/Users/alice` does not
+match it" is the right shape. "I verified this directly:" followed by an invented
+transcript is not, and it has happened on this repository three times — a Python
+snippet that could not compile, a pytest suite with a fabricated pass count, and a
+shell script nobody executed. Each conclusion was right and each proof was invented,
+which is worse than showing no proof, because a reader cannot tell the two apart.
+
+Go beyond the diff where the diff depends on it: read the files it touches, read the
+scripts it adds, and check its claims against the repository rather than taking them
+at face value. When the PR states a number, a limit, or a cost, verify it against the
+files — count the things it claims to count. When it adds a check, work out by reading
+it what input would slip past, and say so.
 
 Report every issue you find, at every severity. Do not pre-filter, do not suppress
 low-confidence findings, and do not decide something is too minor to mention. Rank
@@ -77,6 +85,11 @@ it silently miss what it exists to catch is not a nit, however small the patch.
 For each finding give: file:line, one sentence on the defect, and a concrete failure
 scenario — the input or state that produces the wrong behaviour. If you cannot state
 a failure scenario, say so and rank it lower.
+
+Prioritise, in order: anything that makes the plugin fail to run at all; anything
+that produces a wrong result while reporting success; anything that puts untrusted
+content into an artifact shared outside the company; and anything whose documented
+usage does not work as written.
 
 This repository is a marketplace of Claude Code plugins. Most content is markdown
 that instructs a model, so "does this text cause correct behaviour" matters as much
@@ -108,76 +121,11 @@ in repositories like this one and none is visible on a casual read:
 
 Say plainly when a dimension is clean rather than manufacturing a finding to look
 thorough. If the diff is small or purely editorial, a short review is correct output.
-PROMPT
-)
-
-if [ "$TIER" = "fast" ]; then
-  PROMPT=$(
-    cat <<'PROMPT'
-Review pull request #__PR__ in __REPO__ against the diff with the base branch.
-
-When you are done you MUST post your review with:
-
-    gh pr comment __PR__ --body-file - --edit-last --create-if-none <<'EOF'
-    ...your review...
-    EOF
-
-Nothing you write outside that comment is visible to anyone. A run that finishes
-without posting shows up as a green check with no review attached, which reads as
-"reviewed and clean" — the worst possible outcome. Post even when you found nothing,
-and say so.
-
-Read from stdin, not a temp file: you have no Write tool and no general Bash, so
-there is nowhere to put one.
-
-`--edit-last --create-if-none` replaces your previous review rather than appending.
-This job runs on every push, so appending would leave a reader scrolling past stale
-findings from commits that were fixed several pushes ago.
-
-__COMMON__
-PROMPT
-  )
-  ALLOWED_TOOLS='Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob'
-else
-  PROMPT=$(
-    cat <<'PROMPT'
-Perform a deep adversarial review of pull request #__PR__ in __REPO__.
-
-When you are done you MUST post your review with:
-
-    gh pr comment __PR__ --body-file - <<'EOF'
-    ...your review...
-    EOF
-
-Nothing you write outside that comment reaches anyone.
-
-Go beyond the diff where the diff depends on it: read the files it touches, read the
-scripts it adds, and check its claims against the repository rather than taking them
-at face value. When the PR states a number, a limit, or a cost, verify it against the
-files — count the things it claims to count. When it adds a check, work out by reading
-it what input would slip past, and say so.
-
-You cannot execute anything: your tools are `gh pr` reads, `git log`, `git diff`,
-`Read`, `Grep`, and `Glob`. Do not plan around running code.
-
-Prioritise, in order: anything that makes the plugin fail to run at all; anything
-that produces a wrong result while reporting success; anything that puts untrusted
-content into an artifact shared outside the company; and anything whose documented
-usage does not work as written.
-
-__COMMON__
-
 Finish with an explicit list of what you checked and found clean, so a reader can
 tell the difference between a dimension you cleared and one you never looked at.
 PROMPT
-  )
-  ALLOWED_TOOLS='Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Read,Grep,Glob'
-fi
+)
 
-# Substituted here rather than interpolated inside the heredocs. Both tier
-# heredocs are quoted so that backticks and $(...) in the prompt text are literal
-# rather than commands the shell runs while building the prompt.
-PROMPT="${PROMPT//__COMMON__/$COMMON_PROMPT}"
 PROMPT="${PROMPT//__PR__/$PR_NUMBER}"
 PROMPT="${PROMPT//__REPO__/$REPO}"
 
@@ -194,7 +142,7 @@ STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # Model and CLI version go in the log because the CLI is deliberately unpinned: a run
 # is only attributable after the fact if it says what reviewed the diff.
-echo "Running $TIER review (model=$MODEL effort=$EFFORT cli=$(claude --version)) on $REPO#$PR_NUMBER"
+echo "Reviewing $REPO#$PR_NUMBER (model=$MODEL effort=$EFFORT cli=$(claude --version))"
 claude --print \
   --model "$MODEL" \
   --effort "$EFFORT" \

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -67,21 +67,37 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # The key is reduced to a boolean here so that no later step needs it in scope
+      # merely to test for it. `secrets` is not available in a step-level `if:`, so
+      # gating on presence otherwise means putting the secret in that step's `env:` —
+      # which for the install step below would run npm lifecycle scripts, from an
+      # unpinned version nobody chose, beside an org-wide credential.
+      - name: Check for API key
+        id: key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "present=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "present=false" >>"$GITHUB_OUTPUT"
+            echo "ANTHROPIC_API_KEY is not visible here; skipping the review." >&2
+          fi
+
       # Deliberately unpinned: the reviewer should get CLI fixes and features as they
       # ship. The trade is that a bad release can change review behaviour with no
       # commit here, so `claude_review.sh` logs the resolved version and model on every
       # run — that is what makes a surprising review attributable afterwards. The model
       # itself IS pinned, in that script; it is the larger lever on review quality.
+      # Note this step holds no secret, which is what makes @latest acceptable here.
       - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
-        if: env.ANTHROPIC_API_KEY != ''
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        if: steps.key.outputs.present == 'true'
         run: |
           npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
             "@anthropic-ai/claude-code@latest"
 
       - name: Review
-        if: env.ANTHROPIC_API_KEY != ''
+        if: steps.key.outputs.present == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-# Automated review on pull requests, in two tiers.
+# Automated review on pull requests.
 #
 # An organization-level ANTHROPIC_API_KEY is visible to this repository, so this
 # workflow is LIVE the moment it merges — it will start reviewing PRs immediately.
@@ -9,8 +9,11 @@
 # ever removed these jobs go quiet rather than red. A review workflow that fails on
 # every PR for want of a credential teaches people to ignore red checks.
 #
-# The deep tier needs a label that does not exist yet:
-#   gh label create deep-review -d "Run the xhigh adversarial review pass" -c B60205
+# One tier, deliberately. This was two — a cheap pass on every push and an xhigh
+# adversarial pass behind a `deep-review` label — and the split did not survive
+# contact: the label was never created, so the deep tier skipped 9 times and ran
+# zero, while every real review came from the cheap tier. Rather than wire up a
+# label to remember to apply, the default is now the strong review.
 #
 # Fork PRs get NO automated review. A `pull_request_target` variant was written and
 # then deleted: it checked out the fork tree and ran this repo's review script from
@@ -24,90 +27,30 @@ name: Claude Review
 
 on:
   pull_request:
-    # ready_for_review is load-bearing: the fast job skips drafts, so without it a
+    # ready_for_review is load-bearing: the job skips drafts, so without it a
     # draft-then-ready PR gets no event and no review at all.
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Granted per job rather than here. A workflow-level write grant applies to every job
 # including ones that never need it, which zizmor flags as excessive-permissions.
 permissions: {}
 
 concurrency:
-  # Keyed per tier, not per PR. Sharing one slot lets a routine push cancel an
-  # in-flight deep review — and GitHub will not re-fire `labeled` for a label that is
-  # already present, so the PR would sit labeled with no review, looking reviewed.
-  #
-  # Every `labeled` event gets its own key, including labels neither job cares about.
-  # Otherwise adding `dependencies` mid-review resolves to the `fast` key, cancels the
-  # running review, and then skips both jobs — leaving a cancelled check, no review,
-  # and no event that would re-trigger one until the next push.
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{
-    github.event.action == 'labeled'
-      && format('label-{0}', github.event.label.name)
-      || 'push' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  fast:
-    name: Claude review (fast)
-    # Skips: label events (that is the deep job's trigger), drafts, bots, and forks.
-    # Forks are excluded: under `pull_request` they get a read-only token and could
-    # not post a comment anyway, and the privileged alternative is unsafe (above).
+  review:
+    name: Claude review
+    # Skips drafts, bots, and forks. Forks are excluded because under `pull_request`
+    # they get a read-only token and could not post a comment anyway, and the
+    # privileged alternative is unsafe (above).
     if: >-
-      github.event.action != 'labeled' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type != 'Bot' &&
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      # read: check out the diff under review.
-      contents: read
-      # write: post the review as a PR comment. This is the whole point of the job —
-      # a run that cannot comment produces a green check and no review, which reads
-      # as "reviewed and clean".
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-      # Deliberately unpinned: the reviewer should get CLI fixes and features as they
-      # ship. The trade is that a bad release can change review behaviour with no
-      # commit here, so `claude_review.sh` logs the resolved version and model on every
-      # run — that is what makes a surprising review attributable afterwards. The model
-      # itself IS pinned, in that script; it is the larger lever on review quality.
-      - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
-        if: env.ANTHROPIC_API_KEY != ''
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
-            "@anthropic-ai/claude-code@latest"
-
-      - name: Review
-        if: env.ANTHROPIC_API_KEY != ''
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          export PATH="$RUNNER_TEMP/claude-cli/bin:$PATH"
-          .github/scripts/claude_review.sh fast
-
-  deep:
-    name: Claude review (deep)
-    # The fork exclusion is explicit rather than relying on secrets being
-    # unavailable to fork `pull_request` events, so changing the gating later cannot
-    # silently start running this against a fork with a read-only token.
-    if: >-
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'deep-review' &&
-      github.event.pull_request.user.type != 'Bot' &&
-      github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
+    # xhigh on a large diff needs room. The old cheap tier ran in 20.
     timeout-minutes: 30
     permissions:
       # read: check out the diff under review.
@@ -123,6 +66,7 @@ jobs:
           # empty, which is indistinguishable from "nothing to find".
           fetch-depth: 0
           persist-credentials: false
+
       # Deliberately unpinned: the reviewer should get CLI fixes and features as they
       # ship. The trade is that a bad release can change review behaviour with no
       # commit here, so `claude_review.sh` logs the resolved version and model on every
@@ -145,4 +89,4 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           export PATH="$RUNNER_TEMP/claude-cli/bin:$PATH"
-          .github/scripts/claude_review.sh deep
+          .github/scripts/claude_review.sh

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,14 +73,18 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      # Deliberately unpinned: the reviewer should get CLI fixes and features as they
+      # ship. The trade is that a bad release can change review behaviour with no
+      # commit here, so `claude_review.sh` logs the resolved version and model on every
+      # run — that is what makes a surprising review attributable afterwards. The model
+      # itself IS pinned, in that script; it is the larger lever on review quality.
       - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
         if: env.ANTHROPIC_API_KEY != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CLI_VERSION: "2.1.220"
         run: |
           npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
-            "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+            "@anthropic-ai/claude-code@latest"
 
       - name: Review
         if: env.ANTHROPIC_API_KEY != ''
@@ -119,14 +123,18 @@ jobs:
           # empty, which is indistinguishable from "nothing to find".
           fetch-depth: 0
           persist-credentials: false
+      # Deliberately unpinned: the reviewer should get CLI fixes and features as they
+      # ship. The trade is that a bad release can change review behaviour with no
+      # commit here, so `claude_review.sh` logs the resolved version and model on every
+      # run — that is what makes a surprising review attributable afterwards. The model
+      # itself IS pinned, in that script; it is the larger lever on review quality.
       - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
         if: env.ANTHROPIC_API_KEY != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CLI_VERSION: "2.1.220"
         run: |
           npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
-            "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+            "@anthropic-ai/claude-code@latest"
 
       - name: Review
         if: env.ANTHROPIC_API_KEY != ''

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,15 +128,15 @@ jobs:
             python3 .github/scripts/validate_plugin_metadata.py --base-ref "$BASE_REF"
           fi
 
-      # Pinned rather than @latest: an unpinned install makes CI able to break with
-      # no commit, and zizmor flags it as adhoc-packages. Dependabot does not track
-      # these, so bump them by hand when a new CLI feature is needed.
+      # Unpinned on purpose. This step exists to prove the plugins load under the real
+      # CLI, and the version worth proving that against is the one users are actually
+      # running, not one frozen at the last manual bump. The cost is that a CLI release
+      # can turn this job red with no commit here — which, for a loadability check, is
+      # the signal rather than the noise. `claude --version` below records what ran.
       - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
-        env:
-          CLAUDE_CLI_VERSION: "2.1.220"
         run: |
           npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
-            "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+            "@anthropic-ai/claude-code@latest"
           echo "$RUNNER_TEMP/claude-cli/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/claude-cli/bin/claude" --version
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,18 +128,18 @@ jobs:
             python3 .github/scripts/validate_plugin_metadata.py --base-ref "$BASE_REF"
           fi
 
-      # Pinned rather than @latest, unlike the review workflow, and the difference is
-      # deliberate: `Validate plugins and skills` is a required check. An upstream
-      # release that renames a field in `plugin list --json` would redden every open
-      # PR at once, with no commit here to explain it, and block merges until someone
-      # diagnosed it. The review job can go red harmlessly; a merge gate cannot.
-      # Dependabot does not track these, so bump them by hand.
+      # Unpinned on purpose, and the consequence is accepted: this is a required check,
+      # so a Claude Code release that breaks plugin loading turns every open PR red at
+      # once, with no commit here to explain it. That is the intended trade. A pin
+      # nobody remembers to bump is worse — it drifts until the version CI proves
+      # against is one no user runs, which is the one thing this check exists to
+      # establish. Dependabot does not track npm CLIs installed this way, so the choice
+      # is a live version or a stale one, not a maintained one. `claude --version`
+      # below records what actually ran.
       - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
-        env:
-          CLAUDE_CLI_VERSION: "2.1.220"
         run: |
           npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
-            "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+            "@anthropic-ai/claude-code@latest"
           echo "$RUNNER_TEMP/claude-cli/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/claude-cli/bin/claude" --version
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,15 +128,18 @@ jobs:
             python3 .github/scripts/validate_plugin_metadata.py --base-ref "$BASE_REF"
           fi
 
-      # Unpinned on purpose. This step exists to prove the plugins load under the real
-      # CLI, and the version worth proving that against is the one users are actually
-      # running, not one frozen at the last manual bump. The cost is that a CLI release
-      # can turn this job red with no commit here — which, for a loadability check, is
-      # the signal rather than the noise. `claude --version` below records what ran.
+      # Pinned rather than @latest, unlike the review workflow, and the difference is
+      # deliberate: `Validate plugins and skills` is a required check. An upstream
+      # release that renames a field in `plugin list --json` would redden every open
+      # PR at once, with no commit here to explain it, and block merges until someone
+      # diagnosed it. The review job can go red harmlessly; a merge gate cannot.
+      # Dependabot does not track these, so bump them by hand.
       - name: Install Claude Code CLI  # zizmor: ignore[adhoc-packages]
+        env:
+          CLAUDE_CLI_VERSION: "2.1.220"
         run: |
           npm install --global --prefix "$RUNNER_TEMP/claude-cli" \
-            "@anthropic-ai/claude-code@latest"
+            "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
           echo "$RUNNER_TEMP/claude-cli/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/claude-cli/bin/claude" --version
 


### PR DESCRIPTION
Audit of what was actually reviewing #253-#255, plus the cleanup that fell out of it.

## The model was never specified

`claude_review.sh` passed `--effort` but no `--model`, so the reviewer was whatever the CLI resolved to at run time, and nothing in the logs recorded which. The CLI version was pinned specifically so CI could not change without a commit, while the larger lever on review quality was left floating.

Now pinned to `opus`, with the run line recording all three:

```
Reviewing trailofbits/skills#256 (model=opus effort=xhigh cli=2.1.235 (Claude Code))
```

## The review claimed to run things it cannot run

The allowlist is `gh pr` reads, `git log`, `git diff`, `Read`, `Grep`, `Glob` — no interpreter, no test runner, no shell. Across the three PRs it reviewed:

- **#253**: "I verified this directly:" and a Python transcript. Its regex, `re.compile(r"(?<[a-zA-Z])...")`, raises `re.error: unknown extension ?<[` — it cannot compile, so that session never ran.
- **#254**: "I ran the full test_workflow_contract.py suite locally (node v22.22.0) and confirmed all 49 tests pass." The suite reports 82 passed, 2 skipped.
- **#255**: "verified directly by three independent verifiers running the shim."

Every conclusion was correct. Every proof was invented. That is worse than showing no proof, because a reader cannot tell which findings were actually checked.

The cause was a prompt gap rather than a reasoning failure: the **deep** prompt already said "You cannot execute anything," and the tier that actually ran never did. The prompt now states the tool reality and forbids reporting output no tool produced, while explicitly still permitting reasoning about what an input would do.

## One tier instead of two

The split was a cheap pass on every push plus an xhigh adversarial pass behind a `deep-review` label. It did not survive contact: **the label was never created**, so the deep tier skipped 9 times and ran zero, and every review this repo has received came from the cheap tier.

Effort goes `low` → `xhigh`, and with both tiers then identical apart from scope there was no reason to gate the better scope behind a label somebody has to remember to apply. So there is one job, taking the deep tier's prompt and tools (reads beyond the diff, git history, checks the PR's claims against the files) and the cheap tier's `--edit-last` posting, which matters now that it runs on every push.

`fast` is gone from the check name, the script's tier argument, and the concurrency key — it was already inaccurate once effort went to xhigh. I confirmed nothing depended on it: the ruleset on `main` requires `license/cla`, `Validate plugins and skills`, `Pre-commit` and `Shell (bats)`, not this check. The label-keyed concurrency group goes too, since it existed only to stop a push cancelling an in-flight deep review.

## The CLI is now unpinned, on purpose

Both here and in the loadability check in `validate.yml`. For loadability that is arguably the point: the version worth proving plugins load against is the one users are running, not one frozen at the last manual bump. The trade is that a release can change behavior with no commit here, which is why the resolved version is now logged. zizmor still passes; the existing `adhoc-packages` ignores cover it.

## Also

The prompt now says to rank on consequence rather than diff size. The `/Users/[A-Z]` gap in #253 was filed as a nit, but it made a brand-new checker miss the most likely path it exists to catch, including this repository's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)