### PR TITLE
gh-cli: intercept GitHub fetches from MCP fetch tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,8 +94,8 @@
     },
     {
       "name": "gh-cli",
-      "version": "1.5.1",
-      "description": "Intercepts GitHub URL fetches and curl/wget commands, redirecting to the authenticated gh CLI.",
+      "version": "1.6.0",
+      "description": "Intercepts GitHub URL fetches (WebFetch and MCP fetch tools) and curl/wget commands, redirecting to the authenticated gh CLI.",
       "author": {
         "name": "William Tan",
         "email": "opensource@trailofbits.com",

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cd /path/to/parent  # e.g., if repo is at ~/projects/skills, be in ~/projects
 |--------|-------------|
 | [code-improver](plugins/code-improver/) | Autonomous review-and-fix workflow over skills, plugins, or a branch, with a pluggable reviewer, findings ledger, escalation, and scope guard |
 | [devcontainer-setup](plugins/devcontainer-setup/) | Create pre-configured devcontainers with Claude Code and language-specific tooling |
-| [gh-cli](plugins/gh-cli/) | Intercept GitHub URL fetches and redirect to the authenticated `gh` CLI |
+| [gh-cli](plugins/gh-cli/) | Intercept GitHub URL fetches — `WebFetch`, MCP fetch tools, and curl/wget — and redirect to the authenticated `gh` CLI |
 | [git-cleanup](plugins/git-cleanup/) | Safely clean up git worktrees and local branches: a dynamic workflow gathers merge evidence and tries to refute its own delete recommendations, behind gated confirmation |
 | [goal-prompt](plugins/goal-prompt/) | Draft `/goal` commands for goal mode in Claude Code and Codex — verifiable completion conditions formatted to a copy-ready single line |
 | [github-triage](plugins/github-triage/) | Triage open GitHub issues and PRs: merge ready bot/approved PRs, review unreviewed ones via subagents, close resolved issues with cited comments, cross-link pending fixes, and score the rest with local-only priority and change-size estimates |

--- a/plugins/gh-cli/.claude-plugin/plugin.json
+++ b/plugins/gh-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh-cli",
-  "version": "1.5.1",
-  "description": "Intercepts GitHub URL fetches and curl/wget commands, redirecting to the authenticated gh CLI.",
+  "version": "1.6.0",
+  "description": "Intercepts GitHub URL fetches (WebFetch and MCP fetch tools) and curl/wget commands, redirecting to the authenticated gh CLI.",
   "author": {
     "name": "William Tan",
     "email": "opensource@trailofbits.com",

--- a/plugins/gh-cli/README.md
+++ b/plugins/gh-cli/README.md
@@ -14,18 +14,26 @@ Claude Code's `WebFetch` tool, MCP fetch tools (Exa's `web_fetch_exa` and simila
 
 This plugin provides:
 
-1. **PreToolUse hooks** that intercept GitHub URL access via `WebFetch`, any MCP fetch tool, or `curl`/`wget`, and suggest the correct `gh` CLI command
+1. **PreToolUse hooks** that intercept GitHub URL access via `WebFetch`, MCP fetch/scrape/crawl/extract tools, or `curl`/`wget`, and suggest the correct `gh` CLI command
 2. **A `gh` PATH shim** that blocks anti-patterns: API `/contents/` fetching and non-session-scoped temp directory clones
 3. **A SessionEnd hook** that automatically cleans up cloned repositories when the session ends
 
 ### What Gets Intercepted
 
-The fetch hook matches `WebFetch` and any MCP tool whose name contains `fetch`
-(`mcp__.*[Ff]etch`), so it covers `mcp__exa__web_fetch_exa` and equivalents from
-other MCP servers. It reads both fetch payload shapes — `WebFetch`'s single `url`
-and the `urls` array that MCP fetch tools use to batch several pages into one
-call. Because a tool call is atomic, one GitHub URL anywhere in a batch denies
-the whole call; the denial names each offending URL alongside its suggestion.
+The fetch hook matches `WebFetch` plus any MCP tool whose name contains `fetch`,
+`scrape`, `crawl`, or `extract` — `mcp__exa__web_fetch_exa`,
+`mcp__firecrawl__firecrawl_scrape`, `mcp__tavily__tavily_extract`, and
+equivalents from other MCP servers. Web tools named something else entirely
+(browser navigation, for instance) are not covered; `hooks/matcher.bats` records
+exactly which names match.
+
+It reads both fetch payload shapes — `WebFetch`'s single `url`, and the `urls`
+field MCP fetch tools use to batch several pages into one call, whether that
+field arrives as an array or a bare string. Because a tool call is atomic, one
+GitHub URL anywhere in a batch denies the whole call; the denial names each
+offending URL alongside its suggestion. `WebFetch`'s `prompt` field is
+deliberately not scanned, so a prompt that merely mentions a GitHub URL is not
+denied.
 
 | Tool | Pattern | Suggestion |
 |------|---------|------------|
@@ -37,7 +45,10 @@ the whole call; the denial names each offending URL alongside its suggestion.
 | `WebFetch`, MCP fetch | `github.com/.../releases/download/...` | `gh release download` |
 | `WebFetch`, MCP fetch | `api.github.com/repos/.../pulls` | `gh pr list` / `gh pr view` |
 | `WebFetch`, MCP fetch | `api.github.com/repos/.../issues` | `gh issue list` / `gh issue view` |
-| `WebFetch`, MCP fetch | `api.github.com/...` | `gh api <endpoint>` |
+| `WebFetch`, MCP fetch | `api.github.com/repos/.../contents/...` | `gh repo clone` + Read |
+| `WebFetch`, MCP fetch | `api.github.com/repos/.../releases` | `gh release list` |
+| `WebFetch`, MCP fetch | `api.github.com/repos/.../actions` | `gh run list` |
+| `WebFetch`, MCP fetch | `api.github.com/...` (anything else) | `gh api <endpoint>` |
 | `WebFetch`, MCP fetch | `raw.githubusercontent.com/...` | `gh repo clone` + Read |
 | `WebFetch`, MCP fetch | `gist.github.com/...` | `gh gist view` |
 | `Bash` | `curl https://api.github.com/...` | `gh api <endpoint>` |

--- a/plugins/gh-cli/README.md
+++ b/plugins/gh-cli/README.md
@@ -4,7 +4,7 @@ A Claude Code plugin that intercepts GitHub URL fetches and redirects Claude to 
 
 ## Problem
 
-Claude Code's `WebFetch` tool and Bash `curl`/`wget` commands don't use the user's GitHub authentication. This means:
+Claude Code's `WebFetch` tool, MCP fetch tools (Exa's `web_fetch_exa` and similar), and Bash `curl`/`wget` commands don't use the user's GitHub authentication. This means:
 
 - **Private repos**: Fetches fail with 404 errors
 - **Rate limits**: Unauthenticated requests are limited to 60/hour (vs 5,000/hour authenticated)
@@ -14,21 +14,32 @@ Claude Code's `WebFetch` tool and Bash `curl`/`wget` commands don't use the user
 
 This plugin provides:
 
-1. **PreToolUse hooks** that intercept GitHub URL access via `WebFetch` or `curl`/`wget`, and suggest the correct `gh` CLI command
+1. **PreToolUse hooks** that intercept GitHub URL access via `WebFetch`, any MCP fetch tool, or `curl`/`wget`, and suggest the correct `gh` CLI command
 2. **A `gh` PATH shim** that blocks anti-patterns: API `/contents/` fetching and non-session-scoped temp directory clones
 3. **A SessionEnd hook** that automatically cleans up cloned repositories when the session ends
 
 ### What Gets Intercepted
 
+The fetch hook matches `WebFetch` and any MCP tool whose name contains `fetch`
+(`mcp__.*[Ff]etch`), so it covers `mcp__exa__web_fetch_exa` and equivalents from
+other MCP servers. It reads both fetch payload shapes — `WebFetch`'s single `url`
+and the `urls` array that MCP fetch tools use to batch several pages into one
+call. Because a tool call is atomic, one GitHub URL anywhere in a batch denies
+the whole call; the denial names each offending URL alongside its suggestion.
+
 | Tool | Pattern | Suggestion |
 |------|---------|------------|
-| `WebFetch` | `github.com/{owner}/{repo}` | `gh repo view owner/repo` |
-| `WebFetch` | `github.com/.../blob/...` | `gh repo clone` + Read |
-| `WebFetch` | `github.com/.../tree/...` | `gh repo clone` + Read/Glob/Grep |
-| `WebFetch` | `api.github.com/repos/.../pulls` | `gh pr list` / `gh pr view` |
-| `WebFetch` | `api.github.com/repos/.../issues` | `gh issue list` / `gh issue view` |
-| `WebFetch` | `api.github.com/...` | `gh api <endpoint>` |
-| `WebFetch` | `raw.githubusercontent.com/...` | `gh repo clone` + Read |
+| `WebFetch`, MCP fetch | `github.com/{owner}/{repo}` | `gh repo view owner/repo` |
+| `WebFetch`, MCP fetch | `github.com/.../blob/...` | `gh repo clone` + Read |
+| `WebFetch`, MCP fetch | `github.com/.../tree/...` | `gh repo clone` + Read/Glob/Grep |
+| `WebFetch`, MCP fetch | `github.com/.../pull/{n}` | `gh pr view` |
+| `WebFetch`, MCP fetch | `github.com/.../issues/{n}` | `gh issue view` |
+| `WebFetch`, MCP fetch | `github.com/.../releases/download/...` | `gh release download` |
+| `WebFetch`, MCP fetch | `api.github.com/repos/.../pulls` | `gh pr list` / `gh pr view` |
+| `WebFetch`, MCP fetch | `api.github.com/repos/.../issues` | `gh issue list` / `gh issue view` |
+| `WebFetch`, MCP fetch | `api.github.com/...` | `gh api <endpoint>` |
+| `WebFetch`, MCP fetch | `raw.githubusercontent.com/...` | `gh repo clone` + Read |
+| `WebFetch`, MCP fetch | `gist.github.com/...` | `gh gist view` |
 | `Bash` | `curl https://api.github.com/...` | `gh api <endpoint>` |
 | `Bash` | `curl https://raw.githubusercontent.com/...` | `gh repo clone` + Read |
 | `Bash` | `wget https://github.com/...` | `gh release download` |

--- a/plugins/gh-cli/hooks/hooks.json
+++ b/plugins/gh-cli/hooks/hooks.json
@@ -23,7 +23,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "WebFetch|mcp__.*[Ff]etch",
+        "matcher": "WebFetch|mcp__.*([Ff]etch|[Ss]crape|[Cc]rawl|[Ee]xtract)",
         "hooks": [
           {
             "type": "command",

--- a/plugins/gh-cli/hooks/hooks.json
+++ b/plugins/gh-cli/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Intercept GitHub URL fetches and curl/wget commands, suggest gh CLI instead. PATH shim blocks gh anti-patterns. Clean up cloned repos on session end.",
+  "description": "Intercept GitHub URL fetches (WebFetch and MCP fetch tools) and curl/wget commands, suggest gh CLI instead. PATH shim blocks gh anti-patterns. Clean up cloned repos on session end.",
   "hooks": {
     "SessionStart": [
       {
@@ -23,7 +23,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "WebFetch",
+        "matcher": "WebFetch|mcp__.*[Ff]etch",
         "hooks": [
           {
             "type": "command",

--- a/plugins/gh-cli/hooks/intercept-github-fetch.bats
+++ b/plugins/gh-cli/hooks/intercept-github-fetch.bats
@@ -272,8 +272,14 @@ load test_helper
   assert_suggestion_contains "gh gist view"
 }
 
-@test "fetch: ignores a non-array urls field" {
+@test "fetch: checks a string-valued urls field" {
   run bash -c 'echo "{\"tool_input\":{\"urls\":\"https://github.com/owner/repo\"}}" | '"'$FETCH_HOOK'"
+  assert_deny
+  assert_suggestion_contains "gh repo view owner/repo"
+}
+
+@test "fetch: allows a non-GitHub string-valued urls field" {
+  run bash -c 'echo "{\"tool_input\":{\"urls\":\"https://pypi.org/project/requests/\"}}" | '"'$FETCH_HOOK'"
   assert_allow
 }
 

--- a/plugins/gh-cli/hooks/intercept-github-fetch.bats
+++ b/plugins/gh-cli/hooks/intercept-github-fetch.bats
@@ -220,3 +220,64 @@ load test_helper
   assert_suggestion_contains "Do NOT use"
   assert_suggestion_contains "base64-decode file contents"
 }
+
+# =============================================================================
+# MCP fetch tools: `urls` array input
+# =============================================================================
+
+@test "fetch: exits silently on empty urls array" {
+  run bash -c 'echo "{\"tool_input\":{\"urls\":[]}}" | '"'$FETCH_HOOK'"
+  assert_allow
+}
+
+@test "fetch: allows a urls array of non-GitHub URLs" {
+  run_fetch_hook_urls "https://pypi.org/project/requests/" "https://dev.to/some-article"
+  assert_allow
+}
+
+@test "fetch: denies a single-element urls array" {
+  run_fetch_hook_urls "https://github.com/j178/prek"
+  assert_deny
+  assert_suggestion_contains "gh repo view j178/prek"
+}
+
+@test "fetch: single-element urls array omits the URL prefix" {
+  run_fetch_hook_urls "https://github.com/j178/prek"
+  assert_deny
+  assert_suggestion_starts_with "Use "
+}
+
+@test "fetch: denies a batch when only one URL is GitHub" {
+  run_fetch_hook_urls "https://pypi.org/project/requests/" "https://github.com/astral-sh/uv"
+  assert_deny
+  assert_suggestion_contains "gh repo view astral-sh/uv"
+}
+
+@test "fetch: batched denial labels the offending URL" {
+  run_fetch_hook_urls "https://pypi.org/project/requests/" "https://github.com/astral-sh/uv"
+  assert_deny
+  assert_suggestion_contains "https://github.com/astral-sh/uv: Use "
+}
+
+@test "fetch: batched denial reports every offending URL" {
+  run_fetch_hook_urls "https://github.com/owner/repo/blob/main/x.js" "https://api.github.com/repos/owner/repo/issues"
+  assert_deny
+  assert_suggestion_contains "gh repo clone owner/repo"
+  assert_suggestion_contains "gh issue list --repo owner/repo"
+}
+
+@test "fetch: url and urls in the same payload are both checked" {
+  run bash -c 'jq -n '"'"'{"tool_input":{"url":"https://example.com","urls":["https://gist.github.com/user/abc123"]}}'"'"' | '"'$FETCH_HOOK'"
+  assert_deny
+  assert_suggestion_contains "gh gist view"
+}
+
+@test "fetch: ignores a non-array urls field" {
+  run bash -c 'echo "{\"tool_input\":{\"urls\":\"https://github.com/owner/repo\"}}" | '"'$FETCH_HOOK'"
+  assert_allow
+}
+
+@test "fetch: ignores non-string entries in urls" {
+  run bash -c 'jq -n '"'"'{"tool_input":{"urls":[null,42,""]}}'"'"' | '"'$FETCH_HOOK'"
+  assert_allow
+}

--- a/plugins/gh-cli/hooks/intercept-github-fetch.sh
+++ b/plugins/gh-cli/hooks/intercept-github-fetch.sh
@@ -4,89 +4,122 @@ set -euo pipefail
 # Fast exit if gh not installed
 command -v gh &>/dev/null || exit 0
 
-# Parse URL from JSON input
-url=$(jq -r '.tool_input.url // empty' 2>/dev/null) || exit 0
-[[ -z "$url" ]] && exit 0
+# WebFetch passes a single `url`; MCP fetch tools (Exa's web_fetch_exa and
+# friends) pass a `urls` array and can batch several URLs into one call. Read
+# both shapes so a batched fetch cannot slip a GitHub URL past the hook.
+urls=$(jq -r '[.tool_input.url?, (.tool_input.urls? | arrays | .[])]
+  | map(select(type == "string" and . != ""))
+  | .[]' 2>/dev/null) || exit 0
+[[ -z "$urls" ]] && exit 0
 
-# Strip protocol to get host/path
-stripped="${url#http://}"
-stripped="${stripped#https://}"
+# Clone-instead-of-fetch guidance, which several URL shapes share verbatim.
+clone_hint() {
+  local owner="$1" repo="$2"
+  local target="\"\${TMPDIR:-/tmp}/gh-clones-\${CLAUDE_SESSION_ID}/${repo}\""
+  echo "Use \`gh repo clone ${owner}/${repo} ${target} -- --depth 1\`, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
+}
 
-# Strip query string and fragment before parsing
-stripped="${stripped%%\?*}"
-stripped="${stripped%%#*}"
+clone_hint_generic() {
+  echo "Use \`gh repo clone\` to a temp directory, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
+}
 
-# Extract hostname and path
-host="${stripped%%/*}"
-path="${stripped#*/}"
-# ${var#*/} returns the original string when there's no slash,
-# so path == host means the URL had no path component (e.g. "https://github.com")
-[[ "$path" == "$host" ]] && path=""
+suggest_api() {
+  local path="$1"
+  if [[ $path =~ ^repos/([^/]+)/([^/]+)/pulls ]]; then
+    echo "Use \`gh pr list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh pr view\` instead"
+  elif [[ $path =~ ^repos/([^/]+)/([^/]+)/issues ]]; then
+    echo "Use \`gh issue list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh issue view\` instead"
+  elif [[ $path =~ ^repos/([^/]+)/([^/]+)/contents ]]; then
+    clone_hint "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  elif [[ $path =~ ^repos/([^/]+)/([^/]+)/releases ]]; then
+    echo "Use \`gh release list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh api ${path}\` instead"
+  elif [[ $path =~ ^repos/([^/]+)/([^/]+)/actions ]]; then
+    echo "Use \`gh run list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh api ${path}\` instead"
+  else
+    echo "Use \`gh api ${path}\` instead"
+  fi
+}
 
-[[ -z "$host" ]] && exit 0
+suggest_raw() {
+  # raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}
+  local path="$1"
+  if [[ $path =~ ^([^/]+)/([^/]+)/[^/]+/(.+) ]]; then
+    clone_hint "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    clone_hint_generic
+  fi
+}
 
-# Skip non-GitHub domains (including github.io — those are regular websites)
-case "$host" in
-  github.com | api.github.com | raw.githubusercontent.com | gist.github.com) ;;
-  *) exit 0 ;;
-esac
+suggest_github_com() {
+  local path="$1"
+  # Skip non-repo paths (single-segment paths are site pages, not repos)
+  # e.g. github.com/settings, github.com/notifications, github.com/login
+  if [[ -z "$path" ]] || ! [[ $path =~ / ]]; then
+    return 0
+  fi
+  # Match specific resource patterns before the generic {owner}/{repo} catch-all
+  if [[ $path =~ ^([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+    echo "Use \`gh pr view ${BASH_REMATCH[3]} --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
+  elif [[ $path =~ ^([^/]+)/([^/]+)/issues/([0-9]+) ]]; then
+    echo "Use \`gh issue view ${BASH_REMATCH[3]} --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
+  elif [[ $path =~ ^([^/]+)/([^/]+)/releases/download/ ]]; then
+    echo "Use \`gh release download --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
+  elif [[ $path =~ ^([^/]+)/([^/]+)/(blob|tree)/ ]]; then
+    clone_hint "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  elif [[ $path =~ ^([^/]+)/([^/]+) ]]; then
+    echo "Use \`gh repo view ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
+  else
+    echo "Use the \`gh\` CLI instead"
+  fi
+}
 
-suggestion=""
+# Echo a gh CLI suggestion for a GitHub URL, or nothing if the URL should pass.
+suggest_for_url() {
+  local url="$1" stripped host path
 
-case "$host" in
-  api.github.com)
-    # Check for specific API patterns
-    if [[ $path =~ ^repos/([^/]+)/([^/]+)/pulls ]]; then
-      suggestion="Use \`gh pr list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh pr view\` instead"
-    elif [[ $path =~ ^repos/([^/]+)/([^/]+)/issues ]]; then
-      suggestion="Use \`gh issue list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh issue view\` instead"
-    elif [[ $path =~ ^repos/([^/]+)/([^/]+)/contents ]]; then
-      suggestion="Use \`gh repo clone ${BASH_REMATCH[1]}/${BASH_REMATCH[2]} \"\${TMPDIR:-/tmp}/gh-clones-\${CLAUDE_SESSION_ID}/${BASH_REMATCH[2]}\" -- --depth 1\`, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
-    elif [[ $path =~ ^repos/([^/]+)/([^/]+)/releases ]]; then
-      suggestion="Use \`gh release list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh api ${path}\` instead"
-    elif [[ $path =~ ^repos/([^/]+)/([^/]+)/actions ]]; then
-      suggestion="Use \`gh run list --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` or \`gh api ${path}\` instead"
-    else
-      suggestion="Use \`gh api ${path}\` instead"
-    fi
-    ;;
-  raw.githubusercontent.com)
-    # raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}
-    if [[ $path =~ ^([^/]+)/([^/]+)/[^/]+/(.+) ]]; then
-      suggestion="Use \`gh repo clone ${BASH_REMATCH[1]}/${BASH_REMATCH[2]} \"\${TMPDIR:-/tmp}/gh-clones-\${CLAUDE_SESSION_ID}/${BASH_REMATCH[2]}\" -- --depth 1\`, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
-    else
-      suggestion="Use \`gh repo clone\` to a temp directory, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
-    fi
-    ;;
-  gist.github.com)
-    suggestion="Use \`gh gist view\` instead"
-    ;;
-  github.com)
-    # Skip non-repo paths (single-segment paths are site pages, not repos)
-    # e.g. github.com/settings, github.com/notifications, github.com/login
-    if [[ -z "$path" ]] || ! [[ $path =~ / ]]; then
-      exit 0
-    fi
-    # Match specific resource patterns before the generic {owner}/{repo} catch-all
-    if [[ $path =~ ^([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
-      suggestion="Use \`gh pr view ${BASH_REMATCH[3]} --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
-    elif [[ $path =~ ^([^/]+)/([^/]+)/issues/([0-9]+) ]]; then
-      suggestion="Use \`gh issue view ${BASH_REMATCH[3]} --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
-    elif [[ $path =~ ^([^/]+)/([^/]+)/releases/download/ ]]; then
-      suggestion="Use \`gh release download --repo ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
-    elif [[ $path =~ ^([^/]+)/([^/]+)/blob/ ]]; then
-      suggestion="Use \`gh repo clone ${BASH_REMATCH[1]}/${BASH_REMATCH[2]} \"\${TMPDIR:-/tmp}/gh-clones-\${CLAUDE_SESSION_ID}/${BASH_REMATCH[2]}\" -- --depth 1\`, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
-    elif [[ $path =~ ^([^/]+)/([^/]+)/tree/ ]]; then
-      suggestion="Use \`gh repo clone ${BASH_REMATCH[1]}/${BASH_REMATCH[2]} \"\${TMPDIR:-/tmp}/gh-clones-\${CLAUDE_SESSION_ID}/${BASH_REMATCH[2]}\" -- --depth 1\`, then use the Explore agent on the clone. Do NOT use \`gh api\` to fetch and base64-decode file contents — clone the repo instead"
-    elif [[ $path =~ ^([^/]+)/([^/]+) ]]; then
-      suggestion="Use \`gh repo view ${BASH_REMATCH[1]}/${BASH_REMATCH[2]}\` instead"
-    else
-      suggestion="Use the \`gh\` CLI instead"
-    fi
-    ;;
-esac
+  # Strip protocol to get host/path
+  stripped="${url#http://}"
+  stripped="${stripped#https://}"
 
-[[ -z "$suggestion" ]] && exit 0
+  # Strip query string and fragment before parsing
+  stripped="${stripped%%\?*}"
+  stripped="${stripped%%#*}"
 
-jq -n --arg reason "${suggestion}. The gh CLI uses your authenticated GitHub token and works with private repos." \
+  # Extract hostname and path
+  host="${stripped%%/*}"
+  path="${stripped#*/}"
+  # ${var#*/} returns the original string when there's no slash,
+  # so path == host means the URL had no path component (e.g. "https://github.com")
+  [[ "$path" == "$host" ]] && path=""
+
+  [[ -z "$host" ]] && return 0
+
+  # Skip non-GitHub domains (including github.io — those are regular websites)
+  case "$host" in
+    api.github.com) suggest_api "$path" ;;
+    raw.githubusercontent.com) suggest_raw "$path" ;;
+    gist.github.com) echo "Use \`gh gist view\` instead" ;;
+    github.com) suggest_github_com "$path" ;;
+    *) return 0 ;;
+  esac
+}
+
+# A tool call is atomic, so one offending URL denies the whole call. Label each
+# suggestion with its URL when the call carried more than one, so the model can
+# tell which of a batch was the problem.
+url_count=$(printf '%s\n' "$urls" | wc -l)
+reason=""
+while IFS= read -r url; do
+  suggestion="$(suggest_for_url "$url")"
+  [[ -z "$suggestion" ]] && continue
+  if [[ $url_count -gt 1 ]]; then
+    suggestion="${url}: ${suggestion}"
+  fi
+  reason="${reason:+${reason}
+}${suggestion}"
+done <<<"$urls"
+
+[[ -z "$reason" ]] && exit 0
+
+jq -n --arg reason "${reason}. The gh CLI uses your authenticated GitHub token and works with private repos." \
   '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'

--- a/plugins/gh-cli/hooks/intercept-github-fetch.sh
+++ b/plugins/gh-cli/hooks/intercept-github-fetch.sh
@@ -7,7 +7,11 @@ command -v gh &>/dev/null || exit 0
 # WebFetch passes a single `url`; MCP fetch tools (Exa's web_fetch_exa and
 # friends) pass a `urls` array and can batch several URLs into one call. Read
 # both shapes so a batched fetch cannot slip a GitHub URL past the hook.
-urls=$(jq -r '[.tool_input.url?, (.tool_input.urls? | arrays | .[])]
+# `urls` is listed twice on purpose: the type filter keeps it when a server
+# declares it as a bare string, and `arrays` unpacks it when it is a list.
+# Only these two fields are read — WebFetch's `prompt` is deliberately not
+# scanned, or a prompt that merely mentions a GitHub URL would false-deny.
+urls=$(jq -r '[.tool_input.url?, .tool_input.urls?, (.tool_input.urls? | arrays | .[])]
   | map(select(type == "string" and . != ""))
   | .[]' 2>/dev/null) || exit 0
 [[ -z "$urls" ]] && exit 0
@@ -121,5 +125,15 @@ done <<<"$urls"
 
 [[ -z "$reason" ]] && exit 0
 
-jq -n --arg reason "${reason}. The gh CLI uses your authenticated GitHub token and works with private repos." \
+# One suggestion reads as a sentence; several read as a list, so the closing
+# note gets its own line rather than trailing only the last entry.
+closing="The gh CLI uses your authenticated GitHub token and works with private repos."
+if [[ "$reason" == *$'\n'* ]]; then
+  reason="${reason}
+${closing}"
+else
+  reason="${reason}. ${closing}"
+fi
+
+jq -n --arg reason "$reason" \
   '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":$reason}}'

--- a/plugins/gh-cli/hooks/matcher.bats
+++ b/plugins/gh-cli/hooks/matcher.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# Tests for the PreToolUse matchers in hooks.json.
+#
+# The hook scripts are well covered, but nothing exercised the matcher that
+# decides whether they run at all — so a matcher that fires on nothing would
+# still pass every other suite in this directory. These tests read the matcher
+# out of hooks.json and check it against real tool names.
+#
+# Claude Code evaluates a matcher containing regex metacharacters as an
+# unanchored JavaScript regular expression. `grep -E` is likewise unanchored,
+# and these patterns use only constructs common to both.
+
+setup() {
+  HOOKS_JSON="${BATS_TEST_DIRNAME}/hooks.json"
+  FETCH_MATCHER=$(jq -r '.hooks.PreToolUse[]
+    | select(.hooks[].command | contains("intercept-github-fetch.sh"))
+    | .matcher' "$HOOKS_JSON")
+  BASH_MATCHER=$(jq -r '.hooks.PreToolUse[]
+    | select(.hooks[].command | contains("intercept-github-curl.sh"))
+    | .matcher' "$HOOKS_JSON")
+}
+
+# A matcher that failed to parse would be empty, and an empty pattern matches
+# every tool name — which would make every assertion below pass vacuously.
+assert_matcher_nonempty() {
+  if [[ -z "$1" ]]; then
+    echo "Matcher not found in $HOOKS_JSON — every match assertion would pass vacuously"
+    return 1
+  fi
+}
+
+assert_matches() {
+  local pattern="$1" tool="$2"
+  assert_matcher_nonempty "$pattern" || return 1
+  if ! printf '%s\n' "$tool" | grep -Eq "$pattern"; then
+    echo "Expected matcher '$pattern' to match tool '$tool'"
+    return 1
+  fi
+}
+
+refute_matches() {
+  local pattern="$1" tool="$2"
+  assert_matcher_nonempty "$pattern" || return 1
+  if printf '%s\n' "$tool" | grep -Eq "$pattern"; then
+    echo "Expected matcher '$pattern' NOT to match tool '$tool'"
+    return 1
+  fi
+}
+
+# =============================================================================
+# The matchers are present at all
+# =============================================================================
+
+@test "matcher: hooks.json is valid JSON" {
+  run jq -e . "$HOOKS_JSON"
+  [[ $status -eq 0 ]]
+}
+
+@test "matcher: fetch hook has a matcher" {
+  assert_matcher_nonempty "$FETCH_MATCHER"
+}
+
+@test "matcher: bash hook has a matcher" {
+  assert_matcher_nonempty "$BASH_MATCHER"
+}
+
+# =============================================================================
+# Built-in tools
+# =============================================================================
+
+@test "matcher: fetch matcher matches WebFetch" {
+  assert_matches "$FETCH_MATCHER" "WebFetch"
+}
+
+@test "matcher: bash matcher matches Bash" {
+  assert_matches "$BASH_MATCHER" "Bash"
+}
+
+@test "matcher: fetch matcher does not match Bash" {
+  refute_matches "$FETCH_MATCHER" "Bash"
+}
+
+@test "matcher: fetch matcher does not match Read" {
+  refute_matches "$FETCH_MATCHER" "Read"
+}
+
+@test "matcher: fetch matcher does not match WebSearch" {
+  refute_matches "$FETCH_MATCHER" "WebSearch"
+}
+
+# =============================================================================
+# MCP tools that retrieve a URL — these are the ones the hook exists for
+# =============================================================================
+
+@test "matcher: fetch matcher matches Exa web_fetch_exa" {
+  assert_matches "$FETCH_MATCHER" "mcp__exa__web_fetch_exa"
+}
+
+@test "matcher: fetch matcher matches a bare fetch server" {
+  assert_matches "$FETCH_MATCHER" "mcp__fetch__fetch"
+}
+
+@test "matcher: fetch matcher matches Firecrawl scrape" {
+  assert_matches "$FETCH_MATCHER" "mcp__firecrawl__firecrawl_scrape"
+}
+
+@test "matcher: fetch matcher matches Firecrawl batch scrape" {
+  assert_matches "$FETCH_MATCHER" "mcp__firecrawl__firecrawl_batch_scrape"
+}
+
+@test "matcher: fetch matcher matches a crawl tool" {
+  assert_matches "$FETCH_MATCHER" "mcp__exa__crawling_exa"
+}
+
+@test "matcher: fetch matcher matches Tavily extract" {
+  assert_matches "$FETCH_MATCHER" "mcp__tavily__tavily_extract"
+}
+
+# =============================================================================
+# MCP tools that do not retrieve a URL — no reason to run the hook
+# =============================================================================
+
+@test "matcher: fetch matcher does not match Exa search" {
+  refute_matches "$FETCH_MATCHER" "mcp__exa__web_search_exa"
+}
+
+@test "matcher: fetch matcher does not match context7 docs query" {
+  refute_matches "$FETCH_MATCHER" "mcp__context7__query-docs"
+}
+
+@test "matcher: fetch matcher does not match a Slack reader" {
+  refute_matches "$FETCH_MATCHER" "mcp__slack__slack_read_channel"
+}

--- a/plugins/gh-cli/hooks/test_helper.bash
+++ b/plugins/gh-cli/hooks/test_helper.bash
@@ -14,6 +14,14 @@ run_fetch_hook() {
   run bash -c 'jq -n --arg url "$1" '"'"'{"tool_input":{"url":$url,"prompt":"test"}}'"'"' | "$2"' _ "$url" "$FETCH_HOOK"
 }
 
+# Run the fetch hook with a `urls` array, as MCP fetch tools (e.g. Exa's
+# web_fetch_exa) pass them.
+# Usage: run_fetch_hook_urls "https://example.com" "https://github.com/owner/repo"
+run_fetch_hook_urls() {
+  local hook="$FETCH_HOOK"
+  run bash -c 'hook="$1"; shift; jq -n '"'"'{"tool_input":{"urls":$ARGS.positional}}'"'"' --args "$@" | "$hook"' _ "$hook" "$@"
+}
+
 # Run the Bash hook with a command
 # Usage: run_curl_hook "curl https://api.github.com/..."
 run_curl_hook() {
@@ -94,6 +102,19 @@ assert_suggestion_contains() {
   fi
   if [[ "$reason" != *"$expected"* ]]; then
     echo "Expected suggestion to contain: $expected"
+    echo "Got: $reason"
+    return 1
+  fi
+}
+
+# Assert the suggestion begins with expected text
+# Usage: assert_suggestion_starts_with "Use "
+assert_suggestion_starts_with() {
+  local expected="$1"
+  local reason
+  reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+  if [[ "$reason" != "$expected"* ]]; then
+    echo "Expected suggestion to start with: $expected"
     echo "Got: $reason"
     return 1
   fi

--- a/plugins/gh-cli/hooks/test_helper.bash
+++ b/plugins/gh-cli/hooks/test_helper.bash
@@ -112,7 +112,16 @@ assert_suggestion_contains() {
 assert_suggestion_starts_with() {
   local expected="$1"
   local reason
+  if [[ -z "$expected" ]]; then
+    echo "assert_suggestion_starts_with called with an empty prefix — it would pass vacuously"
+    return 1
+  fi
   reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+  if [[ -z "$reason" ]]; then
+    echo "No permissionDecisionReason found in output"
+    echo "Output: $output"
+    return 1
+  fi
   if [[ "$reason" != "$expected"* ]]; then
     echo "Expected suggestion to start with: $expected"
     echo "Got: $reason"

--- a/plugins/gh-cli/skills/gh-cli/SKILL.md
+++ b/plugins/gh-cli/skills/gh-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-cli
-description: Enforces authenticated gh CLI workflows over unauthenticated curl/WebFetch patterns. Use when working with GitHub URLs, API access, pull requests, or issues.
+description: Enforces authenticated gh CLI workflows over unauthenticated curl, WebFetch, and MCP fetch patterns. Use when working with GitHub URLs, API access, pull requests, or issues.
 ---
 
 # gh-cli
@@ -9,7 +9,7 @@ description: Enforces authenticated gh CLI workflows over unauthenticated curl/W
 
 - Working with GitHub repositories, pull requests, issues, releases, or raw file URLs.
 - You need authenticated access to private repositories or higher API rate limits.
-- You are about to use `curl`, `wget`, or unauthenticated web fetches against GitHub.
+- You are about to use `curl`, `wget`, `WebFetch`, or an MCP fetch tool against GitHub.
 
 ## When NOT to Use
 


### PR DESCRIPTION
## What

The gh-cli fetch hook only matched `WebFetch`. A GitHub URL fetched through an MCP fetch tool bypassed it entirely, so the plugin's premise — no unauthenticated GitHub access — did not hold for the fetch path many setups actually prefer.

The matcher is now `WebFetch|mcp__.*[Ff]etch`, which covers `mcp__exa__web_fetch_exa` and equivalents from other MCP servers.

A matcher alone is not enough. `WebFetch` passes a single `url`; MCP fetch tools pass a `urls` **array** and batch several pages into one call. The hook now reads both shapes:

```sh
urls=$(jq -r '[.tool_input.url?, (.tool_input.urls? | arrays | .[])]
  | map(select(type == "string" and . != ""))
  | .[]' 2>/dev/null) || exit 0
```

`arrays` drops a non-array `urls` instead of erroring; the `map(select(...))` drops nulls, numbers, and empty strings.

A tool call is atomic, so one GitHub URL anywhere in a batch denies the whole call, and each offending URL is labeled with its own suggestion so the model can tell which one was the problem. Single-URL calls keep the bare message they had.

The URL classification moved into `suggest_api`, `suggest_raw`, and `suggest_github_com` behind a `suggest_for_url` dispatcher, which is what lets it run per URL in a loop. That also collapses eight verbatim copies of the clone-hint string into one helper. Behavior is unchanged — `blob` and `tree` merge into one branch because they emitted identical text.

Also updated: the plugin README (matcher, both payload shapes, and the table now lists the `pull`, `issues`, `releases`, and `gist` patterns the hook already handled but never documented), the `SKILL.md` description, the root README row, and the version `1.5.1` → `1.6.0`.

## Testing

- 101/101 gh-cli bats tests pass — 32 pre-existing fetch, 10 new, 59 curl/session/shim.
- The 10 new tests were run against the old hook from `HEAD`: the 6 asserting new behavior fail there ("Expected deny JSON output, got empty"), and the 4 pass-through ones pass on both. The tests measure the fix rather than just accompanying it.
- `make lint shell validate` clean.
- Checked against a realistic Exa payload: `["https://docs.astral.sh/uv/", "https://raw.githubusercontent.com/astral-sh/uv/main/README.md"]` is denied with the offending URL named and a `gh repo clone astral-sh/uv` suggestion; the same batch without the GitHub URL passes through silently.

Two pre-existing failures on clean `main`, unrelated to this branch and confirmed by stashing: `make eval-self-tests` fails with 14 assertions in `property-based-testing/evals-extra/run.sh`, and `make python-tests` fails in `constant-time-analysis` on a machine without `javac` or a Rust `std` for the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
