### PR TITLE
Close unterminated fences in cairo, algorand, and ton scanner skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "building-secure-contracts",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "description": "Comprehensive smart contract security toolkit based on Trail of Bits' Building Secure Contracts framework. Includes vulnerability scanners for 6 blockchains and 5 development guideline assistants.",
       "author": {
         "name": "Omar Inuwa && Pawe\u0142 P\u0142atek"

--- a/plugins/building-secure-contracts/.claude-plugin/plugin.json
+++ b/plugins/building-secure-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "building-secure-contracts",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Comprehensive smart contract security toolkit based on Trail of Bits' Building Secure Contracts framework. Includes vulnerability scanners for 6 blockchains and 5 development guideline assistants.",
   "author": {
     "name": "Omar Inuwa && Paweł Płatek",

--- a/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
@@ -175,7 +175,7 @@ For atomic transaction groups:
 ## 8. Reporting Format
 
 ### Finding Template
-```markdown
+````markdown
 ## [SEVERITY] Vulnerability Name (e.g., Missing RekeyTo Validation)
 
 **Location**: `contract.teal:45-50` or `approval_program.py:withdraw()`
@@ -209,7 +209,7 @@ If(And(
 **References**:
 - building-secure-contracts/not-so-smart-contracts/algorand/rekeying
 - Tealer detector: `unprotected-rekey`
-```
+````
 
 ---
 

--- a/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/algorand-vulnerability-scanner/SKILL.md
@@ -87,11 +87,11 @@ Code:
 
 Issue: The contract doesn't validate the RekeyTo field, allowing attackers
 to change account authorization and bypass restrictions.
-
+```
 
 ---
 
-## 5. Vulnerability Patterns (11 Patterns)
+## 6. Vulnerability Patterns (11 Patterns)
 
 I check for 11 critical vulnerability patterns unique to Algorand. For detailed detection patterns, code examples, mitigations, and testing strategies, see [VULNERABILITY_PATTERNS.md](resources/VULNERABILITY_PATTERNS.md).
 
@@ -110,7 +110,8 @@ I check for 11 critical vulnerability patterns unique to Algorand. For detailed 
 11. **Logic Signature Reuse** ⚠️ HIGH - Logic sigs without uniqueness constraints
 
 For complete vulnerability patterns with code examples, see [VULNERABILITY_PATTERNS.md](resources/VULNERABILITY_PATTERNS.md).
-## 5. Scanning Workflow
+
+## 7. Scanning Workflow
 
 ### Step 1: Platform Identification
 1. Confirm file extensions (`.teal`, `.py`)
@@ -171,7 +172,7 @@ For atomic transaction groups:
 
 ---
 
-## 6. Reporting Format
+## 8. Reporting Format
 
 ### Finding Template
 ```markdown
@@ -212,7 +213,7 @@ If(And(
 
 ---
 
-## 7. Priority Guidelines
+## 9. Priority Guidelines
 
 ### Critical (Immediate Fix Required)
 - Rekeying attacks
@@ -232,7 +233,7 @@ If(And(
 
 ---
 
-## 8. Testing Recommendations
+## 10. Testing Recommendations
 
 ### Unit Tests Required
 - Test each vulnerability scenario with PoC exploit
@@ -256,7 +257,7 @@ tealer approval.teal --detect all --fail-on critical,high
 
 ---
 
-## 9. Additional Resources
+## 11. Additional Resources
 
 - **Building Secure Contracts**: `building-secure-contracts/not-so-smart-contracts/algorand/`
 - **Tealer Documentation**: https://github.com/crytic/tealer
@@ -265,7 +266,7 @@ tealer approval.teal --detect all --fail-on critical,high
 
 ---
 
-## 10. Quick Reference Checklist
+## 12. Quick Reference Checklist
 
 Before completing Algorand audit, verify ALL items checked:
 

--- a/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
@@ -87,11 +87,11 @@ When vulnerabilities are found, you'll get a report like this:
 
 ```
 === CAIRO/STARKNET VULNERABILITY SCAN RESULTS ===
-
+```
 
 ---
 
-## 5. Vulnerability Patterns (6 Patterns)
+## 6. Vulnerability Patterns (6 Patterns)
 
 I check for 6 critical vulnerability patterns unique to Cairo/Starknet. For detailed detection patterns, code examples, mitigations, and testing strategies, see [VULNERABILITY_PATTERNS.md](resources/VULNERABILITY_PATTERNS.md).
 
@@ -105,7 +105,8 @@ I check for 6 critical vulnerability patterns unique to Cairo/Starknet. For deta
 6. **Missing Caller Validation** ⚠️ CRITICAL - No get_caller_address() checks
 
 For complete vulnerability patterns with code examples, see [VULNERABILITY_PATTERNS.md](resources/VULNERABILITY_PATTERNS.md).
-## 5. Scanning Workflow
+
+## 7. Scanning Workflow
 
 ### Step 1: Platform Identification
 1. Verify Cairo language and StarkNet framework
@@ -159,7 +160,7 @@ caracal detect src/ --detectors missing-nonce-validation
 
 ---
 
-## 6. Reporting Format
+## 8. Reporting Format
 
 ### Finding Template
 ```markdown
@@ -218,7 +219,7 @@ fn handle_deposit(
 
 ---
 
-## 7. Priority Guidelines
+## 9. Priority Guidelines
 
 ### Critical (Immediate Fix Required)
 - Unchecked from_address in L1 handlers (infinite mint)
@@ -234,7 +235,7 @@ fn handle_deposit(
 
 ---
 
-## 8. Testing Recommendations
+## 10. Testing Recommendations
 
 ### Unit Tests
 ```rust
@@ -285,7 +286,7 @@ fn test_deposit_withdraw_roundtrip() {
 
 ---
 
-## 9. Additional Resources
+## 11. Additional Resources
 
 - **Building Secure Contracts**: `building-secure-contracts/not-so-smart-contracts/cairo/`
 - **Caracal**: https://github.com/crytic/caracal
@@ -295,7 +296,7 @@ fn test_deposit_withdraw_roundtrip() {
 
 ---
 
-## 10. Quick Reference Checklist
+## 12. Quick Reference Checklist
 
 Before completing Cairo/StarkNet audit:
 

--- a/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/cairo-vulnerability-scanner/SKILL.md
@@ -163,7 +163,7 @@ caracal detect src/ --detectors missing-nonce-validation
 ## 8. Reporting Format
 
 ### Finding Template
-```markdown
+````markdown
 ## [CRITICAL] Unchecked from_address in L1 Handler
 
 **Location**: `src/bridge.cairo:145-155` (handle_deposit function)
@@ -215,7 +215,7 @@ fn handle_deposit(
 **References**:
 - building-secure-contracts/not-so-smart-contracts/cairo/unchecked_l1_handler_from
 - Caracal detector: `unchecked-l1-handler-from`
-```
+````
 
 ---
 

--- a/plugins/building-secure-contracts/skills/solana-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/solana-vulnerability-scanner/SKILL.md
@@ -186,7 +186,7 @@ solana-program = "1.17"  # Use latest version
 ## 8. Reporting Format
 
 ### Finding Template
-```markdown
+````markdown
 ## [CRITICAL] Arbitrary CPI - Unchecked Program ID
 
 **Location**: `programs/vault/src/lib.rs:145-160` (withdraw function)
@@ -256,7 +256,7 @@ pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> Result<()> {
 **References**:
 - building-secure-contracts/not-so-smart-contracts/solana/arbitrary_cpi
 - Trail of Bits lint: `unchecked-cpi-program-id`
-```
+````
 
 ---
 

--- a/plugins/building-secure-contracts/skills/ton-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/ton-vulnerability-scanner/SKILL.md
@@ -87,11 +87,11 @@ Vulnerabilities Found: 2
 [CRITICAL] Missing Replay Protection
 File: contracts/wallet.fc:45
 Pattern: No sequence number or nonce validation
-
+```
 
 ---
 
-## 5. Vulnerability Patterns (3 Patterns)
+## 6. Vulnerability Patterns (3 Patterns)
 
 I check for 3 critical vulnerability patterns unique to TON. For detailed detection patterns, code examples, mitigations, and testing strategies, see [VULNERABILITY_PATTERNS.md](resources/VULNERABILITY_PATTERNS.md).
 
@@ -102,7 +102,8 @@ I check for 3 critical vulnerability patterns unique to TON. For detailed detect
 3. **Improper Gas Handling** ⚠️ HIGH - Insufficient gas reservations
 
 For complete vulnerability patterns with code examples, see [VULNERABILITY_PATTERNS.md](resources/VULNERABILITY_PATTERNS.md).
-## 5. Scanning Workflow
+
+## 7. Scanning Workflow
 
 ### Step 1: Platform Identification
 1. Verify FunC language (`.fc` or `.func` files)
@@ -164,7 +165,7 @@ TON contracts require thorough manual review:
 
 ---
 
-## 6. Reporting Format
+## 8. Reporting Format
 
 ### Finding Template
 ```markdown
@@ -246,7 +247,7 @@ global slice jetton_wallet_address;
 
 ---
 
-## 7. Priority Guidelines
+## 9. Priority Guidelines
 
 ### Critical (Immediate Fix Required)
 - Fake Jetton contract (unauthorized minting/crediting)
@@ -257,7 +258,7 @@ global slice jetton_wallet_address;
 
 ---
 
-## 8. Testing Recommendations
+## 10. Testing Recommendations
 
 ### Unit Tests
 ```typescript
@@ -345,7 +346,7 @@ it("should accept transfer from real jetton wallet", async () => {
 
 ---
 
-## 9. Additional Resources
+## 11. Additional Resources
 
 - **Building Secure Contracts**: `building-secure-contracts/not-so-smart-contracts/ton/`
 - **TON Documentation**: https://docs.ton.org/
@@ -355,7 +356,7 @@ it("should accept transfer from real jetton wallet", async () => {
 
 ---
 
-## 10. Quick Reference Checklist
+## 12. Quick Reference Checklist
 
 Before completing TON contract audit:
 

--- a/plugins/building-secure-contracts/skills/ton-vulnerability-scanner/SKILL.md
+++ b/plugins/building-secure-contracts/skills/ton-vulnerability-scanner/SKILL.md
@@ -168,7 +168,7 @@ TON contracts require thorough manual review:
 ## 8. Reporting Format
 
 ### Finding Template
-```markdown
+````markdown
 ## [CRITICAL] Fake Jetton Contract - Missing Sender Validation
 
 **Location**: `contracts/staking.fc:85-95` (recv_internal, transfer_notification handler)
@@ -243,7 +243,7 @@ global slice jetton_wallet_address;
 
 **References**:
 - building-secure-contracts/not-so-smart-contracts/ton/fake_jetton_contract
-```
+````
 
 ---
 


### PR DESCRIPTION
Fixes #260

## What was wrong

The cairo, algorand, and ton scanner skills each opened a code fence for the "Example Output" report and never closed it, so a long stretch of each file rendered as one code block. Under a CommonMark parser, only 8 of each file's 12 `## N.` heading lines rendered as headings before this PR. Each file also carried three H2 sections numbered `## 5.`, and the "Scanning Workflow" heading was glued to the preceding paragraph with no blank line.

`solana-vulnerability-scanner` is the fourth sibling, repaired the same way in #160 — but see the second commit: it shared one further defect with the other three.

## What changed

**Commit 1** — one closing fence per file at the end of the surviving example report, plus an H2 renumber to 1..12 in document order matching solana:

| section | before | after |
|---|---|---|
| Example Output | 5 | 5 |
| Vulnerability Patterns | 5 | 6 |
| Scanning Workflow | 5 | 7 |
| Reporting Format | 6 | 8 |
| Priority Guidelines | 7 | 9 |
| Testing Recommendations | 8 | 10 |
| Additional Resources | 9 | 11 |
| Quick Reference Checklist | 10 | 12 |

**Commit 2** — widened the Finding Template's outer fence from ` ```markdown ` to four backticks in **all four** files, solana included. The template nests triple-backtick code snippets, and per CommonMark a closing fence must be bare — so the first bare ` ``` ` after a nested snippet closed the outer block early and a later bare fence swallowed `## 9.` and `## 10.` as code. After commit 1 the files rendered 10 of 12 sections; after commit 2, 12 of 12.

No prose was added or rewritten. Version bumped 1.1.3 → 1.1.4 in `plugin.json` and `marketplace.json`.

## What could not be recovered

The example reports are still truncated, and I left them that way rather than inventing replacement text:

- **cairo** retains only its banner line, `=== CAIRO/STARKNET VULNERABILITY SCAN RESULTS ===`. The project/file-count summary and every finding are gone.
- **algorand** and **ton** both print `Vulnerabilities Found: 2` but show one finding, and that finding stops mid-entry — algorand's has no recommendation, ton's has no code or issue text.

This content was already missing in the initial import (695119c), so there is no earlier revision to restore it from. Note that solana's `## 5. Example Output` is an empty section for the same reason, so an empty or partial example is the existing norm for this family rather than a new gap.

## Verification

An earlier version of this description quoted a hand-rolled render check that toggled fence state on every ` ``` ` line. That check was wrong in both directions — it reported "5 sections" pre-fix where CommonMark renders 8 heading lines, and "12 sections, 12 max" after commit 1 when CommonMark renders 10 — because a parity toggle cannot model the bare-closer rule. Its output has been removed from this description; do not use it as evidence.

The evidence now comes from an actual CommonMark parser (`markdown-it-py`), counting `## N.` lines that render as headings:

```
pre-fix (main):        algorand 8/12   cairo 8/12   ton 8/12
after commit 1:        algorand 10/12  cairo 10/12  ton 10/12  solana 10/12
after commit 2 (HEAD): algorand 12/12  cairo 12/12  ton 12/12  solana 12/12
```

Each file has exactly one `## 5.`, headings run 1..12 in document order, and fence-marker lines are balanced in all four files.

Plugin validator: zero errors (8 pre-existing line-length warnings, all in `testing-handbook-skills`, untouched here). `make self-test eval-self-tests lint shell validate` pass. Two `make check` stages fail on this machine for reasons unrelated to this branch, both confirmed to fail identically with these changes stashed: 4 `plugins/modern-python/hooks/shims/uv-shim.bats` cases (the local modern-python 1.5.3 shim intercepting the test's own `uv` calls), and `constant-time-analysis` Python tests that need a Java toolchain and a Rust cross-arch stdlib that are not installed here. `building-secure-contracts` ships no Python tests.