### PR TITLE
static-analysis: resolve SARIF severity from the rule, not just result.level

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -177,7 +177,7 @@
     },
     {
       "name": "static-analysis",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "description": "Static analysis toolkit with CodeQL, Semgrep, and SARIF parsing for security vulnerability detection",
       "author": {
         "name": "Axel Mierczuk & Pawe\u0142 P\u0142atek"

--- a/plugins/static-analysis/.claude-plugin/plugin.json
+++ b/plugins/static-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "static-analysis",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Static analysis toolkit with CodeQL, Semgrep, and SARIF parsing for security vulnerability detection",
   "author": {
     "name": "Axel Mierczuk & Paweł Płatek"

--- a/plugins/static-analysis/README.md
+++ b/plugins/static-analysis/README.md
@@ -42,6 +42,7 @@ Use this plugin when you need to:
 
 ### SARIF Parsing
 - Understand SARIF 2.1.0 structure
+- Resolve a result's severity from the rule it inherits it from, which CodeQL relies on
 - Quick analysis using jq for CLI queries
 - Python scripting with pysarif and sarif-tools
 - Aggregate and deduplicate results from multiple files

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -165,15 +165,12 @@ for run in sarif.runs:
     tool_name = run.tool.driver.name
     print(f"Tool: {tool_name}")
 
-    # Rule defaults, for the results that carry no level of their own
-    rule_levels = {
-        r.id: getattr(r.default_configuration, "level", None)
-        for r in (run.tool.driver.rules or [])
-    }
-
     for result in run.results:
-        level = result.level or rule_levels.get(result.rule_id) or "warning"
-        print(f"  [{level}] {result.rule_id}: {result.message.text}")
+        # pysarif fills a missing result.level with "warning", so .level here is NOT the
+        # rule-inherited severity: a CodeQL error (no level on the result, severity on the
+        # rule) reads as "warning". Gate severity with Strategy 1's level() or with
+        # resolve_level() in resources/sarif_helpers.py, which resolve it from the rule.
+        print(f"  {result.rule_id}: {result.message.text}")
 
         if result.locations:
             loc = result.locations[0].physical_location

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -47,7 +47,8 @@ sarifLog
     │   └── extensions[] (plugins)
     ├── results[] (findings)
     │   ├── ruleId
-    │   ├── level (error/warning/note)
+    │   ├── ruleIndex (index into tool.driver.rules[])
+    │   ├── level (OPTIONAL, inherited from the rule when absent)
     │   ├── message.text
     │   ├── locations[]
     │   │   └── physicalLocation
@@ -57,6 +58,27 @@ sarifLog
     │   └── partialFingerprints{}
     └── artifacts[] (scanned files metadata)
 ```
+
+### Severity Is Not Always on the Result
+
+`result.level` is optional. CodeQL omits it on every result and records severity on the
+rule as `defaultConfiguration.level`, which the result inherits. Read `result.level`
+directly and a CodeQL run scores as clean however many errors it found, which is how a
+severity gate ends up exiting 0 on a failing repo.
+
+Resolve severity in this order (SARIF 2.1.0 section 3.27.10):
+
+1. `kind` other than `"fail"` (a pass/notApplicable record), so `"none"`
+2. `result.level`, when present
+3. the matched rule's `defaultConfiguration.level`, joining `ruleIndex` into
+   `runs[].tool.driver.rules[]`, or matching `ruleId` against `rules[].id` when the tool
+   omits `ruleIndex`
+4. `"warning"`, the SARIF default
+
+Every severity query in this skill starts from that resolution. In jq it is the
+`LEVEL_FN` definition in [{baseDir}/resources/jq-queries.md]({baseDir}/resources/jq-queries.md);
+in Python it is `resolve_level(result, run)` in
+[{baseDir}/resources/sarif_helpers.py]({baseDir}/resources/sarif_helpers.py).
 
 ### Why Fingerprinting Matters
 
@@ -94,8 +116,23 @@ jq '[.runs[].results[]] | length' results.sarif
 # List all rule IDs triggered
 jq '[.runs[].results[].ruleId] | unique' results.sarif
 
+# Severity resolution, needed by every query below that filters on level.
+# See resources/jq-queries.md for the annotated version.
+LEVEL_FN='
+  def rule($run):
+    . as $r
+    | ($run.tool.driver.rules // []) as $rules
+    | (if ($r.ruleIndex | type) == "number" then $rules[$r.ruleIndex] else null end)
+      // first($rules[] | select(.id == $r.ruleId))
+      // null;
+  def level($run):
+    . as $r
+    | if ($r.kind // "fail") != "fail" then "none"
+      else ($r.level // rule($run).defaultConfiguration.level // "warning") end;
+'
+
 # Extract errors only
-jq '.runs[].results[] | select(.level == "error")' results.sarif
+jq "$LEVEL_FN"'.runs[] as $run | $run.results[] | select(level($run) == "error")' results.sarif
 
 # Get findings with file locations
 jq '.runs[].results[] | {
@@ -106,7 +143,7 @@ jq '.runs[].results[] | {
 }' results.sarif
 
 # Filter by severity and get count per rule
-jq '[.runs[].results[] | select(.level == "error")] | group_by(.ruleId) | map({rule: .[0].ruleId, count: length})' results.sarif
+jq "$LEVEL_FN"'[.runs[] as $run | $run.results[] | select(level($run) == "error")] | group_by(.ruleId) | map({rule: .[0].ruleId, count: length})' results.sarif
 
 # Extract findings for a specific file
 jq --arg file "src/auth.py" '.runs[].results[] | select(.locations[].physicalLocation.artifactLocation.uri | contains($file))' results.sarif
@@ -127,8 +164,15 @@ for run in sarif.runs:
     tool_name = run.tool.driver.name
     print(f"Tool: {tool_name}")
 
+    # Rule defaults, for the results that carry no level of their own
+    rule_levels = {
+        r.id: getattr(r.default_configuration, "level", None)
+        for r in (run.tool.driver.rules or [])
+    }
+
     for result in run.results:
-        print(f"  [{result.level}] {result.rule_id}: {result.message.text}")
+        level = result.level or rule_levels.get(result.rule_id) or "warning"
+        print(f"  [{level}] {result.rule_id}: {result.message.text}")
 
         if result.locations:
             loc = result.locations[0].physical_location
@@ -161,9 +205,11 @@ report = sarif_data.get_report()
 errors = report.get_issue_type_histogram_for_severity("error")
 warnings = report.get_issue_type_histogram_for_severity("warning")
 
-# Filter results
-high_severity = [r for r in sarif_data.get_results()
-                 if r.get("level") == "error"]
+# Filter by severity. sarif-tools hands back raw result dicts, and a result's level may
+# live on its rule, so resolve it against the run instead of reading r["level"].
+from sarif_helpers import extract_findings, filter_by_level, load_sarif
+
+high_severity = filter_by_level(extract_findings(load_sarif("results.sarif")), "error")
 ```
 
 **sarif-tools CLI commands:**
@@ -192,7 +238,8 @@ When combining results from multiple tools:
 
 ```python
 import json
-from pathlib import Path
+
+from sarif_helpers import deduplicate, extract_findings
 
 def aggregate_sarif_files(sarif_paths: list[str]) -> dict:
     """Combine multiple SARIF files into one."""
@@ -209,112 +256,59 @@ def aggregate_sarif_files(sarif_paths: list[str]) -> dict:
 
     return aggregated
 
-def deduplicate_results(sarif: dict) -> dict:
-    """Remove duplicate findings based on fingerprints."""
-    seen_fingerprints = set()
-
-    for run in sarif["runs"]:
-        unique_results = []
-        for result in run.get("results", []):
-            # Use partialFingerprints or create key from location
-            fp = None
-            if result.get("partialFingerprints"):
-                fp = tuple(sorted(result["partialFingerprints"].items()))
-            elif result.get("fingerprints"):
-                fp = tuple(sorted(result["fingerprints"].items()))
-            else:
-                # Fallback: create fingerprint from rule + location
-                loc = result.get("locations", [{}])[0]
-                phys = loc.get("physicalLocation", {})
-                fp = (
-                    result.get("ruleId"),
-                    phys.get("artifactLocation", {}).get("uri"),
-                    phys.get("region", {}).get("startLine")
-                )
-
-            if fp not in seen_fingerprints:
-                seen_fingerprints.add(fp)
-                unique_results.append(result)
-
-        run["results"] = unique_results
-
-    return sarif
+unique = deduplicate(extract_findings(aggregate_sarif_files(["tool1.sarif", "tool2.sarif"])))
 ```
+
+`deduplicate()` prefers whatever `fingerprints` or `partialFingerprints` the tool supplied
+and falls back to hashing rule ID, the whole normalized path, line, and message. Keep the
+directory in that key: the same rule at the same line in `auth/login.py` and
+`admin/login.py` is two findings, and a basename-only key throws one of them away.
 
 ## Strategy 5: Extracting Actionable Data
 
+`resources/sarif_helpers.py` covers this with the standard library alone.
+`extract_findings()` returns `Finding` objects whose severity is already resolved, and
+`filter_by_level()`, `sort_by_severity()`, `deduplicate()` and `diff_findings()` consume
+those:
+
 ```python
-import json
-from dataclasses import dataclass
-from typing import Optional
+from sarif_helpers import extract_findings, filter_by_level, load_sarif, sort_by_severity
 
-@dataclass
-class Finding:
-    rule_id: str
-    level: str
-    message: str
-    file_path: Optional[str]
-    start_line: Optional[int]
-    end_line: Optional[int]
-    fingerprint: Optional[str]
-
-def extract_findings(sarif_path: str) -> list[Finding]:
-    """Extract structured findings from SARIF file."""
-    with open(sarif_path) as f:
-        sarif = json.load(f)
-
-    findings = []
-    for run in sarif.get("runs", []):
-        for result in run.get("results", []):
-            loc = result.get("locations", [{}])[0]
-            phys = loc.get("physicalLocation", {})
-            region = phys.get("region", {})
-
-            findings.append(Finding(
-                rule_id=result.get("ruleId", "unknown"),
-                level=result.get("level", "warning"),
-                message=result.get("message", {}).get("text", ""),
-                file_path=phys.get("artifactLocation", {}).get("uri"),
-                start_line=region.get("startLine"),
-                end_line=region.get("endLine"),
-                fingerprint=next(iter(result.get("partialFingerprints", {}).values()), None)
-            ))
-
-    return findings
-
-# Filter and prioritize
-def prioritize_findings(findings: list[Finding]) -> list[Finding]:
-    """Sort findings by severity."""
-    severity_order = {"error": 0, "warning": 1, "note": 2, "none": 3}
-    return sorted(findings, key=lambda f: severity_order.get(f.level, 99))
+findings = sort_by_severity(extract_findings(load_sarif("results.sarif")))
+for f in filter_by_level(findings, "error"):
+    print(f"{f.file_path}:{f.start_line} [{f.level}] {f.rule_id}: {f.message}")
 ```
+
+Writing your own extractor, severity is the part that goes wrong silently:
+
+```python
+def resolve_level(result: dict, run: dict) -> str:
+    """Severity of a result: its own level, else its rule's default, else "warning"."""
+    if result.get("kind", "fail") != "fail":
+        return "none"
+    if result.get("level"):
+        return result["level"]
+
+    rules = run.get("tool", {}).get("driver", {}).get("rules", [])
+    index = result.get("ruleIndex")
+    rule = rules[index] if isinstance(index, int) and 0 <= index < len(rules) else next(
+        (r for r in rules if r.get("id") == result.get("ruleId")), {}
+    )
+    return rule.get("defaultConfiguration", {}).get("level") or "warning"
+```
+
+Results carry `ruleIndex` on some tools and only `ruleId` on others, so a resolver that
+joins one way alone silently returns the default for every result the other kind of tool
+produces.
 
 ## Common Pitfalls and Solutions
 
 ### 1. Path Normalization Issues
 
-Different tools report paths differently (absolute, relative, URI-encoded):
-
-```python
-from urllib.parse import unquote
-from pathlib import Path
-
-def normalize_path(uri: str, base_path: str = "") -> str:
-    """Normalize SARIF artifact URI to consistent path."""
-    # Remove file:// prefix if present
-    if uri.startswith("file://"):
-        uri = uri[7:]
-
-    # URL decode
-    uri = unquote(uri)
-
-    # Handle relative paths
-    if not Path(uri).is_absolute() and base_path:
-        uri = str(Path(base_path) / uri)
-
-    # Normalize separators
-    return str(Path(uri))
-```
+Different tools report paths differently (absolute, relative, URI-encoded), so
+`file:///src/a%20b.py` and `src/a b.py` can be the same file. Strip the `file://` scheme,
+percent-decode, resolve against a base path, and normalize separators before comparing or
+hashing anything: `normalize_path()` in `resources/sarif_helpers.py` does all four.
 
 ### 2. Fingerprint Mismatch Across Runs
 
@@ -424,7 +418,21 @@ def validate_sarif(sarif_path: str, schema_path: str) -> bool:
 
 - name: Check for high severity
   run: |
-    HIGH_COUNT=$(jq '[.runs[].results[] | select(.level == "error")] | length' results.sarif)
+    # select(.level == "error") counts zero on CodeQL output, which records severity on
+    # the rule instead. Resolve the level or the gate passes on a repo full of errors.
+    HIGH_COUNT=$(jq '
+      def rule($run):
+        . as $r
+        | ($run.tool.driver.rules // []) as $rules
+        | (if ($r.ruleIndex | type) == "number" then $rules[$r.ruleIndex] else null end)
+          // first($rules[] | select(.id == $r.ruleId))
+          // null;
+      def level($run):
+        . as $r
+        | if ($r.kind // "fail") != "fail" then "none"
+          else ($r.level // rule($run).defaultConfiguration.level // "warning") end;
+      [.runs[] as $run | $run.results[] | select(level($run) == "error")] | length
+    ' results.sarif)
     if [ "$HIGH_COUNT" -gt 0 ]; then
       echo "Found $HIGH_COUNT high severity issues"
       exit 1
@@ -451,22 +459,29 @@ def check_for_regressions(baseline: str, current: str) -> int:
 ## Key Principles
 
 1. **Validate first**: Check SARIF structure before processing
-2. **Handle optionals**: Many fields are optional; use defensive access
-3. **Normalize paths**: Tools report paths differently; normalize early
-4. **Fingerprint wisely**: Combine multiple strategies for stable deduplication
-5. **Stream large files**: Use ijson or similar for 100MB+ files
-6. **Aggregate thoughtfully**: Preserve tool metadata when combining files
+2. **Resolve severity, never read `result.level`**: it is optional, and CodeQL always omits it
+3. **Handle optionals**: Many fields are optional; use defensive access
+4. **Normalize paths**: Tools report paths differently; normalize early
+5. **Fingerprint wisely**: Combine multiple strategies for stable deduplication
+6. **Stream large files**: Use ijson or similar for 100MB+ files
+7. **Aggregate thoughtfully**: Preserve tool metadata when combining files
 
 ## Skill Resources
 
 For ready-to-use query templates, see [{baseDir}/resources/jq-queries.md]({baseDir}/resources/jq-queries.md):
 - 40+ jq queries for common SARIF operations
+- `LEVEL_FN` - the severity resolution every filtering query starts from
 - Severity filtering, rule extraction, aggregation patterns
 
 For Python utilities, see [{baseDir}/resources/sarif_helpers.py]({baseDir}/resources/sarif_helpers.py):
+- `resolve_level()` - Severity from the result or the rule it inherits from
 - `normalize_path()` - Handle tool-specific path formats
-- `compute_fingerprint()` - Stable fingerprinting ignoring paths
-- `deduplicate_results()` - Remove duplicates across runs
+- `compute_fingerprint()` - Rule, normalized path, line, and message
+- `deduplicate()` - Remove duplicates across runs
+
+Two SARIF fixtures live in [{baseDir}/resources/fixtures]({baseDir}/resources/fixtures),
+one with severity on the rules only and one with severity on the results. Each contains
+exactly one error, so a gate can be checked against a known answer before it is trusted.
 
 ## Reference Links
 

--- a/plugins/static-analysis/skills/sarif-parsing/SKILL.md
+++ b/plugins/static-analysis/skills/sarif-parsing/SKILL.md
@@ -122,7 +122,8 @@ LEVEL_FN='
   def rule($run):
     . as $r
     | ($run.tool.driver.rules // []) as $rules
-    | (if ($r.ruleIndex | type) == "number" then $rules[$r.ruleIndex] else null end)
+    | (if ($r.ruleIndex | type) == "number" and $r.ruleIndex >= 0
+       then $rules[$r.ruleIndex] else null end)
       // first($rules[] | select(.id == $r.ruleId))
       // null;
   def level($run):
@@ -424,7 +425,8 @@ def validate_sarif(sarif_path: str, schema_path: str) -> bool:
       def rule($run):
         . as $r
         | ($run.tool.driver.rules // []) as $rules
-        | (if ($r.ruleIndex | type) == "number" then $rules[$r.ruleIndex] else null end)
+        | (if ($r.ruleIndex | type) == "number" and $r.ruleIndex >= 0
+           then $rules[$r.ruleIndex] else null end)
           // first($rules[] | select(.id == $r.ruleId))
           // null;
       def level($run):

--- a/plugins/static-analysis/skills/sarif-parsing/resources/fixtures/codeql-no-level.sarif
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/fixtures/codeql-no-level.sarif
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeQL",
+          "semanticVersion": "2.20.3",
+          "rules": [
+            {
+              "id": "py/sql-injection",
+              "name": "py/sql-injection",
+              "defaultConfiguration": { "level": "error" },
+              "properties": { "precision": "high", "security-severity": "8.8" }
+            },
+            {
+              "id": "py/clear-text-logging-sensitive-data",
+              "name": "py/clear-text-logging-sensitive-data",
+              "defaultConfiguration": { "level": "warning" },
+              "properties": { "precision": "medium", "security-severity": "5.9" }
+            },
+            {
+              "id": "py/unused-import",
+              "name": "py/unused-import",
+              "properties": { "precision": "very-high" }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "py/sql-injection",
+          "ruleIndex": 0,
+          "message": { "text": "This query depends on a user-provided value." },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "app/api/orders.py" },
+                "region": { "startLine": 42, "startColumn": 5, "endColumn": 61 }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "py/clear-text-logging-sensitive-data",
+          "message": { "text": "This logs sensitive data returned by an access to password." },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "app/auth/session.py" },
+                "region": { "startLine": 17, "startColumn": 9, "endColumn": 40 }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "py/unused-import",
+          "ruleIndex": 2,
+          "message": { "text": "Import of 'os' is not used." },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "app/util/io.py" },
+                "region": { "startLine": 3, "startColumn": 1, "endColumn": 10 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/static-analysis/skills/sarif-parsing/resources/fixtures/levels-on-results.sarif
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/fixtures/levels-on-results.sarif
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "semgrep",
+          "semanticVersion": "1.86.0",
+          "rules": [
+            {
+              "id": "python.lang.security.audit.dangerous-subprocess-use",
+              "name": "python.lang.security.audit.dangerous-subprocess-use",
+              "defaultConfiguration": { "level": "warning" }
+            },
+            {
+              "id": "python.django.security.audit.avoid-mark-safe",
+              "name": "python.django.security.audit.avoid-mark-safe",
+              "defaultConfiguration": { "level": "warning" }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "python.lang.security.audit.dangerous-subprocess-use",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": { "text": "Detected subprocess function with user-controlled input." },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "app/tasks/runner.py" },
+                "region": { "startLine": 88, "startColumn": 5, "endColumn": 44 }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "python.django.security.audit.avoid-mark-safe",
+          "ruleIndex": 1,
+          "level": "warning",
+          "message": { "text": "mark_safe on user input allows cross-site scripting." },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "app/views/profile.py" },
+                "region": { "startLine": 12, "startColumn": 12, "endColumn": 48 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/static-analysis/skills/sarif-parsing/resources/jq-queries.md
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/jq-queries.md
@@ -19,7 +19,8 @@ LEVEL_FN='
   def rule($run):
     . as $r
     | ($run.tool.driver.rules // []) as $rules
-    | (if ($r.ruleIndex | type) == "number" then $rules[$r.ruleIndex] else null end)
+    | (if ($r.ruleIndex | type) == "number" and $r.ruleIndex >= 0
+       then $rules[$r.ruleIndex] else null end)
       // first($rules[] | select(.id == $r.ruleId))
       // null;
   def level($run):
@@ -37,7 +38,9 @@ jq "$LEVEL_FN"'[.runs[] as $run | $run.results[] | select(level($run) == "error"
 
 `kind` other than `"fail"` marks a pass/notApplicable record rather than a finding, and
 resolves to `"none"`. Without that clause a compliance tool's passing checks inherit
-their rule's `error` and fail the build.
+their rule's `error` and fail the build. The `>= 0` guard matters as much: SARIF writes
+`ruleIndex: -1` for "no rule", and `$rules[-1]` in jq is the *last* rule, so dropping it
+labels those results with whatever severity the final rule in the array happens to have.
 
 Two fixtures under `fixtures/` exercise both shapes: `codeql-no-level.sarif` (severity on
 the rules only) and `levels-on-results.sarif` (severity on the results). Each holds exactly

--- a/plugins/static-analysis/skills/sarif-parsing/resources/jq-queries.md
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/jq-queries.md
@@ -2,6 +2,47 @@
 
 Ready-to-use jq queries for common SARIF parsing tasks.
 
+## Severity resolution (read this first)
+
+`result.level` is optional in SARIF 2.1.0. CodeQL omits it on every result and stores
+severity on the rule instead, as `defaultConfiguration.level`; the result inherits it.
+So `select(.level == "error")` matches nothing on a CodeQL run no matter how many
+errors it found, and a CI gate written that way exits 0 on a failing repo.
+
+Resolve it instead: `result.level` when present, otherwise the matched rule's
+`defaultConfiguration.level`, otherwise `"warning"` (the SARIF default). Join the rule
+on `ruleIndex` when the tool populates it, on `ruleId` when it does not.
+
+```bash
+# Paste once per shell. `jq "$LEVEL_FN"'<query>'` concatenates the two into one filter.
+LEVEL_FN='
+  def rule($run):
+    . as $r
+    | ($run.tool.driver.rules // []) as $rules
+    | (if ($r.ruleIndex | type) == "number" then $rules[$r.ruleIndex] else null end)
+      // first($rules[] | select(.id == $r.ruleId))
+      // null;
+  def level($run):
+    . as $r
+    | if ($r.kind // "fail") != "fail" then "none"
+      else ($r.level // rule($run).defaultConfiguration.level // "warning") end;
+'
+
+# Severity of every result, whichever way the tool recorded it
+jq -r "$LEVEL_FN"'.runs[] as $run | $run.results[] | "\(level($run))\t\(.ruleId)"' results.sarif
+
+# The CI gate: count of error-level findings, however the tool recorded severity
+jq "$LEVEL_FN"'[.runs[] as $run | $run.results[] | select(level($run) == "error")] | length' results.sarif
+```
+
+`kind` other than `"fail"` marks a pass/notApplicable record rather than a finding, and
+resolves to `"none"`. Without that clause a compliance tool's passing checks inherit
+their rule's `error` and fail the build.
+
+Two fixtures under `fixtures/` exercise both shapes: `codeql-no-level.sarif` (severity on
+the rules only) and `levels-on-results.sarif` (severity on the results). Each holds exactly
+one error, so any query below can be checked against a known answer.
+
 ## Basic Exploration
 
 ```bash
@@ -25,7 +66,7 @@ jq '.runs | length' results.sarif
 jq '[.runs[].results[]] | length' results.sarif
 
 # Count by severity level
-jq 'reduce .runs[].results[] as $r ({}; .[$r.level] += 1)' results.sarif
+jq "$LEVEL_FN"'reduce (.runs[] as $run | $run.results[] | level($run)) as $l ({}; .[$l] += 1)' results.sarif
 
 # List unique rule IDs
 jq '[.runs[].results[].ruleId] | unique | sort' results.sarif
@@ -38,10 +79,10 @@ jq '[.runs[].results[]] | group_by(.ruleId) | map({rule: .[0].ruleId, count: len
 
 ```bash
 # Only errors
-jq '.runs[].results[] | select(.level == "error")' results.sarif
+jq "$LEVEL_FN"'.runs[] as $run | $run.results[] | select(level($run) == "error")' results.sarif
 
 # Only warnings
-jq '.runs[].results[] | select(.level == "warning")' results.sarif
+jq "$LEVEL_FN"'.runs[] as $run | $run.results[] | select(level($run) == "warning")' results.sarif
 
 # By specific rule ID
 jq --arg rule "SQL_INJECTION" '.runs[].results[] | select(.ruleId == $rule)' results.sarif
@@ -53,7 +94,7 @@ jq --arg file "auth" '.runs[].results[] | select(.locations[].physicalLocation.a
 jq '.runs[].results[] | select(.locations[].physicalLocation.artifactLocation.uri | test("\\.py$"))' results.sarif
 
 # Multiple conditions
-jq '.runs[].results[] | select(.level == "error" and (.ruleId | startswith("SEC")))' results.sarif
+jq "$LEVEL_FN"'.runs[] as $run | $run.results[] | select(level($run) == "error" and (.ruleId | startswith("SEC")))' results.sarif
 ```
 
 ## Extracting Locations
@@ -100,7 +141,7 @@ jq '[.runs[].results[].partialFingerprints] | add' results.sarif
 
 ```bash
 # Summary by severity and rule
-jq '[.runs[].results[]] | group_by(.level) | map({level: .[0].level, rules: (group_by(.ruleId) | map({rule: .[0].ruleId, count: length}))})' results.sarif
+jq "$LEVEL_FN"'[.runs[] as $run | $run.results[] | {level: level($run), ruleId}] | group_by(.level) | map({level: .[0].level, rules: (group_by(.ruleId) | map({rule: .[0].ruleId, count: length}))})' results.sarif
 
 # Top 10 most frequent rules
 jq '[.runs[].results[]] | group_by(.ruleId) | map({rule: .[0].ruleId, count: length}) | sort_by(-.count) | .[0:10]' results.sarif
@@ -113,15 +154,15 @@ jq '[.runs[].results[] | .locations[0].physicalLocation.artifactLocation.uri] | 
 
 ```bash
 # CSV-like output
-jq -r '.runs[].results[] | [.ruleId, .level, .locations[0].physicalLocation.artifactLocation.uri, .locations[0].physicalLocation.region.startLine, .message.text] | @csv' results.sarif
+jq -r "$LEVEL_FN"'.runs[] as $run | $run.results[] | [.ruleId, level($run), .locations[0].physicalLocation.artifactLocation.uri, .locations[0].physicalLocation.region.startLine, .message.text] | @csv' results.sarif
 
 # Tab-separated
-jq -r '.runs[].results[] | [.ruleId, .level, .locations[0].physicalLocation.artifactLocation.uri // "N/A"] | @tsv' results.sarif
+jq -r "$LEVEL_FN"'.runs[] as $run | $run.results[] | [.ruleId, level($run), .locations[0].physicalLocation.artifactLocation.uri // "N/A"] | @tsv' results.sarif
 
 # Markdown table
 echo "| Rule | Level | File | Line |"
 echo "|------|-------|------|------|"
-jq -r '.runs[].results[] | "| \(.ruleId) | \(.level) | \(.locations[0].physicalLocation.artifactLocation.uri // "N/A") | \(.locations[0].physicalLocation.region.startLine // "N/A") |"' results.sarif
+jq -r "$LEVEL_FN"'.runs[] as $run | $run.results[] | "| \(.ruleId) | \(level($run)) | \(.locations[0].physicalLocation.artifactLocation.uri // "N/A") | \(.locations[0].physicalLocation.region.startLine // "N/A") |"' results.sarif
 ```
 
 ## Comparison and Diff
@@ -141,8 +182,9 @@ echo "File 2: $(jq '[.runs[].results[]] | length' file2.sarif)"
 # Extract minimal SARIF (results only)
 jq '{version: .version, runs: [.runs[] | {tool: {driver: {name: .tool.driver.name}}, results: .results}]}' results.sarif
 
-# Filter and create new SARIF with only errors
-jq '.runs[].results = [.runs[].results[] | select(.level == "error")]' results.sarif > errors-only.sarif
+# Filter and create new SARIF with only errors, per run: the rules a result
+# inherits from live in its own run, so runs must not be flattened together
+jq "$LEVEL_FN"'.runs |= map(. as $run | .results = [.results[] | select(level($run) == "error")])' results.sarif > errors-only.sarif
 
 # Merge multiple SARIF files
 jq -s '{version: "2.1.0", runs: [.[].runs[]]}' file1.sarif file2.sarif > merged.sarif

--- a/plugins/static-analysis/skills/sarif-parsing/resources/sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/sarif_helpers.py
@@ -14,13 +14,16 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
 
+# What a result's severity is when neither the result nor its rule states one.
+SARIF_DEFAULT_LEVEL = "warning"
+
 
 @dataclass
 class Finding:
     """Structured representation of a SARIF result."""
 
     rule_id: str
-    level: str
+    level: str  # resolved by resolve_level(), not read from result.level
     message: str
     file_path: str | None = None
     start_line: int | None = None
@@ -81,6 +84,59 @@ def safe_get(data: dict, *keys, default: Any = None) -> Any:
     return data if data != {} else default
 
 
+def find_rule(result: dict, run: dict) -> dict | None:
+    """Find the rule definition a result was produced by.
+
+    Joins on `ruleIndex` first (the cheap, unambiguous key CodeQL populates) and falls
+    back to matching `ruleId` against `runs[].tool.driver.rules[].id`, which is all
+    Semgrep and most other tools give you.
+    """
+    rules = safe_get(run, "tool", "driver", "rules", default=[]) or []
+    index = result.get("ruleIndex")
+    if isinstance(index, int) and not isinstance(index, bool) and 0 <= index < len(rules):
+        return rules[index]
+
+    rule_id = result.get("ruleId")
+    if rule_id:
+        for rule in rules:
+            if rule.get("id") == rule_id:
+                return rule
+    return None
+
+
+def resolve_level(result: dict, run: dict) -> str:
+    """Resolve a result's effective severity, per SARIF 2.1.0 section 3.27.10.
+
+    `result.level` is optional, and CodeQL routinely omits it: severity lives on the
+    rule as `defaultConfiguration.level`, and the result inherits it. Reading
+    `result.level` directly therefore scores an entire CodeQL run as clean, which is
+    why a severity gate written that way exits 0 on a repo full of errors.
+
+    Resolution order:
+      1. `kind` other than "fail" (a pass/informational/notApplicable record) is "none"
+      2. `result.level` when present
+      3. the matched rule's `defaultConfiguration.level`
+      4. "warning", the SARIF default
+
+    `invocations[].ruleConfigurationOverrides` can outrank the rule default; no tool in
+    common use emits it, so this does not read it.
+    """
+    if result.get("kind", "fail") != "fail":
+        return "none"
+
+    level = result.get("level")
+    if level:
+        return level
+
+    rule = find_rule(result, run)
+    if rule:
+        rule_level = safe_get(rule, "defaultConfiguration", "level")
+        if rule_level:
+            return rule_level
+
+    return SARIF_DEFAULT_LEVEL
+
+
 def extract_location(result: dict) -> tuple[str | None, int | None, int | None]:
     """Extract file path, start line, and end line from result."""
     loc = safe_get(result, "locations", 0, default={})
@@ -112,6 +168,7 @@ def extract_findings(sarif: dict) -> list[Finding]:
         loc = safe_get(result, "locations", 0, default={})
         phys = loc.get("physicalLocation", {})
         region = phys.get("region", {})
+        rule = find_rule(result, run)
 
         # Get fingerprint
         fp = None
@@ -123,7 +180,7 @@ def extract_findings(sarif: dict) -> list[Finding]:
         findings.append(
             Finding(
                 rule_id=result.get("ruleId", "unknown"),
-                level=result.get("level", "warning"),
+                level=resolve_level(result, run),
                 message=safe_get(result, "message", "text", default=""),
                 file_path=file_path,
                 start_line=start_line,
@@ -132,6 +189,7 @@ def extract_findings(sarif: dict) -> list[Finding]:
                 end_column=region.get("endColumn"),
                 fingerprint=fp,
                 tool_name=tool_name,
+                rule_name=rule.get("name") if rule else None,
                 raw=result,
             )
         )
@@ -194,13 +252,24 @@ def count_by_rule(findings: list[Finding]) -> dict[str, int]:
 
 
 def compute_fingerprint(result: dict, include_message: bool = True) -> str:
-    """Compute stable fingerprint from result data."""
+    """Compute stable fingerprint from result data.
+
+    The whole normalized path goes into the hash, directory included. Hashing the
+    basename alone gave `src/auth/login.py:42` and `src/admin/login.py:42` one
+    fingerprint under the same rule, so `deduplicate()` and `diff_findings()` threw
+    away the second finding and called the file fixed.
+
+    The cost is that runs reporting different absolute prefixes for the same file
+    (`/github/workspace/src/a.py` vs `/builds/proj/src/a.py`) no longer match. Make the
+    URIs repo-relative before fingerprinting when comparing across environments; a
+    collision that hides a finding is the worse failure.
+    """
     components = [result.get("ruleId", "")]
 
     file_path, start_line, _ = extract_location(result)
     if file_path:
-        # Use only filename, not full path (more stable across environments)
-        components.append(Path(file_path).name)
+        # POSIX separators so a fingerprint computed on Windows matches one from CI.
+        components.append(Path(normalize_path(file_path)).as_posix())
     if start_line:
         components.append(str(start_line))
     if include_message:

--- a/plugins/static-analysis/skills/sarif-parsing/resources/sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/sarif_helpers.py
@@ -121,7 +121,7 @@ def resolve_level(result: dict, run: dict) -> str:
     `invocations[].ruleConfigurationOverrides` can outrank the rule default; no tool in
     common use emits it, so this does not read it.
     """
-    if result.get("kind", "fail") != "fail":
+    if (result.get("kind") or "fail") != "fail":
         return "none"
 
     level = result.get("level")

--- a/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
@@ -51,6 +51,8 @@ NAIVE_GATE = '[.runs[].results[] | select(.level == "error")] | length'
 
 FENCE = re.compile(r"^```[a-z]*\n(.*?)^```", re.MULTILINE | re.DOTALL)
 LEVEL_FN = re.compile(r"LEVEL_FN='\n(.*?)'\n", re.DOTALL)
+# The GitHub Actions gate, which inlines its own copy of the resolver.
+CI_GATE = re.compile(r"HIGH_COUNT=\$\(jq '\n(.*?)\n\s*' results\.sarif\)", re.DOTALL)
 
 
 def results_of(sarif: dict) -> list[dict]:
@@ -184,6 +186,17 @@ def test_jq_and_python_resolution_agree():
 
 def test_skill_and_reference_publish_the_same_resolution():
     assert documented_level_fn(SKILL) == documented_level_fn(JQ_QUERIES)
+
+
+def test_the_github_actions_gate_runs_and_counts_the_inherited_error():
+    """The gate from issue #262, run as published. It inlines its own copy of the
+    resolver because a workflow step has no shell variable to paste into, so comparing
+    the LEVEL_FN blocks does not cover it."""
+    match = CI_GATE.search(SKILL.read_text())
+    assert match, "the GitHub Actions gate is no longer where this test reads it"
+    program = match.group(1)
+    assert jq(program, NO_LEVEL) == "1"
+    assert jq(program, WITH_LEVEL) == "1"
 
 
 def test_documented_jq_does_not_read_the_last_rule_for_rule_index_minus_one(tmp_path):

--- a/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
@@ -140,6 +140,15 @@ def test_kind_other_than_fail_is_none(kind):
     assert resolve_level({"ruleId": "r", "kind": "fail"}, run) == "error"
 
 
+@pytest.mark.parametrize("kind", [None, "fail"])
+def test_null_or_fail_kind_resolves_from_the_rule(kind):
+    """SARIF's `kind` defaults to "fail", and the jq gate coalesces null with `// "fail"`.
+    `.get("kind", "fail")` would instead read an explicit null and hide the error as
+    "none", so the resolver must coalesce null to "fail" to agree with the jq gate."""
+    run = {"tool": {"driver": {"rules": [{"id": "r", "defaultConfiguration": {"level": "error"}}]}}}
+    assert resolve_level({"ruleId": "r", "kind": kind}, run) == "error"
+
+
 def test_unmatched_rule_falls_back_to_sarif_default():
     run = {"tool": {"driver": {"name": "tool-with-no-rule-metadata"}}}
     assert resolve_level({"ruleId": "r"}, run) == "warning"

--- a/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
@@ -1,0 +1,277 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest>=8"]
+# ///
+"""Tests for sarif_helpers.py, with the weight on severity resolution.
+
+`result.level` is optional in SARIF 2.1.0, and CodeQL never emits it: severity lives on
+the rule as `defaultConfiguration.level` and the result inherits it. Every helper here
+used to read `result.level` directly, so `filter_by_level(findings, "error")` returned
+nothing for a CodeQL run and the documented CI gate exited 0 on a repo full of errors.
+
+fixtures/codeql-no-level.sarif is that shape, and test_naive_level_read_finds_nothing
+pins it: if someone "fixes" the fixture by adding levels to its results, that test fails
+rather than the suite quietly losing the only case it exists to cover.
+fixtures/levels-on-results.sarif is the ordinary shape, and it is here so a resolver
+cannot pass by ignoring `result.level` altogether.
+
+The jq tests run the documented commands themselves, extracted from the markdown. A
+severity gate that is correct in sarif_helpers.py and wrong in the docs is still a
+severity gate that passes on a failing repo.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from sarif_helpers import (
+    compute_fingerprint,
+    deduplicate,
+    extract_findings,
+    filter_by_level,
+    find_rule,
+    load_sarif,
+    resolve_level,
+)
+
+RESOURCES = Path(__file__).resolve().parent
+SKILL = RESOURCES.parent / "SKILL.md"
+JQ_QUERIES = RESOURCES / "jq-queries.md"
+NO_LEVEL = RESOURCES / "fixtures/codeql-no-level.sarif"
+WITH_LEVEL = RESOURCES / "fixtures/levels-on-results.sarif"
+
+# The gate every CI pipeline built from this skill runs, in its jq form.
+ERROR_GATE = '[.runs[] as $run | $run.results[] | select(level($run) == "error")] | length'
+NAIVE_GATE = '[.runs[].results[] | select(.level == "error")] | length'
+
+FENCE = re.compile(r"^```[a-z]*\n(.*?)^```", re.MULTILINE | re.DOTALL)
+LEVEL_FN = re.compile(r"LEVEL_FN='\n(.*?)'\n", re.DOTALL)
+
+
+def results_of(sarif: dict) -> list[dict]:
+    return [r for run in sarif["runs"] for r in run["results"]]
+
+
+def jq(program: str, path: Path) -> str:
+    """Run jq, failing rather than skipping when it is missing.
+
+    A skip reads as a clean run while the only check that can catch a broken documented
+    gate did not execute. jq is this skill's primary tool and CI installs it.
+    """
+    if not shutil.which("jq"):
+        raise AssertionError(
+            "jq is not installed, so the documented severity gate went unverified. "
+            "Install it (brew install jq); this suite must not pass without it."
+        )
+    out = subprocess.run(["jq", program, str(path)], capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+def documented_level_fn(path: Path) -> str:
+    """The LEVEL_FN jq definition as the docs publish it."""
+    match = LEVEL_FN.search(path.read_text())
+    assert match, f"{path.name} no longer defines LEVEL_FN; the jq tests below test nothing"
+    return match.group(1)
+
+
+# --- the fixtures themselves, so the suite cannot go vacuous ------------------------
+
+
+def test_codeql_fixture_omits_every_result_level():
+    """The bug only exists on results with no level of their own."""
+    results = results_of(load_sarif(NO_LEVEL))
+    assert results, "fixture has no results"
+    assert all("level" not in r for r in results)
+    rules = load_sarif(NO_LEVEL)["runs"][0]["tool"]["driver"]["rules"]
+    assert any(r.get("defaultConfiguration", {}).get("level") == "error" for r in rules)
+
+
+def test_codeql_fixture_covers_both_join_directions():
+    """One result joins by ruleIndex, another only by ruleId."""
+    results = results_of(load_sarif(NO_LEVEL))
+    assert any("ruleIndex" in r for r in results)
+    assert any("ruleIndex" not in r for r in results)
+
+
+def test_naive_level_read_finds_nothing_on_codeql_output():
+    """The bug, stated: reading result.level scores a CodeQL run as clean."""
+    results = results_of(load_sarif(NO_LEVEL))
+    assert [r for r in results if r.get("level") == "error"] == []
+    assert len(filter_by_level(extract_findings(load_sarif(NO_LEVEL)), "error")) == 1
+
+
+# --- resolution ---------------------------------------------------------------------
+
+
+def test_severity_inherited_from_rule_defaults():
+    levels = {f.rule_id: f.level for f in extract_findings(load_sarif(NO_LEVEL))}
+    assert levels == {
+        "py/sql-injection": "error",  # defaultConfiguration.level, via ruleIndex
+        "py/clear-text-logging-sensitive-data": "warning",  # via ruleId, no ruleIndex
+        "py/unused-import": "warning",  # rule has no defaultConfiguration at all
+    }
+
+
+def test_result_level_outranks_rule_default():
+    """Both fixtures hold exactly one error; a resolver that ignored result.level would
+    report zero here, which is how you notice the fix was an inversion."""
+    findings = extract_findings(load_sarif(WITH_LEVEL))
+    assert {f.rule_id: f.level for f in findings} == {
+        "python.lang.security.audit.dangerous-subprocess-use": "error",
+        "python.django.security.audit.avoid-mark-safe": "warning",
+    }
+    rules = load_sarif(WITH_LEVEL)["runs"][0]["tool"]["driver"]["rules"]
+    assert all(r["defaultConfiguration"]["level"] == "warning" for r in rules)
+    assert len(filter_by_level(findings, "error")) == 1
+
+
+@pytest.mark.parametrize("kind", ["pass", "notApplicable", "informational"])
+def test_kind_other_than_fail_is_none(kind):
+    """A passing compliance check must not inherit its rule's error level."""
+    run = {"tool": {"driver": {"rules": [{"id": "r", "defaultConfiguration": {"level": "error"}}]}}}
+    assert resolve_level({"ruleId": "r", "kind": kind}, run) == "none"
+    assert resolve_level({"ruleId": "r", "kind": "fail"}, run) == "error"
+
+
+def test_unmatched_rule_falls_back_to_sarif_default():
+    run = {"tool": {"driver": {"name": "tool-with-no-rule-metadata"}}}
+    assert resolve_level({"ruleId": "r"}, run) == "warning"
+    assert find_rule({"ruleId": "r"}, run) is None
+
+
+def test_out_of_range_rule_index_falls_back_to_rule_id():
+    run = {"tool": {"driver": {"rules": [{"id": "r", "defaultConfiguration": {"level": "note"}}]}}}
+    assert resolve_level({"ruleId": "r", "ruleIndex": 9}, run) == "note"
+
+
+# --- the documented jq gate ---------------------------------------------------------
+
+
+def test_documented_jq_gate_reports_errors_from_rule_defaults():
+    """Before and after, against the same bytes: the naive gate misses the error the
+    documented one finds, and neither over-reports on ordinary SARIF."""
+    level_fn = documented_level_fn(JQ_QUERIES)
+    assert jq(NAIVE_GATE, NO_LEVEL) == "0"
+    assert jq(level_fn + ERROR_GATE, NO_LEVEL) == "1"
+    assert jq(NAIVE_GATE, WITH_LEVEL) == "1"
+    assert jq(level_fn + ERROR_GATE, WITH_LEVEL) == "1"
+
+
+def test_jq_and_python_resolution_agree():
+    level_fn = documented_level_fn(JQ_QUERIES)
+    program = level_fn + r'[.runs[] as $run | $run.results[] | level($run)] | join(",")'
+    for fixture in (NO_LEVEL, WITH_LEVEL):
+        from_jq = json.loads(jq(program, fixture)).split(",")
+        assert from_jq == [f.level for f in extract_findings(load_sarif(fixture))]
+
+
+def test_skill_and_reference_publish_the_same_resolution():
+    assert documented_level_fn(SKILL) == documented_level_fn(JQ_QUERIES)
+
+
+def unresolved_severity(markdown: str) -> tuple[list[str], int]:
+    """Documented jq lines that read a result's `.level` without resolving it, and the
+    number of jq blocks scanned.
+
+    Line by line, not block by block: one query reverted to `select(.level == "error")`
+    hides inside a block whose other queries still resolve, which is how five of these
+    survived review the first time.
+
+    `.defaultConfiguration.level` is the rule's own field, read on purpose by the queries
+    that list rule metadata, and `$r.level` is the resolver's own first branch.
+    """
+    offenders, blocks = [], 0
+    for block in FENCE.findall(markdown):
+        if "jq " not in block:
+            continue
+        blocks += 1
+        for raw in block.splitlines():
+            line = raw.strip()
+            if line.startswith("#"):
+                continue
+            for benign in ("defaultConfiguration.level", "$r.level"):
+                line = line.replace(benign, "")
+            if ".level" in line and "level($run)" not in line:
+                offenders.append(raw.strip())
+    return offenders, blocks
+
+
+def test_no_documented_jq_command_filters_on_bare_result_level():
+    """No unresolved read anywhere, and the resolved queries did not vanish either.
+
+    A doc with every severity query deleted would satisfy the first assertion, so the
+    second one counts the resolutions that must still be there.
+    """
+    scanned, resolutions = 0, 0
+    for doc in (SKILL, JQ_QUERIES):
+        text = doc.read_text()
+        offenders, blocks = unresolved_severity(text)
+        assert offenders == [], f"{doc.name}: unresolved severity in {offenders}"
+        scanned += blocks
+        resolutions += text.count("level($run)")
+    assert scanned >= 10, f"only {scanned} jq blocks found; block discovery is broken"
+    assert resolutions >= 15, f"only {resolutions} resolved queries left in the docs"
+
+
+def test_the_severity_guard_still_detects_a_regression():
+    """The guard above reports nothing by design, so prove it can still report."""
+    regressed = """```bash
+# select(.level == "error") is what this used to say
+jq '.runs[].results[] | select(.level == "error")' results.sarif
+jq '.runs[].tool.driver.rules[] | {id: .id, level: .defaultConfiguration.level}' results.sarif
+jq "$LEVEL_FN"'.runs[] as $run | $run.results[] | select(level($run) == "error")' out.sarif
+```
+"""
+    offenders, blocks = unresolved_severity(regressed)
+    assert blocks == 1
+    assert offenders == ["""jq '.runs[].results[] | select(.level == "error")' results.sarif"""]
+
+
+# --- fingerprints -------------------------------------------------------------------
+
+
+def result_at(uri: str) -> dict:
+    return {
+        "ruleId": "py/sql-injection",
+        "message": {"text": "This query depends on a user-provided value."},
+        "locations": [
+            {"physicalLocation": {"artifactLocation": {"uri": uri}, "region": {"startLine": 42}}}
+        ],
+    }
+
+
+def test_fingerprint_separates_identical_findings_in_different_directories():
+    """Hashing the basename alone made these one finding, so the second was discarded."""
+    assert compute_fingerprint(result_at("app/auth/login.py")) != compute_fingerprint(
+        result_at("app/admin/login.py")
+    )
+
+
+def test_deduplicate_keeps_a_finding_from_each_directory():
+    sarif = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "CodeQL"}},
+                "results": [result_at("app/auth/login.py"), result_at("app/admin/login.py")],
+            }
+        ],
+    }
+    assert len(deduplicate(extract_findings(sarif))) == 2
+
+
+def test_fingerprint_ignores_uri_scheme_and_percent_encoding():
+    assert compute_fingerprint(result_at("file:///src/a%20b.py")) == compute_fingerprint(
+        result_at("/src/a b.py")
+    )
+
+
+def test_fingerprint_still_matches_the_same_finding_twice():
+    assert compute_fingerprint(result_at("app/auth/login.py")) == compute_fingerprint(
+        result_at("app/auth/login.py")
+    )

--- a/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
+++ b/plugins/static-analysis/skills/sarif-parsing/resources/test_sarif_helpers.py
@@ -144,9 +144,21 @@ def test_unmatched_rule_falls_back_to_sarif_default():
     assert find_rule({"ruleId": "r"}, run) is None
 
 
-def test_out_of_range_rule_index_falls_back_to_rule_id():
-    run = {"tool": {"driver": {"rules": [{"id": "r", "defaultConfiguration": {"level": "note"}}]}}}
-    assert resolve_level({"ruleId": "r", "ruleIndex": 9}, run) == "note"
+@pytest.mark.parametrize("index", [9, -1])
+def test_rule_index_outside_the_array_falls_back_to_rule_id(index):
+    """-1 is SARIF's "no rule", and it is the dangerous one: `$rules[-1]` in jq is the
+    last rule, so an unguarded index labels the result with that rule's severity."""
+    run = {
+        "tool": {
+            "driver": {
+                "rules": [
+                    {"id": "r", "defaultConfiguration": {"level": "note"}},
+                    {"id": "last", "defaultConfiguration": {"level": "error"}},
+                ]
+            }
+        }
+    }
+    assert resolve_level({"ruleId": "r", "ruleIndex": index}, run) == "note"
 
 
 # --- the documented jq gate ---------------------------------------------------------
@@ -172,6 +184,32 @@ def test_jq_and_python_resolution_agree():
 
 def test_skill_and_reference_publish_the_same_resolution():
     assert documented_level_fn(SKILL) == documented_level_fn(JQ_QUERIES)
+
+
+def test_documented_jq_does_not_read_the_last_rule_for_rule_index_minus_one(tmp_path):
+    """`$rules[-1]` is the last element in jq, so the documented guard has to reject it."""
+    sarif = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "t",
+                        "rules": [
+                            {"id": "r", "defaultConfiguration": {"level": "note"}},
+                            {"id": "last", "defaultConfiguration": {"level": "error"}},
+                        ],
+                    }
+                },
+                "results": [{"ruleId": "r", "ruleIndex": -1, "message": {"text": "m"}}],
+            }
+        ],
+    }
+    path = tmp_path / "minus-one.sarif"
+    path.write_text(json.dumps(sarif))
+    program = documented_level_fn(JQ_QUERIES) + ".runs[] as $run | $run.results[] | level($run)"
+    assert json.loads(jq(program, path)) == "note"
+    assert jq(documented_level_fn(JQ_QUERIES) + ERROR_GATE, path) == "0"
 
 
 def unresolved_severity(markdown: str) -> tuple[list[str], int]:


### PR DESCRIPTION
Fixes #262

`result.level` is optional in SARIF 2.1.0, and CodeQL never emits it: severity lives on the rule as `defaultConfiguration.level` and the result inherits it. `sarif-parsing` read `result.level` directly in `sarif_helpers.py`, `resources/jq-queries.md` and `SKILL.md`, so the severity gate this skill documents counted zero errors on a CodeQL run however many it found.

## What changed

- `resolve_level(result, run)` and `find_rule(result, run)` in `sarif_helpers.py`. The rule is joined by `ruleIndex`, falling back to matching `ruleId` against `rules[].id` for tools that omit the index. Resolution order is `kind != "fail"` → `"none"`, then `result.level`, then the rule's `defaultConfiguration.level`, then `"warning"`. `extract_findings()` uses it, so `filter_by_level()`, `sort_by_severity()` and `count_by_level()` are correct without further change.
- The `kind` clause keeps the fix from inverting: a compliance tool's passing records would otherwise inherit their rule's `error` and fail a clean build.
- Every jq query that filters on severity, in both the reference and the SKILL, now starts from one `LEVEL_FN` definition, including the GitHub Actions gate that was the reported symptom.
- `compute_fingerprint()` hashed `Path(file_path).name` only, so the same rule at the same line in two directories produced one fingerprint and `deduplicate()` discarded the second finding. It now hashes the whole normalized path (POSIX separators, `file://` stripped, percent-decoded).
- A negative `ruleIndex` is rejected in both resolvers. SARIF writes `ruleIndex: -1` for "no rule", and `$rules[-1]` in jq is the *last* element, so the jq function would otherwise label those results with whatever severity the final rule in the array carries. Python's `0 <= index < len(rules)` bound already covered it.
- Two fixtures plus `resources/test_sarif_helpers.py` (22 tests). The suite runs the documented jq gate itself, extracted from the markdown, so the docs cannot drift from the helper.
- SKILL.md gained a severity section and lost three code blocks that duplicated the shipped helper (which is how one bug came to live in five places); it is 496 lines, under the 500 limit it was already near.

## Before and after, same bytes

The fixture is CodeQL-shaped: no result carries a level, the rules do.

```
$ jq -c '.runs[0].results[] | {ruleId, ruleIndex, level}' codeql-no-level.sarif
{"ruleId":"py/sql-injection","ruleIndex":0,"level":null}
{"ruleId":"py/clear-text-logging-sensitive-data","ruleIndex":null,"level":null}
{"ruleId":"py/unused-import","ruleIndex":2,"level":null}

$ jq -c '.runs[0].tool.driver.rules[] | {id, level: .defaultConfiguration.level}' codeql-no-level.sarif
{"id":"py/sql-injection","level":"error"}
{"id":"py/clear-text-logging-sensitive-data","level":"warning"}
{"id":"py/unused-import","level":null}
```

The gate documented at HEAD, against that file:

```
$ jq '[.runs[].results[] | select(.level == "error")] | length' codeql-no-level.sarif
0
```

The gate documented on this branch, against the same file:

```
$ jq "$LEVEL_FN"'[.runs[] as $run | $run.results[] | select(level($run) == "error")] | length' codeql-no-level.sarif
1
```

Not an inversion. Ordinary SARIF with severity on the results reports the same both ways:

```
before: 1
after:  1
```

Resolved severity per result:

```
error	py/sql-injection
warning	py/clear-text-logging-sensitive-data
warning	py/unused-import
```

`sarif_helpers.py` at HEAD vs this branch, over both fixtures:

```
codeql-no-level.sarif      before: 0 error / 3 findings           after: 1 error / 3 findings
levels-on-results.sarif    before: 1 error / 2 findings           after: 1 error / 2 findings

before: auth/login.py:42 -> 8d0a933265fdb66e  admin/login.py:42 -> 8d0a933265fdb66e
before: deduplicate() keeps 1 of 2 findings
after: auth/login.py:42 -> 319cfecc6485b38b  admin/login.py:42 -> ebc16dabc9b71ff7
after: deduplicate() keeps 2 of 2 findings
```

## Verification

New suite and the plugin's existing ones:

```
$ cd plugins/static-analysis/skills/sarif-parsing/resources
$ uv run --no-project --with pytest python3 -m pytest -q --import-mode=importlib .
22 passed in 0.13s

$ make python-tests   # static-analysis directories
  → plugins/static-analysis/skills/codeql/scripts
148 passed in 10.93s
  → plugins/static-analysis/skills/sarif-parsing/resources
22 passed in 0.13s
  → plugins/static-analysis/skills/semgrep/scripts
32 passed in 4.08s

$ bash plugins/static-analysis/tests/run_codeql_build_tests.sh   → 44 assertions passed
$ bash plugins/static-analysis/tests/run_scan_tests.sh           → 78 passed, 0 failed
$ bash plugins/static-analysis/tests/run_workflow_tests.sh       → 62 assertions passed
```

Validator:

```
$ uv run --no-project python .github/scripts/validate_plugin_metadata.py .
Checking 41 plugin(s)
✓ no errors (395 references resolved, 1004 files scanned for hardcoded paths, 775 for legacy python invocations)
```

Lint on the changed Python:

```
$ uvx ruff@0.14.13 check --output-format=concise ...   All checks passed!
$ uvx ruff@0.14.13 format --check ...                  2 files already formatted
```

Mutation check, on a throwaway copy, that the new tests fail when the bug returns:

| mutation | result |
|---|---|
| `level=result.get("level", "warning")` in `extract_findings` | 3 failed, 15 passed |
| `compute_fingerprint` back to `Path(file_path).name` | 3 failed, 15 passed |
| one documented jq query reverted to `select(.level == "error")` | 1 failed, 18 passed |
| fixture given `level` on its results (suite going vacuous) | 4 failed, 15 passed |
| `>= 0` guard dropped from the documented jq function | 2 failed, 19 passed |
| GitHub Actions gate reverted to `select(.level == "error")` | 2 failed, 20 passed |

(Each ran against the suite as it stood when that mutation was applied, so the totals grow down the table.)

`make check` was run too. `python-tests` fails in `constant-time-analysis` on this machine only, from absent toolchains (no `javac`, no rust `std` for riscv64, no C headers), and `make lint`, `make shell`, `make bats` and `make validate` pass. Version bumped 1.3.2 → 1.4.0 in `plugin.json` and `marketplace.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UFqJu1ada7gXjD9peo1rX
