### PR TITLE
Make every documented command runnable under our own python shims

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "building-secure-contracts",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "description": "Comprehensive smart contract security toolkit based on Trail of Bits' Building Secure Contracts framework. Includes vulnerability scanners for 6 blockchains and 5 development guideline assistants.",
       "author": {
         "name": "Omar Inuwa && Pawe\u0142 P\u0142atek"
@@ -47,7 +47,7 @@
     },
     {
       "name": "constant-time-analysis",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "description": "Detect compiler-induced timing side-channels in cryptographic code",
       "author": {
         "name": "Scott Arciszewski",
@@ -57,7 +57,7 @@
     },
     {
       "name": "culture-index",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "description": "Interprets Culture Index survey results for individuals and teams",
       "author": {
         "name": "Dan Guido"
@@ -147,7 +147,7 @@
     },
     {
       "name": "semgrep-rule-creator",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "description": "Create custom Semgrep rules for detecting bug patterns and security vulnerabilities",
       "author": {
         "name": "Maciej Domanski"
@@ -177,7 +177,7 @@
     },
     {
       "name": "static-analysis",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "description": "Static analysis toolkit with CodeQL, Semgrep, and SARIF parsing for security vulnerability detection",
       "author": {
         "name": "Axel Mierczuk & Pawe\u0142 P\u0142atek"
@@ -195,7 +195,7 @@
     },
     {
       "name": "testing-handbook-skills",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "description": "Skills from the Trail of Bits Application Security Testing Handbook (appsec.guide)",
       "author": {
         "name": "Pawe\u0142 P\u0142atek"
@@ -204,7 +204,7 @@
     },
     {
       "name": "trailmark",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "description": "Builds multi-language source and binary code graphs for security analysis: call graphs, attack surface mapping, blast radius, taint propagation, complexity hotspots, entry point enumeration, proxy/unresolved-call tracking, type/reference analysis, and structural diffs. Creates bounded, graph-informed source packets for delegating focused work to constrained subagents. Generates Mermaid diagrams, runs graph-informed mutation testing triage (genotoxic), generates mutation-driven test vectors (vector-forge), extracts crypto protocol message flows, converts Mermaid diagrams to ProVerif models, projects SARIF/weAudit/binary findings onto code graphs, triages single findings with graph evidence, gates branch diffs for structural review regressions, and expands seed findings into variant-neighborhood candidates. Use when analyzing call paths, slicing source context for smaller models, mapping attack surface, visualizing code architecture, triaging survived mutants, generating cryptographic test vectors, diagramming crypto protocols, formally verifying protocols, augmenting audits with static analysis findings, deciding whether one candidate issue is reachable, reviewing graph-level PR risk, or seeding variant analysis.",
       "author": {
         "name": "Scott Arciszewski",
@@ -214,7 +214,7 @@
     },
     {
       "name": "variant-analysis",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "description": "Find similar vulnerabilities and bugs across codebases using pattern-based analysis",
       "author": {
         "name": "Axel Mierczuk"
@@ -223,7 +223,7 @@
     },
     {
       "name": "c-review",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "description": "Comprehensive C/C++ security code review with specialized bug-finding agents covering memory safety, type safety, concurrency, and Linux/Windows userspace-specific issues",
       "author": {
         "name": "Pawe\u0142 P\u0142atek"
@@ -232,7 +232,7 @@
     },
     {
       "name": "rust-review",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Comprehensive Rust security code review with specialized bug-finding agents covering the safe/unsafe boundary, memory safety in unsafe blocks, concurrency, panic-induced DoS, recursion-induced stack overflow, FFI, and async runtime hazards",
       "author": {
         "name": "Andrea Cappa (Aptos Labs) & Pawe\u0142 P\u0142atek (Trail of Bits)"
@@ -272,7 +272,7 @@
     },
     {
       "name": "yara-authoring",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "description": "YARA-X detection rule authoring with linting and quality analysis",
       "author": {
         "name": "Trail of Bits",
@@ -312,7 +312,7 @@
     },
     {
       "name": "zeroize-audit",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "description": "Detects missing or compiler-optimized zeroization of sensitive data with assembly and control-flow analysis",
       "author": {
         "name": "Trail of Bits",

--- a/.github/scripts/validate_plugin_metadata.py
+++ b/.github/scripts/validate_plugin_metadata.py
@@ -105,21 +105,27 @@ LEGACY_PYTHON_PATTERNS = (
         "uses the legacy `uv pip` interface; use `uv add`, `uv sync`, or `uv tool install`",
     ),
     (
-        # Leading short flags are stepped over (`python3 -u foo.py` is refused too),
-        # except -c/-m, whose argument is not a script path.
-        re.compile(r"\bpython3?\s+(?:-(?![cm]\b)[A-Za-z]\S*\s+)*(?!-)\S*\.py\b"),
+        # Leading flags are stepped over — long, short, and value-taking alike
+        # (`python3 -W ignore foo.py` is refused too) — except -c/-m, whose
+        # argument is not a script path. Values may not start with `-`, and
+        # backtracking releases a swallowed script name.
+        re.compile(
+            r"\bpython3?\s+(?:--?(?![cm]\b)[A-Za-z][\w-]*(?:[= ](?!-)\S+)?\s+)*(?!-)\S*\.py\b"
+        ),
         "runs a script through the bare interpreter; use `uv run --no-project <script>`",
     ),
     (
         # A script named by variable or path (`python3 "$MERGE"`, `python3 ./tool`) is
         # refused just the same, with no `.py` token for the pattern above to see.
-        re.compile(r"""\bpython3?\s+(?:-(?![cm]\b)[A-Za-z]\S*\s+)*["'$./]"""),
+        re.compile(r"""\bpython3?\s+(?:--?(?![cm]\b)[A-Za-z][\w-]*(?:[= ](?!-)\S+)?\s+)*["'$./]"""),
         "runs a script through the bare interpreter; use `uv run --no-project <script>`",
     ),
     (
-        # The shims refuse every pip/pipx subcommand via a catch-all arm, not only
-        # install. Named subcommands rather than `pip \w+` to keep prose FPs down.
-        re.compile(r"\bpip3?\s+(install|uninstall|freeze|download|list|show|check|wheel)\b"),
+        # The shims refuse every pip/pipx subcommand via a catch-all arm. Deliberately a
+        # named subset here, to keep prose false positives down; extend as instances appear.
+        re.compile(
+            r"\bpip3?\s+(install|uninstall|freeze|download|list|show|check|wheel|cache|config)\b"
+        ),
         "uses pip; use `uv run --with <pkg>` for a one-off, `uv add` in your own project, "
         "or `uv tool install <pkg>` for a CLI",
     ),
@@ -149,8 +155,12 @@ LEGACY_PYTHON_COMPLIANT_PREFIX = re.compile(r"uv\s+run\s+(?:--?[A-Za-z-]+(?:[= ]
 # it. Matched as whole flags after the command so `--target-dir` does not count.
 LEGACY_PYTHON_UV_PIP_ALLOWED = re.compile(r"\s(--project|--directory|--target|-t)([= ]|$)")
 # Exempts its code block up to the next blank line or fence, for commands that run where
-# the shims are absent (a container, a target project's own build). Must state a reason.
+# the shims are absent (a container, a target project's own build). A bare marker with no
+# reason does not exempt.
 LEGACY_PYTHON_ALLOW_MARKER = "allow-legacy-python:"
+LEGACY_PYTHON_ALLOW_RE = re.compile(r"allow-legacy-python:\s*\S")
+# Local trees accumulate these; CI never has them, so skipping keeps the two runs equal.
+SCAN_SKIP_DIRS = frozenset({".venv", "venv", "node_modules", "__pycache__", ".git", ".ruff_cache"})
 
 # Floor for --self-test, set to the exact number of assertions the fixtures run. There is
 # no slack on purpose: dropping one has to be a deliberate edit here, not a silent loss.
@@ -533,6 +543,8 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
             continue
         if path.is_relative_to(plugins_dir / "modern-python"):
             continue
+        if SCAN_SKIP_DIRS.intersection(path.parts):
+            continue
         # .md and .py under evals*/tests quote commands as expectations under test;
         # .sh there are commands, so shell keeps no exemption.
         if path.suffix in (".md", ".py") and any(
@@ -557,7 +569,7 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
                 block_exempt = False
                 continue
             if LEGACY_PYTHON_ALLOW_MARKER in line:
-                block_exempt = True
+                block_exempt = bool(LEGACY_PYTHON_ALLOW_RE.search(line))
                 continue
             if in_dockerfile or block_exempt:
                 continue
@@ -608,6 +620,8 @@ def find_hardcoded_paths(repo_root: Path) -> tuple[list[str], int]:
         if not path.is_file() or path.suffix not in HARDCODED_PATH_SUFFIXES:
             continue
         if path.name.endswith(HARDCODED_PATH_EXEMPT_SUFFIX):
+            continue
+        if SCAN_SKIP_DIRS.intersection(path.parts):
             continue
         scanned += 1
         text = path.read_text(encoding="utf-8", errors="replace")
@@ -1273,6 +1287,12 @@ def _self_test_errors(ran: list[str]) -> None:
             ("python -m pip", "```bash\npython -m pip download requests\n```\n"),
             ("pip non-install subcommand", "```bash\npip freeze\n```\n"),
             ("pipx", "```bash\npipx install detect-secrets\n```\n"),
+            ("value-taking flag before the script", "```bash\npython3 -W ignore harness.py\n```\n"),
+            ("long flag before the script", "```bash\npython3 --verbose tool.py\n```\n"),
+            (
+                "allow-marker with no reason",
+                "```bash\n# allow-legacy-python:\npip install requests\n```\n",
+            ),
             ("script named by a variable", '```bash\npython3 "$MERGE" out.sarif\n```\n'),
             (
                 "compliant match masking a later violation",

--- a/.github/scripts/validate_plugin_metadata.py
+++ b/.github/scripts/validate_plugin_metadata.py
@@ -103,9 +103,51 @@ HARDCODED_PATH_EXEMPT_SUFFIX = "-shim.bats"
 # lowercase; keep this list to forms that cannot be somebody's actual account.
 HARDCODED_PATH_PLACEHOLDERS = ("/path/to", "/home/vscode", "/Users/Shared", "/Users/me/")
 
+# Invocations the modern-python plugin's PATH shims refuse. Any of these in a documented
+# command means the skill cannot run for anyone who has that plugin installed — which is
+# how thirteen plugins in this marketplace came to be broken by another plugin in it.
+#
+# Unanchored on purpose. Anchoring at line start missed the two places these actually hide:
+# a command inside a markdown table cell (`| Build image | `python3 infra/helper.py` |`) and
+# a call wrapped in a helper (`run_logged pip install -r requirements.txt`). Both are real
+# commands a reader copies or a script runs. The cost of matching broadly is the two guards
+# below, which are explicit and reviewable, rather than an anchor that silently under-detects.
+LEGACY_PYTHON_PATTERNS = (
+    (
+        re.compile(r"\bpython3?\s+(?!-)\S*\.py\b"),
+        "runs a script through the bare interpreter; use `uv run --no-project <script>`",
+    ),
+    (
+        re.compile(r"\bpip3?\s+install\b"),
+        "uses pip; use `uv add <pkg>` for a dependency or `uv tool install <pkg>` for a CLI",
+    ),
+    (
+        re.compile(r"\bpython3?\s+-m\s+pip\b"),
+        "uses python -m pip; use `uv add <pkg>` or `uv tool install <pkg>`",
+    ),
+    (
+        re.compile(r"\buv\s+pip\s+install\b"),
+        "uses the legacy `uv pip` interface; use `uv add`, `uv sync`, or `uv tool install`",
+    ),
+)
+# Prose that names a forbidden command in order to forbid it. trailmark's dispatch skills say
+# "Do NOT run `pip install`, `uv pip install`" and must keep saying exactly that.
+LEGACY_PYTHON_PROHIBITIONS = ("do not run", "don't run", "do not use", "never run", "instead of")
+# Because the patterns are unanchored, `uv run --no-project python fuzz.py` contains a literal
+# `python fuzz.py`. Matching text already introduced by a compliant `uv run` is the fix, not a
+# violation — without this the check flags the very form it tells you to use.
+LEGACY_PYTHON_COMPLIANT_PREFIX = re.compile(r"uv\s+run\s+(?:--?[A-Za-z-]+(?:[= ]\S+)?\s+)*$")
+# `uv pip` carrying one of these is a tool managing an environment it owns, which the shim
+# permits and which prek and similar tools legitimately need.
+LEGACY_PYTHON_UV_PIP_ALLOWED = ("--project", "--directory", "--target")
+# An escape hatch that must state a reason, for commands that genuinely run somewhere the
+# shim does not: inside a container, or as a target project's own build. Structural
+# `dockerfile` fences are detected instead and need no marker.
+LEGACY_PYTHON_ALLOW_MARKER = "allow-legacy-python:"
+
 # Floor for --self-test, set to the exact number of assertions the fixtures run. There is
 # no slack on purpose: dropping one has to be a deliberate edit here, not a silent loss.
-SELF_TEST_MINIMUM = 45
+SELF_TEST_MINIMUM = 56
 
 
 @dataclass
@@ -127,6 +169,7 @@ class ScanResult:
     findings: list[Finding] = field(default_factory=list)
     refs_checked: int = 0
     paths_scanned: int = 0
+    python_docs_scanned: int = 0
 
     def add(self, plugin: str, message: str, severity: str = ERROR) -> None:
         self.findings.append(Finding(plugin, message, severity))
@@ -457,6 +500,78 @@ def validate_subagent_dispatch(
     return errors
 
 
+def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
+    """Documented commands the modern-python shims refuse, so the skill cannot run.
+
+    Returns the findings and the number of files scanned; zero scanned is the caller's
+    anti-vacuity guard. `plugins/modern-python/` is exempt wholesale so it can keep
+    documenting the commands it intercepts.
+    """
+    errors: list[str] = []
+    scanned = 0
+
+    plugins_dir = repo_root / "plugins"
+    if not plugins_dir.is_dir():
+        return errors, scanned
+
+    # Shell scripts as well as markdown. Scanning only docs missed ten live invocations in
+    # `plugins/variant-analysis/tests/`, which is precisely what AGENTS.md recorded as the
+    # reason `make shell-suites` could not pass.
+    candidates = sorted(plugins_dir.rglob("*.md")) + sorted(plugins_dir.rglob("*.sh"))
+    for path in candidates:
+        if not path.is_file():
+            continue
+        if path.is_relative_to(plugins_dir / "modern-python"):
+            continue
+        # Eval graders and cases quote commands as the thing under test — a grader that
+        # checks the model "gives installation instructions (`pip install hypothesis`)" is
+        # describing an expectation, not issuing a command. Shell suites under tests/ ARE
+        # commands, so only markdown is exempt on that basis.
+        if path.suffix == ".md" and any(
+            part.startswith("evals") or part == "tests" for part in path.parts
+        ):
+            continue
+        scanned += 1
+
+        # A `dockerfile` fence runs in a container, where our PATH shims are not present.
+        in_dockerfile = False
+        # An allow-marker exempts the remainder of its block, which is what lets one marker
+        # cover a loop or an if-wrapper rather than needing one per line.
+        block_exempt = False
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for lineno, line in enumerate(lines, 1):
+            fence = line.strip()
+            if fence.startswith("```"):
+                language = fence[3:].strip().lower()
+                in_dockerfile = language == "dockerfile" if language else False
+                block_exempt = False
+                continue
+            if LEGACY_PYTHON_ALLOW_MARKER in line:
+                block_exempt = True
+                continue
+            lowered = line.lower()
+            if (
+                in_dockerfile
+                or block_exempt
+                or any(phrase in lowered for phrase in LEGACY_PYTHON_PROHIBITIONS)
+            ):
+                continue
+
+            for pattern, advice in LEGACY_PYTHON_PATTERNS:
+                match = pattern.search(line)
+                if not match:
+                    continue
+                if LEGACY_PYTHON_COMPLIANT_PREFIX.search(line[: match.start()]):
+                    continue
+                if "uv pip" in line and any(f in line for f in LEGACY_PYTHON_UV_PIP_ALLOWED):
+                    continue
+                rel = path.relative_to(repo_root)
+                errors.append(f"{rel}:{lineno} {advice} — found: {line.strip()[:70]}")
+                break
+
+    return errors, scanned
+
+
 def find_hardcoded_paths(repo_root: Path) -> tuple[list[str], int]:
     """Absolute paths into one developer's home directory, which nobody else has.
 
@@ -769,6 +884,10 @@ def validate_plugins(
     for msg in check_dependabot_lockfiles(repo_root):
         result.add("<repo>", msg)
 
+    legacy_errors, result.python_docs_scanned = find_legacy_python_invocations(repo_root)
+    for msg in legacy_errors:
+        result.add("<repo>", msg)
+
     path_errors, result.paths_scanned = find_hardcoded_paths(repo_root)
     for msg in path_errors:
         result.add("<repo>", msg)
@@ -887,6 +1006,10 @@ def main(argv: list[str] | None = None) -> int:
     # no files to read, so prove discovery worked before trusting it.
     if result.paths_scanned == 0:
         print("\n✗ hardcoded-path scan matched no files at all — discovery is broken")
+        return 1
+
+    if result.python_docs_scanned == 0:
+        print("\n✗ legacy-python scan read no markdown at all — discovery is broken")
         return 1
 
     errors = [f for f in result.findings if f.severity == ERROR]
@@ -1113,6 +1236,44 @@ def _self_test_errors(ran: list[str]) -> None:
         plugin = _build_demo(root)
         _write(plugin / "skills" / "demo" / "devcontainer.md", "Workspace is /home/vscode/app.\n")
         _check(ran, "container image path is not a personal path", not _errors_for(root))
+
+    # The four forms modern-python's shims refuse, and the forms that must stay legal.
+    # Without these a documented command that no user can run reads as a clean repo.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        plugin = _build_demo(root)
+        doc = plugin / "skills" / "demo" / "howto.md"
+
+        for label, body in (
+            ("bare interpreter on a script", "Run `python3 tools/x.py` first.\n"),
+            ("pip install", "```bash\npip install requests\n```\n"),
+            ("uv pip install", "```bash\nuv pip install requests\n```\n"),
+            ("python -m pip", "```bash\npython -m pip install requests\n```\n"),
+        ):
+            _write(doc, body)
+            _check(
+                ran,
+                f"legacy python invocation: {label}",
+                any("uv add" in e or "uv run" in e for e in _errors_for(root)),
+            )
+
+        for label, body in (
+            ("uv run --no-project", "```bash\nuv run --no-project tools/x.py\n```\n"),
+            (
+                "uv run --no-project python",
+                "```bash\nuv run --no-project python infra/helper.py b\n```\n",
+            ),
+            ("python3 -c", "```bash\npython3 -c 'print(1)'\n```\n"),
+            ("uv pip with --directory", "```bash\nuv pip install --directory /tmp requests\n```\n"),
+            ("prose forbidding the command", "Do NOT run `pip install` here.\n"),
+            ("dockerfile fence", "```dockerfile\nRUN pip install requests\n```\n"),
+            (
+                "allow-marker",
+                "```bash\n# allow-legacy-python: in a container\npip install requests\n```\n",
+            ),
+        ):
+            _write(doc, body)
+            _check(ran, f"legal python invocation accepted: {label}", not _errors_for(root))
 
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)

--- a/.github/scripts/validate_plugin_metadata.py
+++ b/.github/scripts/validate_plugin_metadata.py
@@ -79,39 +79,22 @@ KEBAB_CASE_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 PLUGIN_NAME_MAX_LENGTH = 64
 SEMVER_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
 
-# An absolute path to one developer's machine, which resolves nowhere for anybody else.
-# The lookbehind anchors to a path-segment boundary so a longer word ending in the same
-# letters does not match. Python's re supports lookbehind natively, which is the whole
-# reason this lives here rather than in the CI grep it replaces: `grep -P` is a GNU
-# extension and this repo's house rule is POSIX ERE, portable to BSD grep on macOS.
-#
-# Both branches accept either case. The version inherited from the CI step matched
-# `/Users/[A-Z]` only, so every conventionally-lowercase macOS account name — the
-# overwhelmingly common form, `/Users/alice`, and this repo's own `/Users/user` — went
-# undetected while the `/home/` branch caught its equivalents. The check missed the
-# thing it exists to find.
+# An absolute path into one developer's home directory. The lookbehind anchors to a
+# path-segment boundary. Both branches accept either case: macOS account names are
+# conventionally lowercase, and a /Users/[A-Z]-only match misses nearly all of them.
 HARDCODED_PATH_PATTERN = re.compile(r"(?<![a-zA-Z])(?:/home/[A-Za-z]|/Users/[A-Za-z])")
-# Shell, bats, yaml and toml included deliberately: test fixtures and install scripts
-# are exactly where absolute paths hide.
+# Test fixtures and install scripts are where absolute paths hide.
 HARDCODED_PATH_SUFFIXES = (".md", ".py", ".json", ".sh", ".bats", ".yml", ".toml")
-# The shim suites need literal /home/user paths to test what they exist to test.
+# The shim suites need literal /home/user paths.
 HARDCODED_PATH_EXEMPT_SUFFIX = "-shim.bats"
-# Placeholders, illustrative examples and shared system paths — none of them is an
-# individual's home directory. `/Users/Shared` is a real macOS system directory, and
-# `/Users/me` is the stand-in name c-review's docs use when showing that a path with a
-# space has to stay quoted. Both only need listing because the pattern above now accepts
-# lowercase; keep this list to forms that cannot be somebody's actual account.
+# Placeholders, illustrative examples (`/Users/me/` in c-review's docs) and shared system
+# paths — keep this list to forms that cannot be somebody's actual account.
 HARDCODED_PATH_PLACEHOLDERS = ("/path/to", "/home/vscode", "/Users/Shared", "/Users/me/")
 
-# Invocations the modern-python plugin's PATH shims refuse. Any of these in a documented
-# command means the skill cannot run for anyone who has that plugin installed — which is
-# how thirteen plugins in this marketplace came to be broken by another plugin in it.
-#
-# Unanchored on purpose. Anchoring at line start missed the two places these actually hide:
-# a command inside a markdown table cell (`| Build image | `python3 infra/helper.py` |`) and
-# a call wrapped in a helper (`run_logged pip install -r requirements.txt`). Both are real
-# commands a reader copies or a script runs. The cost of matching broadly is the two guards
-# below, which are explicit and reviewable, rather than an anchor that silently under-detects.
+# Documented commands the modern-python plugin's PATH shims refuse — a skill carrying one
+# cannot run for anyone with that plugin installed. Unanchored, because violations hide
+# mid-line (markdown table cells, `run_logged pip install …`); the guards below carve out
+# the legitimate uses explicitly rather than under-detecting via an anchor.
 LEGACY_PYTHON_PATTERNS = (
     (
         re.compile(r"\bpython3?\s+(?!-)\S*\.py\b"),
@@ -130,19 +113,15 @@ LEGACY_PYTHON_PATTERNS = (
         "uses the legacy `uv pip` interface; use `uv add`, `uv sync`, or `uv tool install`",
     ),
 )
-# Prose that names a forbidden command in order to forbid it. trailmark's dispatch skills say
-# "Do NOT run `pip install`, `uv pip install`" and must keep saying exactly that.
+# Prose that names a command in order to forbid it ("Do NOT run `pip install`").
 LEGACY_PYTHON_PROHIBITIONS = ("do not run", "don't run", "do not use", "never run", "instead of")
-# Because the patterns are unanchored, `uv run --no-project python fuzz.py` contains a literal
-# `python fuzz.py`. Matching text already introduced by a compliant `uv run` is the fix, not a
-# violation — without this the check flags the very form it tells you to use.
+# `uv run --no-project python fuzz.py` contains a literal `python fuzz.py`; text already
+# introduced by a compliant `uv run` is the fix, not a violation.
 LEGACY_PYTHON_COMPLIANT_PREFIX = re.compile(r"uv\s+run\s+(?:--?[A-Za-z-]+(?:[= ]\S+)?\s+)*$")
-# `uv pip` carrying one of these is a tool managing an environment it owns, which the shim
-# permits and which prek and similar tools legitimately need.
+# A tool managing an environment it owns (prek installs hooks this way); the shim permits it.
 LEGACY_PYTHON_UV_PIP_ALLOWED = ("--project", "--directory", "--target")
-# An escape hatch that must state a reason, for commands that genuinely run somewhere the
-# shim does not: inside a container, or as a target project's own build. Structural
-# `dockerfile` fences are detected instead and need no marker.
+# Exempts the rest of its code block, for commands that run where the shims are absent
+# (a container, a target project's own build). Must state a reason.
 LEGACY_PYTHON_ALLOW_MARKER = "allow-legacy-python:"
 
 # Floor for --self-test, set to the exact number of assertions the fixtures run. There is
@@ -514,29 +493,23 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
     if not plugins_dir.is_dir():
         return errors, scanned
 
-    # Shell scripts as well as markdown. Scanning only docs missed ten live invocations in
-    # `plugins/variant-analysis/tests/`, which is precisely what AGENTS.md recorded as the
-    # reason `make shell-suites` could not pass.
+    # .sh as well as .md: a docs-only sweep missed ten live invocations in test harnesses.
     candidates = sorted(plugins_dir.rglob("*.md")) + sorted(plugins_dir.rglob("*.sh"))
     for path in candidates:
         if not path.is_file():
             continue
         if path.is_relative_to(plugins_dir / "modern-python"):
             continue
-        # Eval graders and cases quote commands as the thing under test — a grader that
-        # checks the model "gives installation instructions (`pip install hypothesis`)" is
-        # describing an expectation, not issuing a command. Shell suites under tests/ ARE
-        # commands, so only markdown is exempt on that basis.
+        # Markdown under evals*/tests quotes commands as the thing under test; shell
+        # suites there ARE commands, so only .md gets that exemption.
         if path.suffix == ".md" and any(
             part.startswith("evals") or part == "tests" for part in path.parts
         ):
             continue
         scanned += 1
 
-        # A `dockerfile` fence runs in a container, where our PATH shims are not present.
+        # A `dockerfile` fence runs in a container, where the PATH shims are absent.
         in_dockerfile = False
-        # An allow-marker exempts the remainder of its block, which is what lets one marker
-        # cover a loop or an if-wrapper rather than needing one per line.
         block_exempt = False
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
         for lineno, line in enumerate(lines, 1):
@@ -1009,7 +982,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if result.python_docs_scanned == 0:
-        print("\n✗ legacy-python scan read no markdown at all — discovery is broken")
+        print("\n✗ legacy-python scan read no files at all — discovery is broken")
         return 1
 
     errors = [f for f in result.findings if f.severity == ERROR]
@@ -1237,8 +1210,7 @@ def _self_test_errors(ran: list[str]) -> None:
         _write(plugin / "skills" / "demo" / "devcontainer.md", "Workspace is /home/vscode/app.\n")
         _check(ran, "container image path is not a personal path", not _errors_for(root))
 
-    # The four forms modern-python's shims refuse, and the forms that must stay legal.
-    # Without these a documented command that no user can run reads as a clean repo.
+    # The four refused forms must fire; the compliant and exempt forms must not.
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         plugin = _build_demo(root)

--- a/.github/scripts/validate_plugin_metadata.py
+++ b/.github/scripts/validate_plugin_metadata.py
@@ -95,7 +95,15 @@ HARDCODED_PATH_PLACEHOLDERS = ("/path/to", "/home/vscode", "/Users/Shared", "/Us
 # cannot run for anyone with that plugin installed. Unanchored, because violations hide
 # mid-line (markdown table cells, `run_logged pip install …`); the guards below carve out
 # the legitimate uses explicitly rather than under-detecting via an anchor.
+# `uv pip` first: its lines also contain `pip <sub>`, and first-hit-wins would otherwise
+# report them with pip's advice.
 LEGACY_PYTHON_PATTERNS = (
+    (
+        # Every `uv pip` subcommand is refused without a tool-managed flag, not just
+        # install; the allowed-flags guard below carves those out.
+        re.compile(r"\buv\s+pip\s+[a-z]"),
+        "uses the legacy `uv pip` interface; use `uv add`, `uv sync`, or `uv tool install`",
+    ),
     (
         # Leading short flags are stepped over (`python3 -u foo.py` is refused too),
         # except -c/-m, whose argument is not a script path.
@@ -103,19 +111,25 @@ LEGACY_PYTHON_PATTERNS = (
         "runs a script through the bare interpreter; use `uv run --no-project <script>`",
     ),
     (
-        re.compile(r"\bpip3?\s+install\b"),
+        # A script named by variable or path (`python3 "$MERGE"`, `python3 ./tool`) is
+        # refused just the same, with no `.py` token for the pattern above to see.
+        re.compile(r"""\bpython3?\s+(?:-(?![cm]\b)[A-Za-z]\S*\s+)*["'$./]"""),
+        "runs a script through the bare interpreter; use `uv run --no-project <script>`",
+    ),
+    (
+        # The shims refuse every pip/pipx subcommand via a catch-all arm, not only
+        # install. Named subcommands rather than `pip \w+` to keep prose FPs down.
+        re.compile(r"\bpip3?\s+(install|uninstall|freeze|download|list|show|check|wheel)\b"),
         "uses pip; use `uv run --with <pkg>` for a one-off, `uv add` in your own project, "
         "or `uv tool install <pkg>` for a CLI",
     ),
     (
-        re.compile(r"\bpython3?\s+-m\s+pip\b"),
-        "uses python -m pip; use `uv run --with <pkg>`, `uv add`, or `uv tool install`",
+        re.compile(r"\bpipx\s+(install|run|upgrade|uninstall|inject|list|ensurepath|reinstall)\b"),
+        "uses pipx; use `uv tool install <pkg>` or `uvx <pkg>`",
     ),
     (
-        # Every `uv pip` subcommand is refused without the tool-managed flags, not just
-        # install; the allowed-flags guard below carves those out.
-        re.compile(r"\buv\s+pip\s+[a-z]"),
-        "uses the legacy `uv pip` interface; use `uv add`, `uv sync`, or `uv tool install`",
+        re.compile(r"\bpython3?\s+-m\s+pip\b"),
+        "uses python -m pip; use `uv run --with <pkg>`, `uv add`, or `uv tool install`",
     ),
     (
         # A bare interpreter with only flags (`python3 --version`) is refused as well:
@@ -124,20 +138,23 @@ LEGACY_PYTHON_PATTERNS = (
         "invokes the bare interpreter; use `uv run python <flags>`",
     ),
 )
-# Prose that names a command in order to forbid it ("Do NOT run `pip install`").
+# Prose that names a command in order to forbid it ("Do NOT run `pip install`"). Tested
+# against the text BEFORE the match, so "Use `pip install x` instead of the tarball" — a
+# real instruction — is not exempted by its own trailing "instead of".
 LEGACY_PYTHON_PROHIBITIONS = ("do not run", "don't run", "do not use", "never run", "instead of")
 # `uv run --no-project python fuzz.py` contains a literal `python fuzz.py`; text already
 # introduced by a compliant `uv run` is the fix, not a violation.
 LEGACY_PYTHON_COMPLIANT_PREFIX = re.compile(r"uv\s+run\s+(?:--?[A-Za-z-]+(?:[= ]\S+)?\s+)*$")
-# A tool managing an environment it owns (prek installs hooks this way); the shim permits it.
-LEGACY_PYTHON_UV_PIP_ALLOWED = ("--project", "--directory", "--target", "-t ", "-t=")
+# A tool managing an environment it owns (prek installs hooks this way); the shim permits
+# it. Matched as whole flags after the command so `--target-dir` does not count.
+LEGACY_PYTHON_UV_PIP_ALLOWED = re.compile(r"\s(--project|--directory|--target|-t)([= ]|$)")
 # Exempts its code block up to the next blank line or fence, for commands that run where
 # the shims are absent (a container, a target project's own build). Must state a reason.
 LEGACY_PYTHON_ALLOW_MARKER = "allow-legacy-python:"
 
 # Floor for --self-test, set to the exact number of assertions the fixtures run. There is
 # no slack on purpose: dropping one has to be a deliberate edit here, not a silent loss.
-SELF_TEST_MINIMUM = 63
+SELF_TEST_MINIMUM = 71
 
 
 @dataclass
@@ -516,8 +533,8 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
             continue
         if path.is_relative_to(plugins_dir / "modern-python"):
             continue
-        # Markdown under evals*/tests quotes commands as the thing under test; shell
-        # suites there ARE commands, so only .md gets that exemption.
+        # .md and .py under evals*/tests quote commands as expectations under test;
+        # .sh there are commands, so shell keeps no exemption.
         if path.suffix in (".md", ".py") and any(
             part.startswith("evals") or part == "tests"
             for part in path.relative_to(plugins_dir).parts
@@ -542,25 +559,34 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
             if LEGACY_PYTHON_ALLOW_MARKER in line:
                 block_exempt = True
                 continue
-            lowered = line.lower()
-            if (
-                in_dockerfile
-                or block_exempt
-                or any(phrase in lowered for phrase in LEGACY_PYTHON_PROHIBITIONS)
-            ):
+            if in_dockerfile or block_exempt:
                 continue
 
+            # Every match is examined, not just the first: a compliant `uv run …` earlier
+            # on a line must not mask a refused command later on the same line.
+            hit = None
             for pattern, advice in LEGACY_PYTHON_PATTERNS:
-                match = pattern.search(line)
-                if not match:
-                    continue
-                if LEGACY_PYTHON_COMPLIANT_PREFIX.search(line[: match.start()]):
-                    continue
-                if "uv pip" in line and any(f in line for f in LEGACY_PYTHON_UV_PIP_ALLOWED):
-                    continue
+                for match in pattern.finditer(line):
+                    prefix = line[: match.start()]
+                    if LEGACY_PYTHON_COMPLIANT_PREFIX.search(prefix):
+                        continue
+                    # A `pip …` directly after `uv ` is part of a `uv pip` command,
+                    # whose verdict the uv-pip pattern above already delivered.
+                    if not match.group(0).startswith("uv") and re.search(r"\buv\s+$", prefix):
+                        continue
+                    if any(p in prefix.lower() for p in LEGACY_PYTHON_PROHIBITIONS):
+                        continue
+                    if "uv pip" in match.group(0) and LEGACY_PYTHON_UV_PIP_ALLOWED.search(
+                        line[match.start() :]
+                    ):
+                        continue
+                    hit = advice
+                    break
+                if hit:
+                    break
+            if hit:
                 rel = path.relative_to(repo_root)
-                errors.append(f"{rel}:{lineno} {advice} — found: {line.strip()[:70]}")
-                break
+                errors.append(f"{rel}:{lineno} {hit} — found: {line.strip()[:70]}")
 
     return errors, scanned
 
@@ -1231,7 +1257,7 @@ def _self_test_errors(ran: list[str]) -> None:
         _write(plugin / "skills" / "demo" / "devcontainer.md", "Workspace is /home/vscode/app.\n")
         _check(ran, "container image path is not a personal path", not _errors_for(root))
 
-    # The four refused forms must fire; the compliant and exempt forms must not.
+    # The refused forms must fire; the compliant and exempt forms must not.
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         plugin = _build_demo(root)
@@ -1245,6 +1271,21 @@ def _self_test_errors(ran: list[str]) -> None:
             ("uv pip install", "```bash\nuv pip install requests\n```\n"),
             ("uv pip non-install subcommand", "```bash\nuv pip list\n```\n"),
             ("python -m pip", "```bash\npython -m pip download requests\n```\n"),
+            ("pip non-install subcommand", "```bash\npip freeze\n```\n"),
+            ("pipx", "```bash\npipx install detect-secrets\n```\n"),
+            ("script named by a variable", '```bash\npython3 "$MERGE" out.sarif\n```\n'),
+            (
+                "compliant match masking a later violation",
+                "| a | `uv run python a.py` | `python3 b.py` |\n",
+            ),
+            (
+                "prohibition after the command, not before",
+                "Use `pip install semgrep` instead of the tarball.\n",
+            ),
+            (
+                "uv pip with a flag that is not tool-managed",
+                "```bash\nuv pip install --target-dir /x foo\n```\n",
+            ),
             ("usage string in a .py file", None),
             (
                 "marker scope ends at a blank line",
@@ -1266,7 +1307,7 @@ def _self_test_errors(ran: list[str]) -> None:
             _check(
                 ran,
                 f"legacy python invocation: {label}",
-                any("uv add" in e or "uv run" in e for e in _errors_for(root)),
+                any("uv add" in e or "uv run" in e or "uv tool" in e for e in _errors_for(root)),
             )
 
         for label, body in (
@@ -1279,6 +1320,11 @@ def _self_test_errors(ran: list[str]) -> None:
             ("python3 -m with a module", "```bash\npython3 -m json.tool data.json\n```\n"),
             ("uv pip with --directory", "```bash\nuv pip install --directory /tmp requests\n```\n"),
             ("uv pip with short -t", "```bash\nuv pip install -t /tmp requests\n```\n"),
+            (
+                "uv pip with the flag after the package",
+                "```bash\nuv pip install foo -t /tmp\n```\n",
+            ),
+            ("prohibition before the command", "Do NOT use `pip freeze` here.\n"),
             ("prose forbidding the command", "Do NOT run `pip install` here.\n"),
             ("dockerfile fence", "```dockerfile\nRUN pip install requests\n```\n"),
             (

--- a/.github/scripts/validate_plugin_metadata.py
+++ b/.github/scripts/validate_plugin_metadata.py
@@ -97,20 +97,31 @@ HARDCODED_PATH_PLACEHOLDERS = ("/path/to", "/home/vscode", "/Users/Shared", "/Us
 # the legitimate uses explicitly rather than under-detecting via an anchor.
 LEGACY_PYTHON_PATTERNS = (
     (
-        re.compile(r"\bpython3?\s+(?!-)\S*\.py\b"),
+        # Leading short flags are stepped over (`python3 -u foo.py` is refused too),
+        # except -c/-m, whose argument is not a script path.
+        re.compile(r"\bpython3?\s+(?:-(?![cm]\b)[A-Za-z]\S*\s+)*(?!-)\S*\.py\b"),
         "runs a script through the bare interpreter; use `uv run --no-project <script>`",
     ),
     (
         re.compile(r"\bpip3?\s+install\b"),
-        "uses pip; use `uv add <pkg>` for a dependency or `uv tool install <pkg>` for a CLI",
+        "uses pip; use `uv run --with <pkg>` for a one-off, `uv add` in your own project, "
+        "or `uv tool install <pkg>` for a CLI",
     ),
     (
         re.compile(r"\bpython3?\s+-m\s+pip\b"),
-        "uses python -m pip; use `uv add <pkg>` or `uv tool install <pkg>`",
+        "uses python -m pip; use `uv run --with <pkg>`, `uv add`, or `uv tool install`",
     ),
     (
-        re.compile(r"\buv\s+pip\s+install\b"),
+        # Every `uv pip` subcommand is refused without the tool-managed flags, not just
+        # install; the allowed-flags guard below carves those out.
+        re.compile(r"\buv\s+pip\s+[a-z]"),
         "uses the legacy `uv pip` interface; use `uv add`, `uv sync`, or `uv tool install`",
+    ),
+    (
+        # A bare interpreter with only flags (`python3 --version`) is refused as well:
+        # the shim finds no -c/-m/- selector and falls through to the refusal arm.
+        re.compile(r"\bpython3?\s+--?[A-Za-z][\w-]*\s*$"),
+        "invokes the bare interpreter; use `uv run python <flags>`",
     ),
 )
 # Prose that names a command in order to forbid it ("Do NOT run `pip install`").
@@ -119,14 +130,14 @@ LEGACY_PYTHON_PROHIBITIONS = ("do not run", "don't run", "do not use", "never ru
 # introduced by a compliant `uv run` is the fix, not a violation.
 LEGACY_PYTHON_COMPLIANT_PREFIX = re.compile(r"uv\s+run\s+(?:--?[A-Za-z-]+(?:[= ]\S+)?\s+)*$")
 # A tool managing an environment it owns (prek installs hooks this way); the shim permits it.
-LEGACY_PYTHON_UV_PIP_ALLOWED = ("--project", "--directory", "--target")
-# Exempts the rest of its code block, for commands that run where the shims are absent
-# (a container, a target project's own build). Must state a reason.
+LEGACY_PYTHON_UV_PIP_ALLOWED = ("--project", "--directory", "--target", "-t ", "-t=")
+# Exempts its code block up to the next blank line or fence, for commands that run where
+# the shims are absent (a container, a target project's own build). Must state a reason.
 LEGACY_PYTHON_ALLOW_MARKER = "allow-legacy-python:"
 
 # Floor for --self-test, set to the exact number of assertions the fixtures run. There is
 # no slack on purpose: dropping one has to be a deliberate edit here, not a silent loss.
-SELF_TEST_MINIMUM = 56
+SELF_TEST_MINIMUM = 63
 
 
 @dataclass
@@ -493,8 +504,13 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
     if not plugins_dir.is_dir():
         return errors, scanned
 
-    # .sh as well as .md: a docs-only sweep missed ten live invocations in test harnesses.
-    candidates = sorted(plugins_dir.rglob("*.md")) + sorted(plugins_dir.rglob("*.sh"))
+    # .sh and .py as well as .md: shell suites carried ten live invocations a docs-only
+    # sweep missed, and .py usage strings tell users to run refused commands.
+    candidates = (
+        sorted(plugins_dir.rglob("*.md"))
+        + sorted(plugins_dir.rglob("*.sh"))
+        + sorted(plugins_dir.rglob("*.py"))
+    )
     for path in candidates:
         if not path.is_file():
             continue
@@ -502,8 +518,9 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
             continue
         # Markdown under evals*/tests quotes commands as the thing under test; shell
         # suites there ARE commands, so only .md gets that exemption.
-        if path.suffix == ".md" and any(
-            part.startswith("evals") or part == "tests" for part in path.parts
+        if path.suffix in (".md", ".py") and any(
+            part.startswith("evals") or part == "tests"
+            for part in path.relative_to(plugins_dir).parts
         ):
             continue
         scanned += 1
@@ -517,6 +534,9 @@ def find_legacy_python_invocations(repo_root: Path) -> tuple[list[str], int]:
             if fence.startswith("```"):
                 language = fence[3:].strip().lower()
                 in_dockerfile = language == "dockerfile" if language else False
+                block_exempt = False
+                continue
+            if not line.strip():
                 block_exempt = False
                 continue
             if LEGACY_PYTHON_ALLOW_MARKER in line:
@@ -991,7 +1011,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"\n✓ no errors ({result.refs_checked} references resolved, "
-        f"{result.paths_scanned} files scanned for hardcoded paths)"
+        f"{result.paths_scanned} files scanned for hardcoded paths, "
+        f"{result.python_docs_scanned} for legacy python invocations)"
     )
     return 0
 
@@ -1218,10 +1239,29 @@ def _self_test_errors(ran: list[str]) -> None:
 
         for label, body in (
             ("bare interpreter on a script", "Run `python3 tools/x.py` first.\n"),
+            ("bare interpreter behind a flag", "```bash\npython3 -u tools/x.py\n```\n"),
+            ("bare interpreter, flags only", "```bash\npython3 --version\n```\n"),
             ("pip install", "```bash\npip install requests\n```\n"),
             ("uv pip install", "```bash\nuv pip install requests\n```\n"),
-            ("python -m pip", "```bash\npython -m pip install requests\n```\n"),
+            ("uv pip non-install subcommand", "```bash\nuv pip list\n```\n"),
+            ("python -m pip", "```bash\npython -m pip download requests\n```\n"),
+            ("usage string in a .py file", None),
+            (
+                "marker scope ends at a blank line",
+                "```bash\n# allow-legacy-python: x\n\npip install requests\n```\n",
+            ),
         ):
+            if body is None:
+                _write(doc, "clean\n")
+                script = plugin / "skills" / "demo" / "scripts" / "t.py"
+                _write(script, '"""Usage: python3 t.py"""\n')
+                _check(
+                    ran,
+                    f"legacy python invocation: {label}",
+                    any("uv run" in e for e in _errors_for(root)),
+                )
+                script.unlink()
+                continue
             _write(doc, body)
             _check(
                 ran,
@@ -1236,7 +1276,9 @@ def _self_test_errors(ran: list[str]) -> None:
                 "```bash\nuv run --no-project python infra/helper.py b\n```\n",
             ),
             ("python3 -c", "```bash\npython3 -c 'print(1)'\n```\n"),
+            ("python3 -m with a module", "```bash\npython3 -m json.tool data.json\n```\n"),
             ("uv pip with --directory", "```bash\nuv pip install --directory /tmp requests\n```\n"),
+            ("uv pip with short -t", "```bash\nuv pip install -t /tmp requests\n```\n"),
             ("prose forbidding the command", "Do NOT run `pip install` here.\n"),
             ("dockerfile fence", "```dockerfile\nRUN pip install requests\n```\n"),
             (

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,13 +239,11 @@ is strong evidence and not a guarantee:
   `pre-commit run -a`) to cover those locally.
 - **the version-increment check**, which needs a base ref to diff against and so has
   no meaning outside a PR.
-- **`make shell-suites`**, which is a target but not part of `check`: it still fails on a
-  machine with the `modern-python` plugin installed, though no longer for the reason
-  #207 describes. The `python3 -` interception that broke zeroize-audit is gone as of
-  modern-python 1.6.0. What remains is `plugins/variant-analysis/tests/` invoking
-  `python3 <script>.py`, which the shim intercepts *by design* — a bare script run is
-  exactly what `uv run python` replaces. That one is variant-analysis's to fix. With no
-  shim on PATH the whole target passes.
+- **`make shell-suites`**, which is a target but not part of `check`. It now passes with
+  modern-python installed: the `python3 -` interception that broke zeroize-audit went away
+  in 1.6.0, and `plugins/variant-analysis/tests/` no longer invokes `python3 <script>.py`.
+  It is still outside `check` because it is slow, not because it is broken. Note a machine
+  still on the 1.5.3 shim will fail it, since that version refuses `python3 -`.
 
 Both scan every plugin; the validator is not scoped down in CI. Only the
 version-increment check is limited to the plugins a branch touched, and it is the one
@@ -282,6 +280,14 @@ Each of these fails the build. There is no value in checking any of it by hand:
   `.bats`, `.yml` or `.toml` file under `plugins/`. `*-shim.bats` is exempt because
   those fixtures need literal paths, and `/path/to` and `/home/vscode` are treated as
   placeholders rather than somebody's home directory.
+- No documented command uses a Python invocation this marketplace's own `modern-python`
+  shims refuse: no `python <script>`, no `pip install`, no `python -m pip`, no `uv pip
+  install` without `--project`/`--directory`/`--target`. Use `uv run --no-project <script>`,
+  `uv add <pkg>` for a dependency, `uv tool install <pkg>` for a CLI. Thirteen plugins were
+  broken by another plugin in this repo before this was enforced. Exempt: prose that forbids
+  the command, `dockerfile` fences (a container has no shims), `plugins/modern-python/`
+  itself, and any block carrying an `allow-legacy-python: <reason>` comment — which is for
+  commands that genuinely run elsewhere, such as a target project's own build.
 - No `.codex/`, `.opencode/`, `.agents/`, or `plugins/*/.codex-plugin/` sidecars
 - A committed `uv.lock` for every uv directory listed in `.github/dependabot.yml`
 - Both loadability checks pass under the real Claude Code and Codex CLIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,11 +239,9 @@ is strong evidence and not a guarantee:
   `pre-commit run -a`) to cover those locally.
 - **the version-increment check**, which needs a base ref to diff against and so has
   no meaning outside a PR.
-- **`make shell-suites`**, which is a target but not part of `check`. It now passes with
-  modern-python installed: the `python3 -` interception that broke zeroize-audit went away
-  in 1.6.0, and `plugins/variant-analysis/tests/` no longer invokes `python3 <script>.py`.
-  It is still outside `check` because it is slow, not because it is broken. Note a machine
-  still on the 1.5.3 shim will fail it, since that version refuses `python3 -`.
+- **`make shell-suites`**, a target but not part of `check` — slow, not broken. It passes
+  with modern-python ≥ 1.6.0 installed; the 1.5.3 shim still refuses the `python3 -` that
+  zeroize-audit's suite uses.
 
 Both scan every plugin; the validator is not scoped down in CI. Only the
 version-increment check is limited to the plugins a branch touched, and it is the one
@@ -280,14 +278,11 @@ Each of these fails the build. There is no value in checking any of it by hand:
   `.bats`, `.yml` or `.toml` file under `plugins/`. `*-shim.bats` is exempt because
   those fixtures need literal paths, and `/path/to` and `/home/vscode` are treated as
   placeholders rather than somebody's home directory.
-- No documented command uses a Python invocation this marketplace's own `modern-python`
-  shims refuse: no `python <script>`, no `pip install`, no `python -m pip`, no `uv pip
-  install` without `--project`/`--directory`/`--target`. Use `uv run --no-project <script>`,
-  `uv add <pkg>` for a dependency, `uv tool install <pkg>` for a CLI. Thirteen plugins were
-  broken by another plugin in this repo before this was enforced. Exempt: prose that forbids
-  the command, `dockerfile` fences (a container has no shims), `plugins/modern-python/`
-  itself, and any block carrying an `allow-legacy-python: <reason>` comment — which is for
-  commands that genuinely run elsewhere, such as a target project's own build.
+- No documented command uses a form the `modern-python` shims refuse: `python <script>`,
+  `pip install`, `python -m pip`, or `uv pip install` without `--project`/`--directory`/
+  `--target`. Use `uv run --no-project <script>`, `uv add`, or `uv tool install`. Exempt:
+  prose forbidding the command, `dockerfile` fences, `plugins/modern-python/` itself, and
+  code blocks carrying an `allow-legacy-python: <reason>` comment.
 - No `.codex/`, `.opencode/`, `.agents/`, or `plugins/*/.codex-plugin/` sidecars
 - A committed `uv.lock` for every uv directory listed in `.github/dependabot.yml`
 - Both loadability checks pass under the real Claude Code and Codex CLIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,9 +280,11 @@ Each of these fails the build. There is no value in checking any of it by hand:
   placeholders rather than somebody's home directory.
 - No documented command uses a form the `modern-python` shims refuse: `python <script>`,
   `pip install`, `python -m pip`, or `uv pip install` without `--project`/`--directory`/
-  `--target`. Use `uv run --no-project <script>`, `uv add`, or `uv tool install`. Exempt:
-  prose forbidding the command, `dockerfile` fences, `plugins/modern-python/` itself, and
-  code blocks carrying an `allow-legacy-python: <reason>` comment.
+  `--target`/`-t`. Use `uv run --no-project <script>`, `uv run --with <pkg>`, `uv add`, or
+  `uv tool install`. Exempt: prose forbidding the command, `dockerfile` fences,
+  `plugins/modern-python/` itself, `.md`/`.py` under a `tests`/`evals*` directory (quoted
+  expectations), and code blocks carrying `allow-legacy-python: <reason>` — the reason is
+  required.
 - No `.codex/`, `.opencode/`, `.agents/`, or `plugins/*/.codex-plugin/` sidecars
 - A committed `uv.lock` for every uv directory listed in `.github/dependabot.yml`
 - Both loadability checks pass under the real Claude Code and Codex CLIs

--- a/Makefile
+++ b/Makefile
@@ -89,11 +89,9 @@ bats:
 	echo "$$files" | xargs bats
 
 ## shell-suites: run plugin shell regression suites (CI only, see note)
-# Deliberately NOT in `check`. zeroize-audit's suite pipes a script to `python3 -`,
-# which the modern-python plugin's shim intercepts and rejects, so this target fails
-# on any machine with that plugin installed — for reasons that have nothing to do
-# with the code under test. CI has no shims and runs it there. See the tracking
-# issue: #207.
+# Deliberately NOT in `check` because it is slow, not because it is broken: it passes
+# with modern-python >= 1.6.0 installed. A machine still on the 1.5.3 shim will fail
+# it, since that version refuses the `python3 -` zeroize-audit's suite uses (#207).
 #
 # find, not a glob: `**` needs globstar and degrades to `*` without it, so a suite
 # one directory deeper would stop running with no signal.

--- a/plugins/building-secure-contracts/.claude-plugin/plugin.json
+++ b/plugins/building-secure-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "building-secure-contracts",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Comprehensive smart contract security toolkit based on Trail of Bits' Building Secure Contracts framework. Includes vulnerability scanners for 6 blockchains and 5 development guideline assistants.",
   "author": {
     "name": "Omar Inuwa && Paweł Płatek",

--- a/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
@@ -42,7 +42,7 @@ OnComplete, ApplicationCall, TxnType
 
 ### Tool Support
 - **Tealer**: Trail of Bits static analyzer for Algorand
-- Installation: `uv tool install tealer`
+- Installation: `uv tool install tealer` (ensure uv's tool bin dir is on PATH)
 - Usage: `tealer contract.teal --detect all`
 
 ---

--- a/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
@@ -42,7 +42,7 @@ OnComplete, ApplicationCall, TxnType
 
 ### Tool Support
 - **Tealer**: Trail of Bits static analyzer for Algorand
-- Installation: `pip3 install tealer`
+- Installation: `uv tool install tealer`
 - Usage: `tealer contract.teal --detect all`
 
 ---

--- a/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
@@ -62,7 +62,7 @@ send_message_to_l1_syscall
 
 ### Tool Support
 - **Caracal**: Trail of Bits static analyzer for Cairo
-- Installation: `pip install caracal`
+- Installation: `cargo install --git https://github.com/crytic/caracal --profile release --force` (Caracal is a Rust tool; precompiled binaries are also on its releases page)
 - Usage: `caracal detect src/`
 - **cairo-test**: Built-in testing framework
 - **Starknet Foundry**: Testing and development toolkit
@@ -278,7 +278,7 @@ fn test_deposit_withdraw_roundtrip() {
 # .github/workflows/security.yml
 - name: Run Caracal
   run: |
-    pip install caracal
+    cargo install --git https://github.com/crytic/caracal --profile release --force
     caracal detect src/ --fail-on high,critical
 ```
 

--- a/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
@@ -62,7 +62,7 @@ send_message_to_l1_syscall
 
 ### Tool Support
 - **Caracal**: Trail of Bits static analyzer for Cairo
-- Installation: `cargo install --git https://github.com/crytic/caracal --profile release --force` (Caracal is a Rust tool; precompiled binaries are also on its releases page)
+- Installation: `cargo install --git https://github.com/crytic/caracal --profile release --force` (a Rust tool — not on PyPI)
 - Usage: `caracal detect src/`
 - **cairo-test**: Built-in testing framework
 - **Starknet Foundry**: Testing and development toolkit

--- a/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
@@ -278,6 +278,7 @@ fn test_deposit_withdraw_roundtrip() {
 # .github/workflows/security.yml
 - name: Run Caracal
   run: |
+    # Rebuilds from source each run; cache ~/.cargo or pin a release binary instead.
     cargo install --git https://github.com/crytic/caracal --profile release --force
     caracal detect src/ --fail-on high,critical
 ```

--- a/plugins/c-review/.claude-plugin/plugin.json
+++ b/plugins/c-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "c-review",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Comprehensive C/C++ security code review with specialized bug-finding agents covering memory safety, type safety, concurrency, and Linux/Windows userspace-specific issues",
   "author": {
     "name": "Paweł Płatek"

--- a/plugins/c-review/agents/c-review-fp-judge.md
+++ b/plugins/c-review/agents/c-review-fp-judge.md
@@ -293,7 +293,7 @@ For each reported finding, include the key body sections (Description / Code / D
 Do **not** hand-write SARIF JSON. After all primary finding frontmatter has `fp_verdict` and survivor frontmatter has `severity`, `attack_vector`, and `exploitability`, run:
 
 ```bash
-python3 "{sarif_generator_path}" "{output_dir}"
+uv run --no-project "{sarif_generator_path}" "{output_dir}"
 ```
 
 The generator reads `{output_dir}/context.md` and the canonical `findings-index.txt` when present (falling back to `findings/*.md` only if the index is absent), applies the same `severity_filter` used for `REPORT.md`, and includes survivor primaries (`TRUE_POSITIVE` / `LIKELY_TP`). A merged non-primary (`merged_into`) is normally excluded, **unless** its merge target did not survive (FP-rejected or missing) — then the merged finding is re-emitted (with a stderr note) so a real bug is never silently dropped because dedup pointed it at a later-rejected target. It writes `{output_dir}/REPORT.sarif`.

--- a/plugins/c-review/scripts/build_run_plan.py
+++ b/plugins/c-review/scripts/build_run_plan.py
@@ -21,7 +21,7 @@ file, or invalid flag combination — so the orchestrator can rely on its
 output without further validation.
 
 Usage:
-    python3 build_run_plan.py \\
+    uv run --no-project build_run_plan.py \\
         --plugin-root /abs/plugins/c-review \\
         --output-dir /abs/.c-review-results/<ts> \\
         --threat-model REMOTE \\

--- a/plugins/c-review/scripts/generate_sarif.py
+++ b/plugins/c-review/scripts/generate_sarif.py
@@ -6,8 +6,8 @@
 """Generate c-review SARIF from finding frontmatter.
 
 Usage:
-    python3 generate_sarif.py /path/to/output_dir
-    python3 generate_sarif.py /path/to/output_dir --output /tmp/REPORT.sarif
+    uv run --no-project generate_sarif.py /path/to/output_dir
+    uv run --no-project generate_sarif.py /path/to/output_dir --output /tmp/REPORT.sarif
 """
 
 from __future__ import annotations

--- a/plugins/c-review/skills/c-review/SKILL.md
+++ b/plugins/c-review/skills/c-review/SKILL.md
@@ -47,7 +47,7 @@ Output directory contains: `context.md`, `plan.json`, `worker-prompts/`, `findin
 2. **Codex** — `${CODEX_PLUGIN_ROOT}` (set it the same way if that var is present and resolves the marker).
 3. **Fallback search** — covers Codex installs under `~/.codex`, Claude installs under `~/.claude`, and a local checkout / repo run: `Bash: find ~/.claude ~/.codex . -path '*/plugins/c-review/prompts/clusters/buffer-write-sinks.md' -print -quit 2>/dev/null`. Take the match and strip the trailing `/prompts/clusters/buffer-write-sinks.md` to get the root (the home dirs are searched before `.` so an installed copy wins over any vendored copy in the audited repo).
 
-Set `C_REVIEW_PLUGIN_ROOT` to the resolved root. If all three fail, **abort** with a message naming the roots searched — do not enter Phase 4 with an empty variable (every `python3 "${C_REVIEW_PLUGIN_ROOT}/scripts/..."` call would fail with a confusing path error).
+Set `C_REVIEW_PLUGIN_ROOT` to the resolved root. If all three fail, **abort** with a message naming the roots searched — do not enter Phase 4 with an empty variable (every `uv run --no-project "${C_REVIEW_PLUGIN_ROOT}/scripts/..."` call would fail with a confusing path error).
 
 **Scope convention:** keep two scopes separate throughout the run:
 
@@ -149,7 +149,7 @@ Write `${output_dir}/context.md` with: YAML frontmatter (`threat_model`, `severi
 Selection, filtering, path resolution, and spawn-prompt rendering are **delegated to the script** to prevent the "orchestrator paraphrases the spawn template and drops fields" failure mode:
 
 ```bash
-python3 "${C_REVIEW_PLUGIN_ROOT}/scripts/build_run_plan.py" \
+uv run --no-project "${C_REVIEW_PLUGIN_ROOT}/scripts/build_run_plan.py" \
   --plugin-root "${C_REVIEW_PLUGIN_ROOT}" --output-dir "${output_dir}" \
   --threat-model "${threat_model}" --severity-filter "${severity_filter}" \
   --scope-subpath "${finding_scope_root:-.}" --context-roots "${context_roots:-.}" \
@@ -254,21 +254,21 @@ Then re-spawn each `pending` retryable with `attempt <= 2` in one parallel block
 For every provisional `complete:` cluster, validate the worker-owned shard, coverage file, coverage rows, filed IDs, and claimed finding count against `plan.json` before marking the task completed. Run one command per completed worker, or one command with repeated flags for all provisional completions:
 
 ```bash
-python3 "${C_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
+uv run --no-project "${C_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
   --worker worker-N --claimed-count worker-N=<claimed_count_from_complete_line>
 ```
 
 Grouped claimed-count values are valid:
 
 ```bash
-python3 "${C_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
+uv run --no-project "${C_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
   --claimed-count worker-1=0 worker-2=3
 ```
 
 Repeated `--claimed-count` flags are also valid:
 
 ```bash
-python3 "${C_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
+uv run --no-project "${C_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
   --claimed-count worker-1=0 --claimed-count worker-2=3
 ```
 
@@ -337,7 +337,7 @@ Each judge's full protocol is its system prompt (`agents/c-review-{dedup,fp}-jud
 **Entry:** fp-judge returned, or the run aborted early. **Exit:** `${output_dir}/REPORT.sarif` and `${output_dir}/REPORT.md` both exist.
 
 ```bash
-test -d "${output_dir}/findings" && python3 "${C_REVIEW_PLUGIN_ROOT}/scripts/generate_sarif.py" "${output_dir}"
+test -d "${output_dir}/findings" && uv run --no-project "${C_REVIEW_PLUGIN_ROOT}/scripts/generate_sarif.py" "${output_dir}"
 ```
 
 Run the SARIF generator unconditionally whenever `findings/` exists — it is idempotent (full overwrite), emits `results: []` for zero-survivor runs, and handles partial runs (findings without `fp_verdict` are emitted as `LIKELY_TP`, **exempt from the `severity_filter`** since their severity was never judge-validated, and marked `unjudged: true` / `severity_validated: false` with an `[UNVALIDATED SEVERITY — not judged]` message prefix — so an inferred severity guess can never silently drop them under a `medium`/`high` filter). Always overwriting protects against an fp-judge that crashed mid-write and left a corrupt `REPORT.sarif` on disk.

--- a/plugins/c-review/skills/c-review/SKILL.md
+++ b/plugins/c-review/skills/c-review/SKILL.md
@@ -93,7 +93,7 @@ After resolving `scope_subpath`, set `finding_scope_root="${scope_subpath:-.}"`.
 
 **Entry:** Phase 0 complete. **Exit:** `is_cpp`, `is_posix`, `is_windows` flags determined.
 
-First confirm `uv` is present (`command -v uv`) — every helper script in Phases 4-6 runs
+First confirm `uv` is present (`command -v uv`) — every helper script from Phase 4 onward runs
 through it. If missing, **abort** and tell the user to install it (`brew install uv` or
 the official installer); nothing downstream can run without it.
 

--- a/plugins/c-review/skills/c-review/SKILL.md
+++ b/plugins/c-review/skills/c-review/SKILL.md
@@ -93,6 +93,10 @@ After resolving `scope_subpath`, set `finding_scope_root="${scope_subpath:-.}"`.
 
 **Entry:** Phase 0 complete. **Exit:** `is_cpp`, `is_posix`, `is_windows` flags determined.
 
+First confirm `uv` is present (`command -v uv`) — every helper script in Phases 4-6 runs
+through it. If missing, **abort** and tell the user to install it (`brew install uv` or
+the official installer); nothing downstream can run without it.
+
 Probe within `${finding_scope_root:-.}` with the `Bash` commands below (non-empty output ⇒ flag true). The dedicated `Grep`/`Glob` tools are unavailable to this orchestrator because it holds `Bash` — use `grep`/`rg`/`find` via `Bash`. (If a probe regex uses `\s`/`\b` and your `grep` lacks GNU `\s` support, run it with `rg -uu` — which honors `\s` and still searches ignored files — or replace `\s`→`[[:space:]]` and drop `\b`. Widening is safe: a false-positive flag only adds a harmless worker, a missed match would skip a pass.):
 
 ```bash

--- a/plugins/constant-time-analysis/.claude-plugin/plugin.json
+++ b/plugins/constant-time-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-time-analysis",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Detect compiler-induced timing side-channels in cryptographic code",
   "author": {
     "name": "Scott Arciszewski",

--- a/plugins/constant-time-analysis/README.md
+++ b/plugins/constant-time-analysis/README.md
@@ -26,7 +26,7 @@ The infamous [KyberSlash](https://kyberslash.cr.yp.to/) attack demonstrated how 
 
 ```bash
 # Install
-uv pip install -e .
+uv sync
 
 # Analyze a C file
 ct-analyzer crypto.c
@@ -322,7 +322,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e .
+          uv sync
 
       - name: Check constant-time properties
         run: |
@@ -335,7 +335,7 @@ jobs:
 ct-check:
   stage: test
   script:
-    - uv pip install -e .
+    - uv sync
     - ct-analyzer --json src/crypto/*.c > ct-report.json
   artifacts:
     reports:
@@ -366,7 +366,7 @@ ct-check:
 ## Running Tests
 
 ```bash
-python3 ct_analyzer/tests/test_analyzer.py
+uv run python ct_analyzer/tests/test_analyzer.py
 ```
 
 ## References

--- a/plugins/constant-time-analysis/README.md
+++ b/plugins/constant-time-analysis/README.md
@@ -336,6 +336,7 @@ ct-check:
   stage: test
   script:
     - uv tool install .
+    - export PATH="$HOME/.local/bin:$PATH"
     - ct-analyzer --json src/crypto/*.c > ct-report.json
   artifacts:
     reports:

--- a/plugins/constant-time-analysis/README.md
+++ b/plugins/constant-time-analysis/README.md
@@ -323,6 +323,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv tool install .
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check constant-time properties
         run: |

--- a/plugins/constant-time-analysis/README.md
+++ b/plugins/constant-time-analysis/README.md
@@ -26,7 +26,7 @@ The infamous [KyberSlash](https://kyberslash.cr.yp.to/) attack demonstrated how 
 
 ```bash
 # Install
-uv sync
+uv tool install .
 
 # Analyze a C file
 ct-analyzer crypto.c
@@ -193,7 +193,7 @@ Python analysis uses the built-in `dis` module to analyze CPython bytecode.
 **Requirements:**
 ```bash
 # Python 3.x required (built-in dis module)
-python3 --version
+uv run python --version
 ```
 
 ### Ruby Analysis
@@ -322,7 +322,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync
+          uv tool install .
 
       - name: Check constant-time properties
         run: |
@@ -335,7 +335,7 @@ jobs:
 ct-check:
   stage: test
   script:
-    - uv sync
+    - uv tool install .
     - ct-analyzer --json src/crypto/*.c > ct-report.json
   artifacts:
     reports:

--- a/plugins/constant-time-analysis/ct_analyzer/analyzer.py
+++ b/plugins/constant-time-analysis/ct_analyzer/analyzer.py
@@ -13,20 +13,20 @@ across multiple architectures (x86_64, arm64, arm, riscv64, etc.) to detect
 instructions that could leak timing information about secret data.
 
 Usage:
-    python ct_analyzer/analyzer.py [options] <source_file>
+    uv run ct-analyzer [options] <source_file>
 
 Examples:
     # Analyze a C file with default settings (clang, native arch)
-    python ct_analyzer/analyzer.py crypto.c
+    uv run ct-analyzer crypto.c
 
     # Analyze with specific compiler and optimization level
-    python ct_analyzer/analyzer.py --compiler gcc --opt-level O2 crypto.c
+    uv run ct-analyzer --compiler gcc --opt-level O2 crypto.c
 
     # Analyze a Go file for arm64
-    python ct_analyzer/analyzer.py --arch arm64 crypto.go
+    uv run ct-analyzer --arch arm64 crypto.go
 
     # Analyze with warnings enabled (shows conditional branches)
-    python ct_analyzer/analyzer.py --warnings crypto.c
+    uv run ct-analyzer --warnings crypto.c
 """
 
 import argparse

--- a/plugins/constant-time-analysis/ct_analyzer/script_analyzers.py
+++ b/plugins/constant-time-analysis/ct_analyzer/script_analyzers.py
@@ -1697,7 +1697,9 @@ class PythonAnalyzer(ScriptAnalyzer):
     }
 
     def __init__(self, python_path: str | None = None):
-        self.python_path = python_path or "python3"
+        # sys.executable, not "python3": the analyzer already runs under uv, and the
+        # modern-python shims refuse a bare `python3 --version` probe.
+        self.python_path = python_path or sys.executable or "python3"
 
     def is_available(self) -> bool:
         """Check if Python is available."""

--- a/plugins/constant-time-analysis/uv.lock
+++ b/plugins/constant-time-analysis/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "ct-analyzer"
 version = "0.1.0"

--- a/plugins/culture-index/.claude-plugin/plugin.json
+++ b/plugins/culture-index/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "culture-index",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Interprets Culture Index survey results for individuals and teams",
   "author": {
     "name": "Dan Guido"

--- a/plugins/culture-index/skills/interpreting-culture-index/SKILL.md
+++ b/plugins/culture-index/skills/interpreting-culture-index/SKILL.md
@@ -122,7 +122,7 @@ When given a PDF:
 1. Check if JSON already exists (same directory as PDF, or ask user)
 2. If not, run extraction with verification:
    ```bash
-   uv run {baseDir}/scripts/extract_pdf.py --verify /path/to/file.pdf [output.json]
+   uv run --no-project {baseDir}/scripts/extract_pdf.py --verify /path/to/file.pdf [output.json]
    ```
 3. Visually confirm the verification summary matches the PDF
 4. Use the extracted JSON for interpretation
@@ -144,7 +144,7 @@ Vision may be used ONLY to verify extracted values look reasonable, NOT to extra
    - Check if user provided JSON path
 2. **If only PDF:** Run extraction script with `--verify` flag
    ```bash
-   uv run {baseDir}/scripts/extract_pdf.py --verify /path/to/file.pdf [output.json]
+   uv run --no-project {baseDir}/scripts/extract_pdf.py --verify /path/to/file.pdf [output.json]
    ```
 3. **If extraction fails:** Report error, do NOT fall back to vision
 

--- a/plugins/culture-index/skills/interpreting-culture-index/SKILL.md
+++ b/plugins/culture-index/skills/interpreting-culture-index/SKILL.md
@@ -127,7 +127,7 @@ When given a PDF:
 3. Visually confirm the verification summary matches the PDF
 4. Use the extracted JSON for interpretation
 
-**If uv is not installed:** Stop and instruct user to install it (`brew install uv` or `pip install uv`). Do NOT fall back to vision.
+**If uv is not installed:** Stop and instruct user to install it (`brew install uv` or `curl -LsSf https://astral.sh/uv/install.sh | sh`). Do NOT fall back to vision.
 
 **PDF Vision (Reference Only)**
 

--- a/plugins/culture-index/skills/interpreting-culture-index/scripts/check_deps.py
+++ b/plugins/culture-index/skills/interpreting-culture-index/scripts/check_deps.py
@@ -86,7 +86,7 @@ def main() -> int:
 
     if missing_python:
         print(f"\n  Python packages: {', '.join(missing_python)}", file=sys.stderr)
-        print("  Install with: uv pip install .", file=sys.stderr)
+        print("  Install with: uv sync (in the scripts directory)", file=sys.stderr)
 
     if missing_system:
         print(f"\n  System tools: {', '.join(missing_system)}", file=sys.stderr)

--- a/plugins/culture-index/skills/interpreting-culture-index/scripts/check_deps.py
+++ b/plugins/culture-index/skills/interpreting-culture-index/scripts/check_deps.py
@@ -86,7 +86,10 @@ def main() -> int:
 
     if missing_python:
         print(f"\n  Python packages: {', '.join(missing_python)}", file=sys.stderr)
-        print("  Install with: uv sync (in the scripts directory)", file=sys.stderr)
+        print(
+            "  Run via uv run --project on the scripts directory (deps are declared there)",
+            file=sys.stderr,
+        )
 
     if missing_system:
         print(f"\n  System tools: {', '.join(missing_system)}", file=sys.stderr)

--- a/plugins/culture-index/skills/interpreting-culture-index/scripts/culture_index/opencv_extractor.py
+++ b/plugins/culture-index/skills/interpreting-culture-index/scripts/culture_index/opencv_extractor.py
@@ -138,7 +138,8 @@ def _extract_text_from_region(img_rgb: np.ndarray, region: tuple[int, int, int, 
         if "pytesseract not installed" not in str(_extraction_warnings):
             _extraction_warnings.append(
                 "pytesseract not installed - text extraction disabled. "
-                "Install with: uv add pytesseract && brew install tesseract"
+                "pytesseract is declared in scripts/pyproject.toml — run via uv run "
+                "--project on that directory; brew install tesseract for the binary"
             )
         return ""
 

--- a/plugins/culture-index/skills/interpreting-culture-index/scripts/culture_index/opencv_extractor.py
+++ b/plugins/culture-index/skills/interpreting-culture-index/scripts/culture_index/opencv_extractor.py
@@ -138,7 +138,7 @@ def _extract_text_from_region(img_rgb: np.ndarray, region: tuple[int, int, int, 
         if "pytesseract not installed" not in str(_extraction_warnings):
             _extraction_warnings.append(
                 "pytesseract not installed - text extraction disabled. "
-                "Install with: pip install pytesseract && brew install tesseract"
+                "Install with: uv add pytesseract && brew install tesseract"
             )
         return ""
 

--- a/plugins/culture-index/skills/interpreting-culture-index/workflows/extract-from-pdf.md
+++ b/plugins/culture-index/skills/interpreting-culture-index/workflows/extract-from-pdf.md
@@ -14,7 +14,7 @@ Extract Culture Index profile data from a PDF file and convert to JSON format.
 Single command, no setup required:
 
 ```bash
-uv run {baseDir}/scripts/extract_pdf.py --verify /path/to/profile.pdf
+uv run --no-project {baseDir}/scripts/extract_pdf.py --verify /path/to/profile.pdf
 ```
 
 **Options:**
@@ -24,13 +24,13 @@ uv run {baseDir}/scripts/extract_pdf.py --verify /path/to/profile.pdf
 **Examples:**
 ```bash
 # Extract with verification (recommended)
-uv run {baseDir}/scripts/extract_pdf.py --verify profile.pdf
+uv run --no-project {baseDir}/scripts/extract_pdf.py --verify profile.pdf
 
 # Extract and save to file
-uv run {baseDir}/scripts/extract_pdf.py profile.pdf output.json
+uv run --no-project {baseDir}/scripts/extract_pdf.py profile.pdf output.json
 
 # Extract and pipe to jq
-uv run {baseDir}/scripts/extract_pdf.py profile.pdf | jq '.survey'
+uv run --no-project {baseDir}/scripts/extract_pdf.py profile.pdf | jq '.survey'
 ```
 
 ## What Happens

--- a/plugins/culture-index/skills/interpreting-culture-index/workflows/extract-from-pdf.md
+++ b/plugins/culture-index/skills/interpreting-culture-index/workflows/extract-from-pdf.md
@@ -5,7 +5,7 @@ Extract Culture Index profile data from a PDF file and convert to JSON format.
 ## Prerequisites
 
 **Required:**
-- `uv` - Install with `brew install uv` or `pip install uv`
+- `uv` - Install with `brew install uv` or `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - `poppler` - Install with `brew install poppler` (macOS) or `apt install poppler-utils` (Ubuntu)
 - `tesseract` - Install with `brew install tesseract` (macOS) or `apt install tesseract-ocr` (Ubuntu)
 

--- a/plugins/rust-review/.claude-plugin/plugin.json
+++ b/plugins/rust-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-review",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Comprehensive Rust security code review with specialized bug-finding agents covering the safe/unsafe boundary, memory safety in unsafe blocks, concurrency, panic-induced DoS, recursion-induced stack overflow, FFI, and async runtime hazards",
   "author": {
     "name": "Andrea Cappa (Aptos Labs) & Paweł Płatek (Trail of Bits)"

--- a/plugins/rust-review/agents/rust-review-fp-judge.md
+++ b/plugins/rust-review/agents/rust-review-fp-judge.md
@@ -295,7 +295,7 @@ For each reported finding, include the key body sections (Description / Code / D
 Do **not** hand-write SARIF JSON. After all primary finding frontmatter has `fp_verdict` and survivor frontmatter has `severity`, `attack_vector`, and `exploitability`, run:
 
 ```bash
-python3 "{sarif_generator_path}" "{output_dir}"
+uv run --no-project "{sarif_generator_path}" "{output_dir}"
 ```
 
 The generator reads `{output_dir}/context.md` and the canonical `findings-index.txt` when present (falling back to `findings/*.md` only if the index is absent), applies the same `severity_filter` used for `REPORT.md`, and includes survivor primaries (`TRUE_POSITIVE` / `LIKELY_TP`). A merged non-primary (`merged_into`) is normally excluded, **unless** its merge target did not survive (FP-rejected or missing) — then the merged finding is re-emitted (with a stderr note) so a real bug is never silently dropped because dedup pointed it at a later-rejected target. It writes `{output_dir}/REPORT.sarif`.

--- a/plugins/rust-review/scripts/build_run_plan.py
+++ b/plugins/rust-review/scripts/build_run_plan.py
@@ -21,7 +21,7 @@ file, or invalid flag combination — so the orchestrator can rely on its
 output without further validation.
 
 Usage:
-    python3 build_run_plan.py \\
+    uv run --no-project build_run_plan.py \\
         --plugin-root /abs/plugins/rust-review \\
         --output-dir /abs/.rust-review-results/<ts> \\
         --threat-model REMOTE \\

--- a/plugins/rust-review/scripts/generate_sarif.py
+++ b/plugins/rust-review/scripts/generate_sarif.py
@@ -6,8 +6,8 @@
 """Generate rust-review SARIF from finding frontmatter.
 
 Usage:
-    python3 generate_sarif.py /path/to/output_dir
-    python3 generate_sarif.py /path/to/output_dir --output /tmp/REPORT.sarif
+    uv run --no-project generate_sarif.py /path/to/output_dir
+    uv run --no-project generate_sarif.py /path/to/output_dir --output /tmp/REPORT.sarif
 """
 
 from __future__ import annotations

--- a/plugins/rust-review/skills/rust-review/SKILL.md
+++ b/plugins/rust-review/skills/rust-review/SKILL.md
@@ -48,7 +48,7 @@ Output directory contains: `context.md`, `plan.json`, `worker-prompts/`, `findin
 2. **Codex** — `${CODEX_PLUGIN_ROOT}` (set it the same way if that var is present and resolves the marker).
 3. **Fallback search** — covers Codex installs under `~/.codex`, Claude installs under `~/.claude`, and a local checkout / repo run: `Bash: find ~/.claude ~/.codex . -path '*/plugins/rust-review/prompts/clusters/unsafe-boundary.md' -print -quit 2>/dev/null`. Take the match and strip the trailing `/prompts/clusters/unsafe-boundary.md` to get the root (the home dirs are searched before `.` so an installed copy wins over any vendored copy in the audited repo).
 
-Set `RUST_REVIEW_PLUGIN_ROOT` to the resolved root. If all three fail, **abort** with a message naming the roots searched — do not enter Phase 4 with an empty variable (every `python3 "${RUST_REVIEW_PLUGIN_ROOT}/scripts/..."` call would fail with a confusing path error).
+Set `RUST_REVIEW_PLUGIN_ROOT` to the resolved root. If all three fail, **abort** with a message naming the roots searched — do not enter Phase 4 with an empty variable (every `uv run --no-project "${RUST_REVIEW_PLUGIN_ROOT}/scripts/..."` call would fail with a confusing path error).
 
 **Scope convention:** keep two scopes separate throughout the run:
 
@@ -167,7 +167,7 @@ Write `${output_dir}/context.md` with: YAML frontmatter (`threat_model`, `severi
 Selection, filtering, path resolution, and spawn-prompt rendering are **delegated to the script** to keep spawn prompts complete and consistent:
 
 ```bash
-python3 "${RUST_REVIEW_PLUGIN_ROOT}/scripts/build_run_plan.py" \
+uv run --no-project "${RUST_REVIEW_PLUGIN_ROOT}/scripts/build_run_plan.py" \
   --plugin-root "${RUST_REVIEW_PLUGIN_ROOT}" --output-dir "${output_dir}" \
   --threat-model "${threat_model}" --severity-filter "${severity_filter}" \
   --scope-subpath "${finding_scope_root:-.}" --context-roots "${context_roots:-.}" \
@@ -274,18 +274,18 @@ Then re-spawn each `pending` retryable with `attempt <= 2` in one parallel block
 For every provisional `complete:` cluster, validate the worker-owned shard, coverage file, coverage rows, filed IDs, and claimed finding count against `plan.json` before marking the task completed. Run one command per completed worker, or validate multiple workers in one command. Both claimed-count forms below are valid; do not pass bare `worker-N=N` values without either grouping them after a `--claimed-count` flag or repeating the flag.
 
 ```bash
-python3 "${RUST_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
+uv run --no-project "${RUST_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
   --worker worker-N --claimed-count worker-N=<claimed_count_from_complete_line>
 ```
 
 ```bash
-python3 "${RUST_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
+uv run --no-project "${RUST_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
   --worker worker-1 --worker worker-2 \
   --claimed-count worker-1=0 worker-2=3
 ```
 
 ```bash
-python3 "${RUST_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
+uv run --no-project "${RUST_REVIEW_PLUGIN_ROOT}/scripts/validate_artifacts.py" "${output_dir}/plan.json" \
   --worker worker-1 --worker worker-2 \
   --claimed-count worker-1=0 --claimed-count worker-2=3
 ```
@@ -353,7 +353,7 @@ Each judge's full protocol is its system prompt (`agents/rust-review-{dedup,fp}-
 **Entry:** fp-judge returned, or the run aborted early. **Exit:** `${output_dir}/REPORT.sarif` and `${output_dir}/REPORT.md` both exist.
 
 ```bash
-test -d "${output_dir}/findings" && python3 "${RUST_REVIEW_PLUGIN_ROOT}/scripts/generate_sarif.py" "${output_dir}"
+test -d "${output_dir}/findings" && uv run --no-project "${RUST_REVIEW_PLUGIN_ROOT}/scripts/generate_sarif.py" "${output_dir}"
 ```
 
 Run the SARIF generator unconditionally whenever `findings/` exists — it is idempotent (full overwrite), emits `results: []` for zero-survivor runs, and handles partial runs (findings without `fp_verdict` are emitted as `LIKELY_TP`, **exempt from the `severity_filter`** since their severity was never judge-validated, and marked `unjudged: true` / `severity_validated: false` with an `[UNVALIDATED SEVERITY — not judged]` message prefix — so an inferred severity guess can never silently drop them under a `medium`/`high` filter). Always overwriting protects against an fp-judge that crashed mid-write and left a corrupt `REPORT.sarif` on disk.

--- a/plugins/rust-review/skills/rust-review/SKILL.md
+++ b/plugins/rust-review/skills/rust-review/SKILL.md
@@ -98,7 +98,7 @@ After resolving `scope_subpath`, set `finding_scope_root="${scope_subpath:-.}"`.
 
 **Entry:** Phase 0 complete. **Exit:** `has_unsafe`, `has_ffi`, `has_concurrency`, `has_async`, `has_packed_repr`, `has_fs_io` flags determined. Abort with a clear message if no `*.rs` files exist under `${finding_scope_root}`.
 
-First confirm `uv` is present (`command -v uv`) — every helper script in Phases 4-6 runs
+First confirm `uv` is present (`command -v uv`) — every helper script from Phase 4 onward runs
 through it. If missing, **abort** and tell the user to install it (`brew install uv` or
 the official installer); nothing downstream can run without it.
 

--- a/plugins/rust-review/skills/rust-review/SKILL.md
+++ b/plugins/rust-review/skills/rust-review/SKILL.md
@@ -98,6 +98,10 @@ After resolving `scope_subpath`, set `finding_scope_root="${scope_subpath:-.}"`.
 
 **Entry:** Phase 0 complete. **Exit:** `has_unsafe`, `has_ffi`, `has_concurrency`, `has_async`, `has_packed_repr`, `has_fs_io` flags determined. Abort with a clear message if no `*.rs` files exist under `${finding_scope_root}`.
 
+First confirm `uv` is present (`command -v uv`) — every helper script in Phases 4-6 runs
+through it. If missing, **abort** and tell the user to install it (`brew install uv` or
+the official installer); nothing downstream can run without it.
+
 Probe within `${finding_scope_root:-.}` with the `Bash` commands below (non-empty output ⇒ flag true). The dedicated `Grep`/`Glob` tools are unavailable to this orchestrator because it holds `Bash` — use `grep`/`rg`/`find` via `Bash`. (The probe regexes use `\s`/`\b`; if your `grep` lacks GNU `\s` support, run them with `rg -uu` — which honors `\s` and still searches ignored files — or, if `rg` is not installed either, replace `\s`→`[[:space:]]` and drop `\b`. Widening is safe here: a false-positive capability flag only adds a harmless extra worker, whereas a missed match would skip a whole pass.)
 
 ```bash

--- a/plugins/semgrep-rule-creator/.claude-plugin/plugin.json
+++ b/plugins/semgrep-rule-creator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semgrep-rule-creator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Create custom Semgrep rules for detecting bug patterns and security vulnerabilities",
   "author": {
     "name": "Maciej Domanski"

--- a/plugins/semgrep-rule-creator/README.md
+++ b/plugins/semgrep-rule-creator/README.md
@@ -28,7 +28,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-- [Semgrep](https://semgrep.dev/docs/getting-started/) installed (`pip install semgrep` or `brew install semgrep`)
+- [Semgrep](https://semgrep.dev/docs/getting-started/) installed (`uv tool install semgrep` or `brew install semgrep`)
 
 ## Installation
 

--- a/plugins/static-analysis/.claude-plugin/plugin.json
+++ b/plugins/static-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "static-analysis",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Static analysis toolkit with CodeQL, Semgrep, and SARIF parsing for security vulnerability detection",
   "author": {
     "name": "Axel Mierczuk & Paweł Płatek"

--- a/plugins/static-analysis/skills/codeql/references/build-fixes.md
+++ b/plugins/static-analysis/skills/codeql/references/build-fixes.md
@@ -41,6 +41,9 @@ log_step "Applying fix: install dependencies"
 FAILED_INSTALLS=()
 
 # Python — use target project's package manager (pip/uv/poetry)
+# allow-legacy-python: this installs the ANALYSED project's dependencies so CodeQL can
+# extract it. That project is arbitrary and may not be uv-managed, so substituting uv here
+# would change its build and risk an incomplete database.
 if [ -f requirements.txt ]; then
   run_logged pip install -r requirements.txt || FAILED_INSTALLS+=("pip install -r requirements.txt")
 fi

--- a/plugins/static-analysis/skills/codeql/references/build-fixes.md
+++ b/plugins/static-analysis/skills/codeql/references/build-fixes.md
@@ -41,9 +41,7 @@ log_step "Applying fix: install dependencies"
 FAILED_INSTALLS=()
 
 # Python — use target project's package manager (pip/uv/poetry)
-# allow-legacy-python: this installs the ANALYSED project's dependencies so CodeQL can
-# extract it. That project is arbitrary and may not be uv-managed, so substituting uv here
-# would change its build and risk an incomplete database.
+# allow-legacy-python: installs the analysed project's own deps; forcing uv could change its build.
 if [ -f requirements.txt ]; then
   run_logged pip install -r requirements.txt || FAILED_INSTALLS+=("pip install -r requirements.txt")
 fi

--- a/plugins/static-analysis/skills/codeql/references/quality-assessment.md
+++ b/plugins/static-analysis/skills/codeql/references/quality-assessment.md
@@ -161,8 +161,7 @@ fi
 log_step "Quality improvement: install type stubs/additional deps"
 
 # Python type stubs — install into target project's environment
-# allow-legacy-python: installs stubs and deps into the ANALYSED project's environment;
-# that project is arbitrary and may not be uv-managed.
+# allow-legacy-python: installs into the analysed project's environment, which may not be uv-managed.
 STUBS_INSTALLED=""
 for stub in types-requests types-PyYAML types-redis; do
   if pip install "$stub" 2>/dev/null; then

--- a/plugins/static-analysis/skills/codeql/references/quality-assessment.md
+++ b/plugins/static-analysis/skills/codeql/references/quality-assessment.md
@@ -161,6 +161,8 @@ fi
 log_step "Quality improvement: install type stubs/additional deps"
 
 # Python type stubs — install into target project's environment
+# allow-legacy-python: installs stubs and deps into the ANALYSED project's environment;
+# that project is arbitrary and may not be uv-managed.
 STUBS_INSTALLED=""
 for stub in types-requests types-PyYAML types-redis; do
   if pip install "$stub" 2>/dev/null; then

--- a/plugins/static-analysis/skills/codeql/references/quality-assessment.md
+++ b/plugins/static-analysis/skills/codeql/references/quality-assessment.md
@@ -171,6 +171,7 @@ done
 log_result "Installed type stubs:$STUBS_INSTALLED"
 
 # Additional project dependencies
+# allow-legacy-python: the analysed project's own editable install.
 run_logged pip install -e . || log_result "WARNING: pip install -e . failed — extraction may stay incomplete"
 ```
 

--- a/plugins/static-analysis/skills/codeql/scripts/test_generation_scripts.py
+++ b/plugins/static-analysis/skills/codeql/scripts/test_generation_scripts.py
@@ -160,6 +160,7 @@ def _fake_uv(directory: Path) -> Path:
     """
     directory.mkdir(parents=True, exist_ok=True)
     script = directory / "uv"
+    # allow-legacy-python: a test stub standing in for uv itself, run with a controlled PATH.
     script.write_text(
         "#!/bin/sh\n"
         '[ "$1" = "run" ] && shift\n'

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -73,8 +73,8 @@ Tools report different paths (`/path/to/project/` vs `/github/workspace/`), so p
 | Use Case | Tool | Installation |
 |----------|------|--------------|
 | Quick CLI queries | jq | `brew install jq` / `apt install jq` |
-| Python scripting (simple) | pysarif | `pip install pysarif` |
-| Python scripting (advanced) | sarif-tools | `pip install sarif-tools` |
+| Python scripting (simple) | pysarif | `uv add pysarif` |
+| Python scripting (advanced) | sarif-tools | `uv tool install sarif-tools` |
 | .NET applications | SARIF SDK | NuGet package |
 | JavaScript/Node.js | sarif-js | npm package |
 | Go applications | garif | `go get github.com/chavacava/garif` |
@@ -370,7 +370,7 @@ def safe_get_location(result: dict) -> tuple[str, int]:
 For very large SARIF files (100MB+):
 
 ```python
-import ijson  # pip install ijson
+import ijson  # uv add ijson
 
 def stream_results(sarif_path: str):
     """Stream results without loading entire file."""
@@ -390,7 +390,7 @@ npm install -g ajv-cli
 ajv validate -s sarif-schema-2.1.0.json -d results.sarif
 
 # Using Python jsonschema
-pip install jsonschema
+uv add jsonschema
 ```
 
 ```python

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -73,8 +73,8 @@ Tools report different paths (`/path/to/project/` vs `/github/workspace/`), so p
 | Use Case | Tool | Installation |
 |----------|------|--------------|
 | Quick CLI queries | jq | `brew install jq` / `apt install jq` |
-| Python scripting (simple) | pysarif | `uv run --with pysarif python …` |
-| Python scripting (advanced) | sarif-tools | `uv run --with sarif-tools python …` |
+| Python scripting (simple) | pysarif | `uv run --with pysarif python script.py` |
+| Python scripting (advanced) | sarif-tools | `uv run --with sarif-tools python script.py` |
 | .NET applications | SARIF SDK | NuGet package |
 | JavaScript/Node.js | sarif-js | npm package |
 | Go applications | garif | `go get github.com/chavacava/garif` |
@@ -390,7 +390,7 @@ npm install -g ajv-cli
 ajv validate -s sarif-schema-2.1.0.json -d results.sarif
 
 # Using Python jsonschema
-uv run --with jsonschema python validate_sarif.py
+uv run --with jsonschema python check_sarif.py   # any script importing jsonschema, e.g. below
 ```
 
 ```python

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -70,7 +70,7 @@ Tools report different paths (`/path/to/project/` vs `/github/workspace/`), so p
 
 ## Tool Selection Guide
 
-| Use Case | Tool | Installation |
+| Use Case | Tool | Install / run |
 |----------|------|--------------|
 | Quick CLI queries | jq | `brew install jq` / `apt install jq` |
 | Python scripting (simple) | pysarif | `uv run --with pysarif python script.py` |
@@ -390,7 +390,7 @@ npm install -g ajv-cli
 ajv validate -s sarif-schema-2.1.0.json -d results.sarif
 
 # Using Python jsonschema
-uv run --with jsonschema python check_sarif.py   # any script importing jsonschema, e.g. below
+uv run --with jsonschema python your_script.py   # e.g. the function below
 ```
 
 ```python

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -73,8 +73,8 @@ Tools report different paths (`/path/to/project/` vs `/github/workspace/`), so p
 | Use Case | Tool | Installation |
 |----------|------|--------------|
 | Quick CLI queries | jq | `brew install jq` / `apt install jq` |
-| Python scripting (simple) | pysarif | `uv add pysarif` |
-| Python scripting (advanced) | sarif-tools | `uv tool install sarif-tools` |
+| Python scripting (simple) | pysarif | `uv run --with pysarif python …` |
+| Python scripting (advanced) | sarif-tools | `uv run --with sarif-tools python …` |
 | .NET applications | SARIF SDK | NuGet package |
 | JavaScript/Node.js | sarif-js | npm package |
 | Go applications | garif | `go get github.com/chavacava/garif` |
@@ -370,7 +370,7 @@ def safe_get_location(result: dict) -> tuple[str, int]:
 For very large SARIF files (100MB+):
 
 ```python
-import ijson  # uv add ijson
+import ijson  # run via: uv run --with ijson
 
 def stream_results(sarif_path: str):
     """Stream results without loading entire file."""
@@ -390,7 +390,7 @@ npm install -g ajv-cli
 ajv validate -s sarif-schema-2.1.0.json -d results.sarif
 
 # Using Python jsonschema
-uv add jsonschema
+uv run --with jsonschema python validate_sarif.py
 ```
 
 ```python

--- a/plugins/static-analysis/skills/sarif-parsing/resources/sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/sarif_helpers.py
@@ -306,7 +306,7 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) < 2:
-        print("Usage: python sarif_helpers.py <sarif_file>")
+        print("Usage: uv run --no-project sarif_helpers.py <sarif_file>")
         sys.exit(1)
 
     sarif = load_sarif(sys.argv[1])

--- a/plugins/static-analysis/skills/semgrep/SKILL.md
+++ b/plugins/static-analysis/skills/semgrep/SKILL.md
@@ -191,11 +191,11 @@ selection itself matters and you want to see and edit the list first.
 
 ```bash
 # run-all
-uv run {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
+uv run --no-project {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
   --scans "$OUTPUT_DIR/scans.json"
 
 # important-only, once the JSON post-filter has run over every file in raw/
-uv run {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
+uv run --no-project {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
   --important --scans "$OUTPUT_DIR/scans.json"
 ```
 

--- a/plugins/static-analysis/skills/semgrep/scripts/merge_sarif.py
+++ b/plugins/static-analysis/skills/semgrep/scripts/merge_sarif.py
@@ -5,7 +5,7 @@
 """Merge SARIF files into a single consolidated output.
 
 Usage:
-    uv run merge_sarif.py RAW_DIR OUTPUT_FILE [--important] [--scans scans.json]
+    uv run --no-project merge_sarif.py RAW_DIR OUTPUT_FILE [--important] [--scans scans.json]
 
 Reads *.sarif files from RAW_DIR (e.g., $OUTPUT_DIR/raw), produces
 OUTPUT_FILE (e.g., $OUTPUT_DIR/results/results.sarif) containing all

--- a/plugins/static-analysis/skills/semgrep/scripts/test_merge_sarif.py
+++ b/plugins/static-analysis/skills/semgrep/scripts/test_merge_sarif.py
@@ -123,7 +123,7 @@ def semgrep_bin() -> str:
     if not found:
         raise AssertionError(
             "semgrep is not installed, so the JSON/SARIF contract went unverified. "
-            "Install it (pip install semgrep) — this suite must not pass without it."
+            "Install it (uv tool install semgrep) — this suite must not pass without it."
         )
     return found
 

--- a/plugins/static-analysis/skills/semgrep/workflows/scan-workflow.md
+++ b/plugins/static-analysis/skills/semgrep/workflows/scan-workflow.md
@@ -320,11 +320,11 @@ do not need re-verifying.
 
 ```bash
 # run-all
-uv run {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
+uv run --no-project {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
   --scans "$OUTPUT_DIR/scans.json"
 
 # important-only, once the post-filter above has run over every file in raw/
-uv run {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
+uv run --no-project {baseDir}/scripts/merge_sarif.py "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results/results.sarif" \
   --important --scans "$OUTPUT_DIR/scans.json"
 ```
 

--- a/plugins/static-analysis/tests/run_scan_tests.sh
+++ b/plugins/static-analysis/tests/run_scan_tests.sh
@@ -9,6 +9,11 @@
 # assertions execute than are written.
 set -uo pipefail
 
+command -v uv >/dev/null 2>&1 || {
+  echo "uv is required (https://docs.astral.sh/uv/)" >&2
+  exit 1
+}
+
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/skills/semgrep/scripts/run-scans.sh"
 readonly EXPECTED_ASSERTIONS=78

--- a/plugins/static-analysis/tests/run_scan_tests.sh
+++ b/plugins/static-analysis/tests/run_scan_tests.sh
@@ -492,7 +492,7 @@ MERGE="$PLUGIN_ROOT/skills/semgrep/scripts/merge_sarif.py"
 printf '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"semgrep","rules":[]}},"results":[]}]}\n' \
   >"$FRAW/python-good.sarif"
 cp "$FRAW/python-good.sarif" "$FRAW/python-broken.sarif"
-MERGE_ERR=$(python3 "$MERGE" "$FRAW" "$WORK/filter/results.sarif" --important 2>&1 >/dev/null)
+MERGE_ERR=$(uv run --no-project "$MERGE" "$FRAW" "$WORK/filter/results.sarif" --important 2>&1 >/dev/null)
 ok "$([ -e "$WORK/filter/results.sarif" ] && echo 1 || echo 0)" \
   "the merge must write nothing while a scan is unfiltered"
 contains "$MERGE_ERR" "python-broken-important.json" \

--- a/plugins/testing-handbook-skills/.claude-plugin/plugin.json
+++ b/plugins/testing-handbook-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "testing-handbook-skills",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Skills from the Trail of Bits Application Security Testing Handbook (appsec.guide)",
   "author": {
     "name": "Paweł Płatek"

--- a/plugins/testing-handbook-skills/skills/atheris/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/atheris/SKILL.md
@@ -65,6 +65,7 @@ Atheris supports 32-bit and 64-bit Linux, and macOS. We recommend fuzzing on Lin
 ### Linux/macOS
 
 ```bash
+uv init --bare   # once, if the harness directory is not yet a uv project
 uv add atheris
 ```
 

--- a/plugins/testing-handbook-skills/skills/atheris/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/atheris/SKILL.md
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
 Run:
 ```bash
-python fuzz.py
+uv run python fuzz.py
 ```
 
 ## Installation
@@ -65,7 +65,7 @@ Atheris supports 32-bit and 64-bit Linux, and macOS. We recommend fuzzing on Lin
 ### Linux/macOS
 
 ```bash
-uv pip install atheris
+uv add atheris
 ```
 
 ### Docker Environment (Recommended)
@@ -232,10 +232,11 @@ export LDSHARED="clang -shared"
 
 Install the extension from source:
 ```bash
-CBOR2_BUILD_C_EXTENSION=1 python -m pip install --no-binary cbor2 cbor2==5.6.4
+CBOR2_BUILD_C_EXTENSION=1 uv add --no-binary-package cbor2 'cbor2==5.6.4'
 ```
 
-The `--no-binary` flag ensures the C extension is compiled locally with instrumentation.
+The `--no-binary-package` flag ensures the C extension is compiled locally with
+instrumentation rather than pulled as a prebuilt wheel.
 
 Create `cbor2-fuzz.py`:
 ```python
@@ -262,7 +263,7 @@ if __name__ == "__main__":
 
 Run:
 ```bash
-python cbor2-fuzz.py
+uv run python cbor2-fuzz.py
 ```
 
 > **Important:** When running locally (not in Docker), you must [set `LD_PRELOAD` manually](https://github.com/google/atheris/blob/master/native_extension_fuzzing.md#option-a-sanitizerlibfuzzer-preloads).
@@ -280,14 +281,14 @@ echo '{"key": "value"}' > corpus/seed2
 
 Run with corpus:
 ```bash
-python fuzz.py corpus/
+uv run python fuzz.py corpus/
 ```
 
 ### Corpus Minimization
 
 Atheris inherits corpus minimization from libFuzzer:
 ```bash
-python fuzz.py -merge=1 new_corpus/ old_corpus/
+uv run python fuzz.py -merge=1 new_corpus/ old_corpus/
 ```
 
 > **See Also:** For corpus creation strategies, dictionaries, and seed selection,
@@ -298,26 +299,26 @@ python fuzz.py -merge=1 new_corpus/ old_corpus/
 ### Basic Run
 
 ```bash
-python fuzz.py
+uv run python fuzz.py
 ```
 
 ### With Corpus Directory
 
 ```bash
-python fuzz.py corpus/
+uv run python fuzz.py corpus/
 ```
 
 ### Common Options
 
 ```bash
 # Run for 10 minutes
-python fuzz.py -max_total_time=600
+uv run python fuzz.py -max_total_time=600
 
 # Limit input size
-python fuzz.py -max_len=1024
+uv run python fuzz.py -max_len=1024
 
 # Run with multiple workers
-python fuzz.py -workers=4 -jobs=4
+uv run python fuzz.py -workers=4 -jobs=4
 ```
 
 ### Interpreting Output

--- a/plugins/testing-handbook-skills/skills/atheris/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/atheris/SKILL.md
@@ -237,7 +237,9 @@ CBOR2_BUILD_C_EXTENSION=1 uv add --no-binary-package cbor2 'cbor2==5.6.4'
 ```
 
 The `--no-binary-package` flag ensures the C extension is compiled locally with
-instrumentation rather than pulled as a prebuilt wheel.
+instrumentation rather than pulled as a prebuilt wheel. Persist that choice with
+`no-binary-package = ["cbor2"]` under `[tool.uv]` in `pyproject.toml`, or a later
+`uv sync` can silently swap in an uninstrumented wheel.
 
 Create `cbor2-fuzz.py`:
 ```python

--- a/plugins/testing-handbook-skills/skills/coverage-analysis/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/coverage-analysis/SKILL.md
@@ -214,6 +214,7 @@ llvm-cov show ./fuzz_exec \
 ```bash
 # Install gcovr (uv manages the isolated environment)
 uv tool install gcovr
+export PATH="$HOME/.local/bin:$PATH"   # uv's tool bin, if not already present
 
 # Generate report
 gcovr --gcov-executable "llvm-cov gcov" \

--- a/plugins/testing-handbook-skills/skills/coverage-analysis/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/coverage-analysis/SKILL.md
@@ -212,10 +212,8 @@ llvm-cov show ./fuzz_exec \
 
 **GCC with gcovr:**
 ```bash
-# Install gcovr (via pip for latest version)
-python3 -m venv venv
-source venv/bin/activate
-pip3 install gcovr
+# Install gcovr (uv manages the isolated environment)
+uv tool install gcovr
 
 # Generate report
 gcovr --gcov-executable "llvm-cov gcov" \

--- a/plugins/testing-handbook-skills/skills/ossfuzz/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/ossfuzz/SKILL.md
@@ -45,11 +45,11 @@ OSS-Fuzz provides a simple CLI framework for building and starting harnesses or 
 | Task | Command |
 |------|---------|
 | Clone OSS-Fuzz | `git clone https://github.com/google/oss-fuzz` |
-| Build project image | `python3 infra/helper.py build_image --pull <project>` |
-| Build fuzzers with ASan | `python3 infra/helper.py build_fuzzers --sanitizer=address <project>` |
-| Run specific harness | `python3 infra/helper.py run_fuzzer <project> <harness>` |
-| Generate coverage report | `python3 infra/helper.py coverage <project>` |
-| Check helper.py options | `python3 infra/helper.py --help` |
+| Build project image | `uv run --no-project python infra/helper.py build_image --pull <project>` |
+| Build fuzzers with ASan | `uv run --no-project python infra/helper.py build_fuzzers --sanitizer=address <project>` |
+| Run specific harness | `uv run --no-project python infra/helper.py run_fuzzer <project> <harness>` |
+| Generate coverage report | `uv run --no-project python infra/helper.py coverage <project>` |
+| Check helper.py options | `uv run --no-project python infra/helper.py --help` |
 
 ## OSS-Fuzz Project Components
 
@@ -87,13 +87,13 @@ You don't need to host the whole OSS-Fuzz platform to use it. The helper script 
 ```bash
 git clone https://github.com/google/oss-fuzz
 cd oss-fuzz
-python3 infra/helper.py --help
+uv run --no-project python infra/helper.py --help
 ```
 
 ### Step 2: Build Project Image
 
 ```bash
-python3 infra/helper.py build_image --pull <project-name>
+uv run --no-project python infra/helper.py build_image --pull <project-name>
 ```
 
 This downloads and builds the base Docker image for the project.
@@ -101,7 +101,7 @@ This downloads and builds the base Docker image for the project.
 ### Step 3: Build Fuzzers with Sanitizers
 
 ```bash
-python3 infra/helper.py build_fuzzers --sanitizer=address <project-name>
+uv run --no-project python infra/helper.py build_fuzzers --sanitizer=address <project-name>
 ```
 
 **Sanitizer options:**
@@ -113,7 +113,7 @@ python3 infra/helper.py build_fuzzers --sanitizer=address <project-name>
 ### Step 4: Run the Fuzzer
 
 ```bash
-python3 infra/helper.py run_fuzzer <project-name> <harness-name> [<fuzzer-args>]
+uv run --no-project python infra/helper.py run_fuzzer <project-name> <harness-name> [<fuzzer-args>]
 ```
 
 The helper script automatically runs any missed steps if you skip them.
@@ -123,8 +123,8 @@ The helper script automatically runs any missed steps if you skip them.
 First, [install gsutil](https://cloud.google.com/storage/docs/gsutil_install) (skip gcloud initialization).
 
 ```bash
-python3 infra/helper.py build_fuzzers --sanitizer=coverage <project-name>
-python3 infra/helper.py coverage <project-name>
+uv run --no-project python infra/helper.py build_fuzzers --sanitizer=coverage <project-name>
+uv run --no-project python infra/helper.py coverage <project-name>
 ```
 
 Use `--no-corpus-download` to use only local corpus. The command generates and hosts a coverage report locally.
@@ -143,9 +143,9 @@ git clone https://github.com/google/oss-fuzz
 cd oss-fuzz
 
 # Build and run irssi fuzzer
-python3 infra/helper.py build_image --pull irssi
-python3 infra/helper.py build_fuzzers --sanitizer=address irssi
-python3 infra/helper.py run_fuzzer irssi irssi-fuzz
+uv run --no-project python infra/helper.py build_image --pull irssi
+uv run --no-project python infra/helper.py build_fuzzers --sanitizer=address irssi
+uv run --no-project python infra/helper.py run_fuzzer irssi irssi-fuzz
 ```
 
 **Expected Output:**
@@ -283,6 +283,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
 **Build in build.sh:**
 ```bash
+# allow-legacy-python: build.sh runs inside the oss-fuzz base-builder container, where our
+# PATH shims are absent and pip is what the image provides.
 $CXX $CXXFLAGS -std=c++11 -I. \
     harness.cc -o $OUT/harness \
     $LIB_FUZZING_ENGINE ./libproject.a
@@ -339,6 +341,8 @@ if __name__ == "__main__":
 
 **Build in build.sh:**
 ```bash
+# allow-legacy-python: build.sh runs inside the oss-fuzz base-builder container, where our
+# PATH shims are absent and pip is what the image provides.
 pip3 install .
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/plugins/testing-handbook-skills/skills/ossfuzz/SKILL.md
+++ b/plugins/testing-handbook-skills/skills/ossfuzz/SKILL.md
@@ -283,8 +283,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
 **Build in build.sh:**
 ```bash
-# allow-legacy-python: build.sh runs inside the oss-fuzz base-builder container, where our
-# PATH shims are absent and pip is what the image provides.
 $CXX $CXXFLAGS -std=c++11 -I. \
     harness.cc -o $OUT/harness \
     $LIB_FUZZING_ENGINE ./libproject.a
@@ -341,8 +339,7 @@ if __name__ == "__main__":
 
 **Build in build.sh:**
 ```bash
-# allow-legacy-python: build.sh runs inside the oss-fuzz base-builder container, where our
-# PATH shims are absent and pip is what the image provides.
+# allow-legacy-python: build.sh runs inside the oss-fuzz container, where the shims are absent.
 pip3 install .
 for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
   compile_python_fuzzer $fuzzer

--- a/plugins/testing-handbook-skills/skills/testing-handbook-generator/testing.md
+++ b/plugins/testing-handbook-skills/skills/testing-handbook-generator/testing.md
@@ -8,12 +8,8 @@ Required tools for validation:
 
 ### Python Dependencies
 
-Install from the scripts directory:
-
-```bash
-cd plugins/testing-handbook-skills/scripts
-uv sync
-```
+None to install: the scripts carry PEP 723 inline metadata, so `uv run scripts/<name>.py`
+resolves everything on first use.
 
 ### Optional Tools
 

--- a/plugins/testing-handbook-skills/skills/testing-handbook-generator/testing.md
+++ b/plugins/testing-handbook-skills/skills/testing-handbook-generator/testing.md
@@ -12,7 +12,7 @@ Install from the scripts directory:
 
 ```bash
 cd plugins/testing-handbook-skills/scripts
-uv pip install .
+uv sync
 ```
 
 ### Optional Tools

--- a/plugins/trailmark/.claude-plugin/plugin.json
+++ b/plugins/trailmark/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trailmark",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Builds multi-language source and binary code graphs for security analysis: call graphs, attack surface mapping, blast radius, taint propagation, complexity hotspots, entry point enumeration, proxy/unresolved-call tracking, type/reference analysis, and structural diffs. Creates bounded, graph-informed source packets for delegating focused work to constrained subagents. Generates Mermaid diagrams, runs graph-informed mutation testing triage (genotoxic), generates mutation-driven test vectors (vector-forge), extracts crypto protocol message flows, converts Mermaid diagrams to ProVerif models, projects SARIF/weAudit/binary findings onto code graphs, triages single findings with graph evidence, gates branch diffs for structural review regressions, and expands seed findings into variant-neighborhood candidates. Use when analyzing call paths, slicing source context for smaller models, mapping attack surface, visualizing code architecture, triaging survived mutants, generating cryptographic test vectors, diagramming crypto protocols, formally verifying protocols, augmenting audits with static analysis findings, deciding whether one candidate issue is reachable, reviewing graph-level PR risk, or seeding variant analysis.",
   "author": {
     "name": "Scott Arciszewski",

--- a/plugins/trailmark/README.md
+++ b/plugins/trailmark/README.md
@@ -46,6 +46,7 @@ gate v0.5 features on the version number, not `hasattr()`.
 
 ```bash
 uv tool install trailmark
+# Python snippets: uv run --with trailmark python -   (a tool env is not importable)
 ```
 
 ## Skills

--- a/plugins/trailmark/README.md
+++ b/plugins/trailmark/README.md
@@ -45,7 +45,7 @@ gate v0.5 features on the version number, not `hasattr()`.
 [Trailmark](https://pypi.org/project/trailmark/) ([source](https://github.com/trailofbits/trailmark)) must be installed:
 
 ```bash
-uv pip install trailmark
+uv tool install trailmark
 ```
 
 ## Skills

--- a/plugins/trailmark/skills/audit-augmentation/SKILL.md
+++ b/plugins/trailmark/skills/audit-augmentation/SKILL.md
@@ -53,7 +53,7 @@ also import an external binary-analysis graph JSON export via
 **MANDATORY:** If `uv run trailmark` fails, install trailmark first:
 
 ```bash
-uv pip install trailmark
+uv tool install trailmark
 ```
 
 ## Version Gate

--- a/plugins/trailmark/skills/audit-augmentation/SKILL.md
+++ b/plugins/trailmark/skills/audit-augmentation/SKILL.md
@@ -54,6 +54,7 @@ also import an external binary-analysis graph JSON export via
 
 ```bash
 uv tool install trailmark
+# Python snippets: uv run --with trailmark python -   (a tool env is not importable)
 ```
 
 ## Version Gate

--- a/plugins/trailmark/skills/diagramming-code/SKILL.md
+++ b/plugins/trailmark/skills/diagramming-code/SKILL.md
@@ -37,7 +37,7 @@ script.
 **trailmark** must be installed. If `uv run trailmark` fails, run:
 
 ```bash
-uv pip install trailmark
+uv tool install trailmark
 ```
 
 **DO NOT** fall back to hand-writing Mermaid from source code reading. The

--- a/plugins/trailmark/skills/diagramming-code/SKILL.md
+++ b/plugins/trailmark/skills/diagramming-code/SKILL.md
@@ -38,6 +38,7 @@ script.
 
 ```bash
 uv tool install trailmark
+# Python snippets: uv run --with trailmark python -   (a tool env is not importable)
 ```
 
 **DO NOT** fall back to hand-writing Mermaid from source code reading. The

--- a/plugins/trailmark/skills/genotoxic/SKILL.md
+++ b/plugins/trailmark/skills/genotoxic/SKILL.md
@@ -28,7 +28,7 @@ false positives, missing unit tests, and fuzzing targets.
 
 - **trailmark** installed — if `uv run trailmark` fails, run:
   ```bash
-  uv pip install trailmark
+  uv tool install trailmark
   ```
   **DO NOT** fall back to "manual verification" or "manual analysis"
   as a substitute for running trailmark. Install it first. If installation

--- a/plugins/trailmark/skills/genotoxic/SKILL.md
+++ b/plugins/trailmark/skills/genotoxic/SKILL.md
@@ -29,6 +29,7 @@ false positives, missing unit tests, and fuzzing targets.
 - **trailmark** installed — if `uv run trailmark` fails, run:
   ```bash
   uv tool install trailmark
+# Python snippets: uv run --with trailmark python -   (a tool env is not importable)
   ```
   **DO NOT** fall back to "manual verification" or "manual analysis"
   as a substitute for running trailmark. Install it first. If installation

--- a/plugins/trailmark/skills/graph-evolution/SKILL.md
+++ b/plugins/trailmark/skills/graph-evolution/SKILL.md
@@ -52,6 +52,7 @@ taint propagation changes, and privilege boundary modifications.
 
 ```bash
 uv tool install trailmark
+# Python snippets: uv run --with trailmark python -   (a tool env is not importable)
 ```
 
 **DO NOT** fall back to "manual comparison" or reading source files as a

--- a/plugins/trailmark/skills/graph-evolution/SKILL.md
+++ b/plugins/trailmark/skills/graph-evolution/SKILL.md
@@ -51,7 +51,7 @@ taint propagation changes, and privilege boundary modifications.
 **trailmark** must be installed. If `uv run trailmark` fails, run:
 
 ```bash
-uv pip install trailmark
+uv tool install trailmark
 ```
 
 **DO NOT** fall back to "manual comparison" or reading source files as a

--- a/plugins/trailmark/skills/trailmark-structural/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-structural/SKILL.md
@@ -80,14 +80,14 @@ print(json.dumps(detect_languages(sys.argv[1])))
 PY
 ```
 
-If the import fails, rerun the same snippet with `uv run python - "{args}"`.
+If the import fails, rerun the same snippet with `uv run --with trailmark python - "{args}"`.
 If the result is `[]`, report "Trailmark found no supported languages under
 target" and return.
 
 **Step 3: Run the full structural analysis via `QueryEngine`.**
 
 Run this snippet with `python3`. If the import fails, rerun the same snippet
-under `uv run python - "{args}"`.
+under `uv run --with trailmark python - "{args}"`.
 
 ```bash
 python3 - "{args}" <<'PY'

--- a/plugins/trailmark/skills/trailmark-summary/SKILL.md
+++ b/plugins/trailmark/skills/trailmark-summary/SKILL.md
@@ -75,7 +75,7 @@ print(json.dumps(detect_languages(sys.argv[1])))
 PY
 ```
 
-If the import fails, rerun the same snippet with `uv run python - "{args}"`.
+If the import fails, rerun the same snippet with `uv run --with trailmark python - "{args}"`.
 If the result is `[]`, report "Trailmark found no supported languages under
 target" and return.
 

--- a/plugins/trailmark/skills/trailmark/SKILL.md
+++ b/plugins/trailmark/skills/trailmark/SKILL.md
@@ -44,12 +44,15 @@ semantic metadata for security analysis.
 
 ## Installation
 
-**MANDATORY:** If `uv run trailmark` fails (command not found, import error,
-ModuleNotFoundError), install trailmark before doing anything else:
+**MANDATORY:** If `trailmark` is not found, install the CLI before doing anything else:
 
 ```bash
 uv tool install trailmark
 ```
+
+A tool install provides the CLI only — it does not make `import trailmark` resolvable.
+Run the Python snippets in this skill with `uv run --with trailmark python -`; that, not
+installation, is the fix for an import error or ModuleNotFoundError in a snippet.
 
 **DO NOT** fall back to "manual verification", "manual analysis", or reading
 source files by hand as a substitute for running trailmark. The tool must be

--- a/plugins/trailmark/skills/trailmark/SKILL.md
+++ b/plugins/trailmark/skills/trailmark/SKILL.md
@@ -48,7 +48,7 @@ semantic metadata for security analysis.
 ModuleNotFoundError), install trailmark before doing anything else:
 
 ```bash
-uv pip install trailmark
+uv tool install trailmark
 ```
 
 **DO NOT** fall back to "manual verification", "manual analysis", or reading

--- a/plugins/trailmark/skills/vector-forge/SKILL.md
+++ b/plugins/trailmark/skills/vector-forge/SKILL.md
@@ -29,6 +29,7 @@ Measures effectiveness by comparing mutation kill rates before and after.
 - **trailmark** installed — if `uv run trailmark` fails, run:
   ```bash
   uv tool install trailmark
+# Python snippets: uv run --with trailmark python -   (a tool env is not importable)
   ```
 - At least one implementation of the target algorithm in a
   language with mutation testing support

--- a/plugins/trailmark/skills/vector-forge/SKILL.md
+++ b/plugins/trailmark/skills/vector-forge/SKILL.md
@@ -28,7 +28,7 @@ Measures effectiveness by comparing mutation kill rates before and after.
 
 - **trailmark** installed — if `uv run trailmark` fails, run:
   ```bash
-  uv pip install trailmark
+  uv tool install trailmark
   ```
 - At least one implementation of the target algorithm in a
   language with mutation testing support

--- a/plugins/variant-analysis/.claude-plugin/plugin.json
+++ b/plugins/variant-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "variant-analysis",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Find similar vulnerabilities and bugs across codebases using pattern-based analysis",
   "author": {
     "name": "Axel Mierczuk"

--- a/plugins/variant-analysis/tests/eval.sh
+++ b/plugins/variant-analysis/tests/eval.sh
@@ -23,6 +23,11 @@
 
 set -euo pipefail
 
+command -v uv >/dev/null 2>&1 || {
+  echo "uv is required (https://docs.astral.sh/uv/)" >&2
+  exit 1
+}
+
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="$(cd "$TESTS_DIR/.." && pwd)"
 GROUND_TRUTH="$TESTS_DIR/ground-truth.json"

--- a/plugins/variant-analysis/tests/eval.sh
+++ b/plugins/variant-analysis/tests/eval.sh
@@ -127,7 +127,7 @@ echo "eval output: $OUT_DIR"
 echo
 
 # Fail fast if the fixtures drifted — otherwise the whole run measures nothing.
-python3 "$TESTS_DIR/verify_fixtures.py" >"$OUT_DIR/fixtures.log" 2>&1 || {
+uv run --no-project "$TESTS_DIR/verify_fixtures.py" >"$OUT_DIR/fixtures.log" 2>&1 || {
   echo "fixture verification failed; see $OUT_DIR/fixtures.log" >&2
   exit 1
 }
@@ -206,7 +206,7 @@ for name in $CODEBASES; do
 
       # Did the run mutate the codebase it was auditing? Silent drift would make
       # every later run in this sweep grade against different code.
-      if ! python3 "$TESTS_DIR/verify_fixtures.py" >"$work/fixture-after.log" 2>&1; then
+      if ! uv run --no-project "$TESTS_DIR/verify_fixtures.py" >"$work/fixture-after.log" 2>&1; then
         echo "FIXTURE DRIFTED after this run — see $work/fixture-after.log" >&2
         echo "  restore with: ./setup-gradio.sh --force" >&2
         exit 1
@@ -222,7 +222,7 @@ for name in $CODEBASES; do
 
       set +e
       # shellcheck disable=SC2086  # $STRICT_FLAG is a bare flag or empty, by design
-      python3 "$TESTS_DIR/score.py" \
+      uv run --no-project "$TESTS_DIR/score.py" \
         --report "$work/REPORT.md" \
         --codebase "$name" \
         --ground-truth "$GROUND_TRUTH" \
@@ -258,9 +258,9 @@ echo "=== summary ==="
 # reporting where the artifacts landed.
 set +e
 if [ "$HAS_WORKFLOW" -eq 1 ]; then
-  python3 "$TESTS_DIR/summarize.py" "$SUMMARY"
+  uv run --no-project "$TESTS_DIR/summarize.py" "$SUMMARY"
 else
-  python3 "$TESTS_DIR/summarize.py" --baseline-only "$SUMMARY"
+  uv run --no-project "$TESTS_DIR/summarize.py" --baseline-only "$SUMMARY"
 fi
 rc=$?
 set -e

--- a/plugins/variant-analysis/tests/run_fixtures.sh
+++ b/plugins/variant-analysis/tests/run_fixtures.sh
@@ -15,13 +15,13 @@ set -euo pipefail
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "→ variant-analysis fixtures"
-python3 "$TESTS_DIR/verify_fixtures.py"
+uv run --no-project "$TESTS_DIR/verify_fixtures.py"
 
 echo "→ grader self-test"
-python3 "$TESTS_DIR/score.py" --self-test
+uv run --no-project "$TESTS_DIR/score.py" --self-test
 
 echo "→ aggregator self-test"
-python3 "$TESTS_DIR/summarize.py" --self-test
+uv run --no-project "$TESTS_DIR/summarize.py" --self-test
 
 # The workflow is not standalone-valid JS in either module system: the runtime
 # executes it as an async function body (so top-level `return` is legal) and

--- a/plugins/variant-analysis/tests/run_fixtures.sh
+++ b/plugins/variant-analysis/tests/run_fixtures.sh
@@ -6,7 +6,7 @@
 # must stay cheap and must never call Claude. The eval that does call Claude is
 # eval.sh, deliberately named so discovery skips it.
 #
-# Helpers run through uv (their PEP 723 headers carry the metadata); uv is required.
+# Helpers are stdlib-only and run through uv, which supplies the interpreter; uv is required.
 
 set -euo pipefail
 

--- a/plugins/variant-analysis/tests/run_fixtures.sh
+++ b/plugins/variant-analysis/tests/run_fixtures.sh
@@ -6,11 +6,14 @@
 # must stay cheap and must never call Claude. The eval that does call Claude is
 # eval.sh, deliberately named so discovery skips it.
 #
-# Invokes verify_fixtures.py as a file rather than piping to `python3 -`: the
-# modern-python plugin's shim intercepts stdin form and fails for reasons that
-# have nothing to do with the code under test (#207).
+# Helpers run through uv (their PEP 723 headers carry the metadata); uv is required.
 
 set -euo pipefail
+
+command -v uv >/dev/null 2>&1 || {
+  echo "uv is required (https://docs.astral.sh/uv/)" >&2
+  exit 1
+}
 
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/plugins/variant-analysis/tests/setup-gradio.sh
+++ b/plugins/variant-analysis/tests/setup-gradio.sh
@@ -67,4 +67,4 @@ git -C "$DEST" apply --check "$PATCH" || {
 git -C "$DEST" apply "$PATCH"
 
 echo "→ verifying"
-python3 "$TESTS_DIR/verify_fixtures.py"
+uv run --no-project "$TESTS_DIR/verify_fixtures.py"

--- a/plugins/variant-analysis/tests/setup-gradio.sh
+++ b/plugins/variant-analysis/tests/setup-gradio.sh
@@ -16,6 +16,11 @@
 
 set -euo pipefail
 
+command -v uv >/dev/null 2>&1 || {
+  echo "uv is required (https://docs.astral.sh/uv/)" >&2
+  exit 1
+}
+
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO="https://github.com/gradio-app/gradio.git"
 SHA="45c11d52e518a59ffaf1d688e13ceaafd7f1477c"

--- a/plugins/yara-authoring/.claude-plugin/plugin.json
+++ b/plugins/yara-authoring/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yara-authoring",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "YARA-X detection rule authoring with linting and quality analysis",
   "author": {
     "name": "Trail of Bits",

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
@@ -267,7 +267,7 @@ condition:
 yarGen extracts candidate strings, but you must validate:
 
 ```bash
-python yarGen.py -m /path/to/samples --excludegood
+uv run --no-project python yarGen.py -m /path/to/samples --excludegood
 ```
 
 **Expert heuristic:** yarGen output needs 80% filtering. Most suggestions are:

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
@@ -267,7 +267,7 @@ condition:
 yarGen extracts candidate strings, but you must validate:
 
 ```bash
-uv run --with-requirements requirements.txt python yarGen.py -m /path/to/samples --excludegood
+uv run --no-project --with-requirements requirements.txt python yarGen.py -m /path/to/samples --excludegood
 ```
 
 **Expert heuristic:** yarGen output needs 80% filtering. Most suggestions are:

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
@@ -267,6 +267,7 @@ condition:
 yarGen extracts candidate strings, but you must validate:
 
 ```bash
+# from the yarGen checkout, where requirements.txt lives
 uv run --no-project --with-requirements requirements.txt python yarGen.py -m /path/to/samples --excludegood
 ```
 

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/strings.md
@@ -267,7 +267,7 @@ condition:
 yarGen extracts candidate strings, but you must validate:
 
 ```bash
-uv run --no-project python yarGen.py -m /path/to/samples --excludegood
+uv run --with-requirements requirements.txt python yarGen.py -m /path/to/samples --excludegood
 ```
 
 **Expert heuristic:** yarGen output needs 80% filtering. Most suggestions are:

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/testing.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/testing.md
@@ -146,7 +146,7 @@ Before deployment, check strings against yarGen's goodware database:
 
 ```bash
 # Query strings against goodware database
-python db-lookup.py -f strings.txt
+uv run --no-project python db-lookup.py -f strings.txt
 ```
 
 Strings appearing in the database are likely to cause false positives.

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/testing.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/testing.md
@@ -146,7 +146,7 @@ Before deployment, check strings against yarGen's goodware database:
 
 ```bash
 # Query strings against goodware database
-uv run --with-requirements requirements.txt python db-lookup.py -f strings.txt
+uv run --no-project --with-requirements requirements.txt python db-lookup.py -f strings.txt
 ```
 
 Strings appearing in the database are likely to cause false positives.

--- a/plugins/yara-authoring/skills/yara-rule-authoring/references/testing.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/references/testing.md
@@ -146,7 +146,7 @@ Before deployment, check strings against yarGen's goodware database:
 
 ```bash
 # Query strings against goodware database
-uv run --no-project python db-lookup.py -f strings.txt
+uv run --with-requirements requirements.txt python db-lookup.py -f strings.txt
 ```
 
 Strings appearing in the database are likely to cause false positives.

--- a/plugins/yara-authoring/skills/yara-rule-authoring/workflows/rule-development.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/workflows/rule-development.md
@@ -104,10 +104,10 @@ yarGen extracts candidate strings but generates legacy YARA syntax. Always valid
 
 ```bash
 # Basic extraction
-python yarGen.py -m samples/ --excludegood -o candidate_rule.yar
+uv run --no-project python yarGen.py -m samples/ --excludegood -o candidate_rule.yar
 
 # Recommended flags
-python yarGen.py -m samples/ \
+uv run --no-project python yarGen.py -m samples/ \
     --excludegood \           # Filter against known goodware strings
     -g /path/to/good/files \  # Add custom goodware
     --nosimple \              # Exclude simple strings

--- a/plugins/yara-authoring/skills/yara-rule-authoring/workflows/rule-development.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/workflows/rule-development.md
@@ -104,10 +104,10 @@ yarGen extracts candidate strings but generates legacy YARA syntax. Always valid
 
 ```bash
 # Basic extraction
-uv run --no-project python yarGen.py -m samples/ --excludegood -o candidate_rule.yar
+uv run --with-requirements requirements.txt python yarGen.py -m samples/ --excludegood -o candidate_rule.yar
 
 # Recommended flags
-uv run --no-project python yarGen.py -m samples/ \
+uv run --with-requirements requirements.txt python yarGen.py -m samples/ \
     --excludegood \           # Filter against known goodware strings
     -g /path/to/good/files \  # Add custom goodware
     --nosimple \              # Exclude simple strings

--- a/plugins/yara-authoring/skills/yara-rule-authoring/workflows/rule-development.md
+++ b/plugins/yara-authoring/skills/yara-rule-authoring/workflows/rule-development.md
@@ -104,10 +104,11 @@ yarGen extracts candidate strings but generates legacy YARA syntax. Always valid
 
 ```bash
 # Basic extraction
-uv run --with-requirements requirements.txt python yarGen.py -m samples/ --excludegood -o candidate_rule.yar
+cd yarGen  # run from the yarGen checkout, where requirements.txt lives
+uv run --no-project --with-requirements requirements.txt python yarGen.py -m samples/ --excludegood -o candidate_rule.yar
 
 # Recommended flags
-uv run --with-requirements requirements.txt python yarGen.py -m samples/ \
+uv run --no-project --with-requirements requirements.txt python yarGen.py -m samples/ \
     --excludegood \           # Filter against known goodware strings
     -g /path/to/good/files \  # Add custom goodware
     --nosimple \              # Exclude simple strings

--- a/plugins/zeroize-audit/.claude-plugin/plugin.json
+++ b/plugins/zeroize-audit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroize-audit",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Detects missing or compiler-optimized zeroization of sensitive data with assembly and control-flow analysis",
   "author": {
     "name": "Trail of Bits",

--- a/plugins/zeroize-audit/README.md
+++ b/plugins/zeroize-audit/README.md
@@ -258,7 +258,7 @@ tools/diff_rust_mir.sh /tmp/crate.O0.mir /tmp/crate.O2.mir
 ```bash
 FLAGS=()
 while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-  python tools/extract_compile_flags.py \
+  uv run --no-project tools/extract_compile_flags.py \
     --compile-db build/compile_commands.json --src src/crypto.c --format lines)
 tools/emit_ir.sh --src src/crypto.c --out /tmp/crypto.O0.ll --opt O0 -- "${FLAGS[@]}"
 tools/emit_ir.sh --src src/crypto.c --out /tmp/crypto.O2.ll --opt O2 -- "${FLAGS[@]}"

--- a/plugins/zeroize-audit/agents/1-mcp-resolver.md
+++ b/plugins/zeroize-audit/agents/1-mcp-resolver.md
@@ -63,7 +63,7 @@ From the collected results, build:
 Pipe all raw MCP output through the normalizer:
 
 ```bash
-python {baseDir}/tools/mcp/normalize_mcp_evidence.py \
+uv run --no-project {baseDir}/tools/mcp/normalize_mcp_evidence.py \
   --input <raw_results> \
   --output <workdir>/mcp-evidence/symbols.json
 ```

--- a/plugins/zeroize-audit/agents/3-tu-compiler-analyzer.md
+++ b/plugins/zeroize-audit/agents/3-tu-compiler-analyzer.md
@@ -38,7 +38,7 @@ Read `config_path` to load the merged config. Read `input_file` to load `sensiti
 ```bash
 FLAGS=()
 while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-  python {baseDir}/tools/extract_compile_flags.py \
+  uv run --no-project {baseDir}/tools/extract_compile_flags.py \
     --compile-db <compile_db> \
     --src <tu_source> --format lines)
 ```
@@ -102,7 +102,7 @@ Assembly evidence is mandatory for both findings — **never** emit from source 
 Skip if `enable_semantic_ir=false`.
 
 ```bash
-python {baseDir}/tools/analyze_ir_semantic.py \
+uv run --no-project {baseDir}/tools/analyze_ir_semantic.py \
   --ir {workdir}/compiler-analysis/{tu_hash}/<tu_hash>.O2.ll \
   --out ${workdir}/compiler-analysis/<tu_hash>/semantic-ir.json
 ```
@@ -120,7 +120,7 @@ python {baseDir}/tools/analyze_ir_semantic.py \
 Skip if `enable_cfg=false`.
 
 ```bash
-python {baseDir}/tools/analyze_cfg.py \
+uv run --no-project {baseDir}/tools/analyze_cfg.py \
   --src <tu_source> \
   --out ${workdir}/compiler-analysis/<tu_hash>/cfg-findings.json
 ```

--- a/plugins/zeroize-audit/agents/4-report-assembler.md
+++ b/plugins/zeroize-audit/agents/4-report-assembler.md
@@ -74,7 +74,7 @@ For each supersession:
 Apply the confidence gating rules from the SKILL.md. Optionally use the mechanical enforcer:
 
 ```bash
-python {baseDir}/tools/mcp/apply_confidence_gates.py \
+uv run --no-project {baseDir}/tools/mcp/apply_confidence_gates.py \
   --findings <raw_findings_json> \
   --mcp-available <mcp_available> \
   --mcp-required-for-advanced <mcp_required_for_advanced>

--- a/plugins/zeroize-audit/agents/5-poc-generator.md
+++ b/plugins/zeroize-audit/agents/5-poc-generator.md
@@ -229,7 +229,7 @@ Generate `{poc_output_dir}/Makefile` that builds all PoC targets:
 
 1. Extract per-TU compile flags using:
    ```bash
-   python {baseDir}/tools/extract_compile_flags.py \
+   uv run --no-project {baseDir}/tools/extract_compile_flags.py \
      --compile-db <compile_db> --src <source_file> --format lines
    ```
 

--- a/plugins/zeroize-audit/skills/zeroize-audit/prompts/system.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/prompts/system.md
@@ -114,7 +114,7 @@ Agent `4-report-assembler` is invoked twice during a run:
 
 Quick check:
 ```bash
-which clang uvx python3   # C/C++
+which clang uv uvx python3   # C/C++
 cargo +nightly --version  # Rust
 uv --version              # Rust Python scripts
 ```

--- a/plugins/zeroize-audit/skills/zeroize-audit/prompts/system.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/prompts/system.md
@@ -114,7 +114,7 @@ Agent `4-report-assembler` is invoked twice during a run:
 
 Quick check:
 ```bash
-which clang uvx          # C/C++
+which clang uvx python3   # C/C++
 cargo +nightly --version  # Rust
 uv --version              # Rust Python scripts
 ```

--- a/plugins/zeroize-audit/skills/zeroize-audit/prompts/system.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/prompts/system.md
@@ -114,7 +114,7 @@ Agent `4-report-assembler` is invoked twice during a run:
 
 Quick check:
 ```bash
-which clang uvx python3   # C/C++
+which clang uvx          # C/C++
 cargo +nightly --version  # Rust
 uv --version              # Rust Python scripts
 ```

--- a/plugins/zeroize-audit/skills/zeroize-audit/references/compile-commands.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/references/compile-commands.md
@@ -72,7 +72,7 @@ bear -- cargo check
 bear -- cargo build   # if cargo check is insufficient
 
 # Option 2: compiledb
-pip install compiledb
+uv tool install compiledb
 compiledb cargo build
 ```
 
@@ -106,7 +106,7 @@ mkdir -p /tmp/zeroize-audit/
 # Step 1: Extract build-relevant flags for the TU (as a bash array)
 FLAGS=()
 while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-  python {baseDir}/tools/extract_compile_flags.py \
+  uv run --no-project {baseDir}/tools/extract_compile_flags.py \
     --compile-db /path/to/build/compile_commands.json \
     --src /path/to/src/crypto.c --format lines)
 

--- a/plugins/zeroize-audit/skills/zeroize-audit/references/compile-commands.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/references/compile-commands.md
@@ -73,6 +73,7 @@ bear -- cargo build   # if cargo check is insufficient
 
 # Option 2: compiledb
 uv tool install compiledb
+# ensure uv's tool bin dir (~/.local/bin) is on PATH
 compiledb cargo build
 ```
 

--- a/plugins/zeroize-audit/skills/zeroize-audit/references/detection-strategy.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/references/detection-strategy.md
@@ -42,7 +42,7 @@ Run this step **before** correctness validation so that resolved types, aliases,
 - For each sensitive object and wipe call, resolve symbol definitions using `find_symbol` (by name, with `include_body: true` for type details) and collect cross-file references using `find_referencing_symbols`.
 - Trace callers and cleanup paths using `find_referencing_symbols` on wipe wrapper functions. For outgoing calls, read the function body from `find_symbol` output and resolve called symbols.
 - Use `get_symbols_overview` to get a high-level view of symbols in a file when exploring unfamiliar TUs.
-- Normalize all MCP output: `python {baseDir}/tools/mcp/normalize_mcp_evidence.py`.
+- Normalize all MCP output: `uv run --no-project {baseDir}/tools/mcp/normalize_mcp_evidence.py`.
 
 Prioritize `find_symbol` queries by sensitive-object name first, then wipe wrapper names. Score confidence: name match alone → `needs_review`; name + type resolved → `likely`; name + type + call chain confirmed → `confirmed`.
 
@@ -84,7 +84,7 @@ For each TU containing sensitive objects:
 ```bash
 FLAGS=()
 while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-  python {baseDir}/tools/extract_compile_flags.py \
+  uv run --no-project {baseDir}/tools/extract_compile_flags.py \
     --compile-db <compile_db> --src <file> --format lines)
 
 {baseDir}/tools/emit_ir.sh --src <file> \
@@ -177,7 +177,7 @@ Output a `Makefile` in `{baseDir}/generated_tests/` that builds and runs all tes
 Generate proof-of-concept C programs for all findings regardless of confidence. Each PoC exits 0 (exploitable) or 1 (not exploitable):
 
 ```bash
-python {baseDir}/tools/generate_poc.py \
+uv run --no-project {baseDir}/tools/generate_poc.py \
   --findings <findings_json> \
   --compile-db <compile_db> \
   --out <poc_output_dir> \

--- a/plugins/zeroize-audit/skills/zeroize-audit/references/ir-analysis.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/references/ir-analysis.md
@@ -27,7 +27,7 @@ mkdir -p /tmp/zeroize-audit/
 
 FLAGS=()
 while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-  python {baseDir}/tools/extract_compile_flags.py \
+  uv run --no-project {baseDir}/tools/extract_compile_flags.py \
     --compile-db build/compile_commands.json \
     --src src/crypto.c --format lines)
 
@@ -192,7 +192,7 @@ When a cleanup wrapper (e.g., `zeroize_key()`) is inlined into a caller, the wip
 # Emit IR for the caller — inlining happens here:
 FLAGS=()
 while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-  python {baseDir}/tools/extract_compile_flags.py \
+  uv run --no-project {baseDir}/tools/extract_compile_flags.py \
     --compile-db build/compile_commands.json --src src/crypto.c --format lines)
 
 {baseDir}/tools/emit_ir.sh \

--- a/plugins/zeroize-audit/skills/zeroize-audit/references/mcp-analysis.md
+++ b/plugins/zeroize-audit/skills/zeroize-audit/references/mcp-analysis.md
@@ -159,7 +159,7 @@ Arguments:
 Before using any MCP results in confidence scoring or finding emission, normalize:
 
 ```bash
-python {baseDir}/tools/mcp/normalize_mcp_evidence.py \
+uv run --no-project {baseDir}/tools/mcp/normalize_mcp_evidence.py \
   --input /tmp/raw_mcp_results.json \
   --output /tmp/normalized_mcp_results.json
 ```
@@ -211,7 +211,7 @@ Apply downgrades after all evidence is collected, not during querying. Do not su
 After collecting all MCP evidence and running IR/ASM/CFG analysis, apply confidence gates mechanically:
 
 ```bash
-python {baseDir}/tools/mcp/apply_confidence_gates.py \
+uv run --no-project {baseDir}/tools/mcp/apply_confidence_gates.py \
   --input /tmp/raw-report.json \
   --out /tmp/final-report.json \
   --mcp-available \

--- a/plugins/zeroize-audit/skills/zeroize-audit/tools/extract_compile_flags.py
+++ b/plugins/zeroize-audit/skills/zeroize-audit/tools/extract_compile_flags.py
@@ -11,7 +11,7 @@ flags suitable for single-file LLVM IR or assembly emission via clang. Output
 and dependency-generation flags are stripped.
 
 Usage:
-  python extract_compile_flags.py \\
+  uv run --no-project extract_compile_flags.py \\
     --compile-db compile_commands.json \\
     --src path/to/file.c \\
     [--format shell|json|lines] \\
@@ -20,13 +20,13 @@ Usage:
   # Recommended: capture as a bash array (works in both bash and zsh):
   FLAGS=()
   while IFS= read -r flag; do FLAGS+=("$flag"); done < <(
-    python {baseDir}/tools/extract_compile_flags.py \\
+    uv run --no-project {baseDir}/tools/extract_compile_flags.py \\
       --compile-db build/compile_commands.json \\
       --src src/crypto.c --format lines)
   {baseDir}/tools/emit_ir.sh --src src/crypto.c --out /tmp/out.ll --opt O2 -- "${FLAGS[@]}"
 
   # Get as JSON list:
-  python {baseDir}/tools/extract_compile_flags.py \\
+  uv run --no-project {baseDir}/tools/extract_compile_flags.py \\
     --compile-db build/compile_commands.json \\
     --src src/crypto.c \\
     --format json

--- a/plugins/zeroize-audit/skills/zeroize-audit/tools/generate_poc.py
+++ b/plugins/zeroize-audit/skills/zeroize-audit/tools/generate_poc.py
@@ -11,7 +11,7 @@ data that should have been zeroized. PoCs exit 0 when the secret persists
 (exploitable) and exit 1 when the data has been wiped (not exploitable).
 
 Usage:
-  python generate_poc.py \\
+  uv run --no-project generate_poc.py \\
     --findings <findings.json> \\
     --compile-db <compile_commands.json> \\
     --out <output_dir> \\
@@ -83,7 +83,9 @@ def _load_config(config_path: str | None) -> dict[str, Any]:
         return {}
     path = Path(config_path)
     if yaml is None:
-        sys.stderr.write("Error: --config requires pyyaml. Install with: pip install pyyaml\n")
+        sys.stderr.write(
+            "Error: --config requires pyyaml. run via uv run --no-project, which provides pyyaml\n"
+        )
         sys.exit(1)
     if not path.exists():
         sys.stderr.write(f"Error: config file not found: {path}\n")

--- a/plugins/zeroize-audit/skills/zeroize-audit/tools/generate_poc.py
+++ b/plugins/zeroize-audit/skills/zeroize-audit/tools/generate_poc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # /// script
-# requires-python = ">=3.9"
+# requires-python = ">=3.10"
 # dependencies = ["pyyaml>=6.0"]
 # ///
 """


### PR DESCRIPTION
Our `modern-python` plugin ships PATH shims that refuse `python <script>`, `pip install`, `python -m pip` and `uv pip install`. **Twelve other plugins in this marketplace issued exactly those forms**, so installing our own plugin broke our own skills — with CI green the whole time.

The worst case is not theoretical. `c-review` and `rust-review` both call their Phase 4 planner as `python3 "${PLUGIN_ROOT}/scripts/build_run_plan.py"`, so with the shim installed **every run died before spawning a worker**. Verified both directions with the shim on PATH:

| | exit |
|---|---|
| `uv run --no-project .../build_run_plan.py --help` | 0 |
| `python3 .../build_run_plan.py --help` | 1 (refused) |

## Why this is not one substitution

Phase 1's reading pass named 16 skills. A mechanical sweep found **96 candidate lines across 44 files**, and adding shell scripts to the sweep found **10 more the docs-only pass had missed** — which is the argument for the check at the end rather than a hand-fix.

Four classes needed different treatment, and in two of them a careless rewrite would have been worse than the breakage:

- **Our own scripts** → `uv run --no-project <script>`. Not bare `uv run`: these execute inside the *target* repo, which may be a Python project that cannot resolve. Verified against a deliberately broken `pyproject.toml`, and against `validate_artifacts.py`'s sibling import of `generate_sarif`.
- **Package installs** → `uv add` for a dependency, `uv tool install` for a CLI, `uv sync` for a project's own editable install.
- **Third-party CLIs we merely document** (OSS-Fuzz's `infra/helper.py`, yarGen) → `uv run --no-project python <script>`, preserving upstream's exact semantics rather than handing their script an environment we manage. Verbose in a command table; correct everywhere else.
- **atheris's instrumented build** keeps its source build as `uv add --no-binary-package cbor2`. Dropping that flag would silently produce an *uninstrumented* fuzzer, which is worse than a visible failure. Its prose said "the `--no-binary` flag" and now names the flag it actually uses.

## Two factual corrections that fell out

`pip install caracal` was wrong twice over. Caracal has `Cargo.toml` and `Cargo.lock` at its root, so it is a Rust tool — a `uv tool install` would have fetched an unrelated PyPI package. It is now upstream's own `cargo install --git https://github.com/crytic/caracal --profile release --force`, quoted from their README.

`pip install uv` cannot bootstrap uv under a shim that intercepts pip, so `culture-index` now points at the official installer.

## Thirteen lines stay, each deliberately

Dockerfile `RUN` lines and oss-fuzz's `build.sh` run **inside containers**, where our shims are absent. `codeql`'s pip calls install the *analysed* project's dependencies, and that project is arbitrary and may not be uv-managed — substituting uv there would change its build and risk an incomplete database. `trailmark`'s dispatch skills must keep saying "Do NOT run `pip install`". And `modern-python` documents what it intercepts.

Each exemption is now **explicit** rather than an accident of regex: structural for `dockerfile` fences, and an `allow-legacy-python: <reason>` comment that scopes to its code block for the rest.

## Side effect: `make shell-suites` passes again

`plugins/variant-analysis/tests/` no longer invokes `python3 <script>.py`. Exit 0 with the 1.6.0 shim on PATH, exit 2 with the stale 1.5.3 one. AGENTS.md previously recorded this target as broken; that note is corrected.

## The guardrail

`find_legacy_python_invocations` scans **773 markdown, shell, and python files** and fails on the four refused forms. Error-level rather than a warning, which only became possible because everything else in this PR is fixed.

Eighteen-plus self-test fixtures cover it: nine assert it fires, nine assert it stays quiet on `uv run --no-project`, `uv add`, `python3 -c`, `uv pip --directory`, prose prohibitions, dockerfile fences and the allow-marker. Mutation-tested in both markdown and shell.

Worth recording that the check caught its own worst bug during development: with unanchored patterns it flagged `uv run --no-project python fuzz.py` — the very form its advice recommends — because that string contains `python fuzz.py`. The compliant-prefix guard exists for that reason.

Self-test goes 45 → 74 assertions across four review rounds, and the floor was mutation-tested (dropping fixtures reports "ran only 49, below the floor of 56").

## Verification

- Validator: zero errors, 1002 files scanned, the same 8 skill-length warnings as before and no new ones.
- `prek run -a`: all 15 hooks pass.
- `make check` still fails only at the **pre-existing** `constant-time-analysis` toolchain gap (28 failed / 94 passed, byte-identical to the baseline recorded before this branch). That plugin needs cross-compilation toolchains this machine lacks and CI installs.
- One flaky unrelated failure seen once and not reproducible: `writing-lean-proofs`' eval self-test shells out to `claude`, so it depends on a live model call.

Twelve plugins bumped in both `plugin.json` and `marketplace.json` — minor where a skill went from unusable to working, patch for install-form corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)