### PR TITLE
constant-time-analysis: make the VLD version lookup portable

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "constant-time-analysis",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "description": "Detect compiler-induced timing side-channels in cryptographic code",
       "author": {
         "name": "Scott Arciszewski",

--- a/plugins/constant-time-analysis/.claude-plugin/plugin.json
+++ b/plugins/constant-time-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-time-analysis",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Detect compiler-induced timing side-channels in cryptographic code",
   "author": {
     "name": "Scott Arciszewski",

--- a/plugins/constant-time-analysis/README.md
+++ b/plugins/constant-time-analysis/README.md
@@ -135,9 +135,11 @@ PHP analysis uses either the VLD extension (recommended) or opcache debug output
 
 ```bash
 # Install VLD extension (recommended)
-# Query latest version from PECL
-VLD_VERSION=$(curl -s https://pecl.php.net/package/vld | grep -oP 'vld-\K[0-9.]+(?=\.tgz)' | head -1)
-pecl install channel://pecl.php.net/vld-${VLD_VERSION}
+# Query latest version from PECL. POSIX ERE, not `grep -P`: PCRE mode is a GNU
+# extension that stock macOS grep rejects, leaving VLD_VERSION empty.
+VLD_VERSION=$(curl -fsS https://pecl.php.net/package/vld |
+  grep -oE 'vld-[0-9]+(\.[0-9]+)*\.tgz' | head -1 | sed -E 's/^vld-//; s/\.tgz$//')
+[ -n "$VLD_VERSION" ] && pecl install channel://pecl.php.net/vld-${VLD_VERSION}
 
 # Or build from source (if PECL fails)
 git clone https://github.com/derickr/vld.git && cd vld

--- a/plugins/constant-time-analysis/skills/constant-time-analysis/references/php.md
+++ b/plugins/constant-time-analysis/skills/constant-time-analysis/references/php.md
@@ -11,15 +11,24 @@ The VLD (Vulcan Logic Dumper) extension is required for detailed opcode analysis
 **Option 1: PECL Install (Recommended)**
 
 ```bash
-# Query latest version from PECL
-VLD_VERSION=$(curl -s https://pecl.php.net/package/vld | grep -oP 'vld-\K[0-9.]+(?=\.tgz)' | head -1)
-echo "Latest VLD version: $VLD_VERSION"
+# Query latest version from PECL. POSIX ERE, not `grep -P`: PCRE mode is a GNU
+# extension and stock macOS grep exits 2 on it, which would silently leave
+# VLD_VERSION empty and install a package named `vld-` with no version.
+VLD_VERSION=$(curl -fsS https://pecl.php.net/package/vld |
+  grep -oE 'vld-[0-9]+(\.[0-9]+)*\.tgz' | head -1 | sed -E 's/^vld-//; s/\.tgz$//')
 
-# Install via PECL channel URL (avoids version detection issues)
-pecl install channel://pecl.php.net/vld-${VLD_VERSION}
+if [ -z "$VLD_VERSION" ]; then
+  echo "Could not read the latest VLD version from PECL." >&2
+  echo "Check https://pecl.php.net/package/vld and set VLD_VERSION by hand." >&2
+else
+  echo "Latest VLD version: $VLD_VERSION"
 
-# Or if above fails, install with explicit channel:
-pecl install https://pecl.php.net/get/vld-${VLD_VERSION}.tgz
+  # Install via PECL channel URL (avoids version detection issues)
+  pecl install channel://pecl.php.net/vld-${VLD_VERSION}
+
+  # Or if above fails, install with explicit channel:
+  pecl install https://pecl.php.net/get/vld-${VLD_VERSION}.tgz
+fi
 ```
 
 **Option 2: Build from Source**


### PR DESCRIPTION
## What

Both copies of the PECL install snippet — `skills/constant-time-analysis/references/php.md:15` and `README.md:139` — ran:

```bash
VLD_VERSION=$(curl -s https://pecl.php.net/package/vld | grep -oP 'vld-\K[0-9.]+(?=\.tgz)' | head -1)
pecl install channel://pecl.php.net/vld-${VLD_VERSION}
```

PCRE mode is a GNU extension. Reproduced under stock macOS grep:

```
grep: invalid option -- P
VLD_VERSION=[]
would run: pecl install channel://pecl.php.net/vld-
```

grep exits 2, the command substitution yields an empty string, and the next line installs a package named `vld-` with no version — a confusing failure several steps removed from its cause. This is the silent-zero-result shape `AGENTS.md` calls the most expensive bug class in this repo.

Three separate things allowed it, so all three are fixed:

- **`grep -oP` → `grep -oE`.** `grep -oE 'vld-[0-9]+(\.[0-9]+)*\.tgz' | head -1 | sed -E 's/^vld-//; s/\.tgz$//'` preserves the `-o` semantics — every match, one per line, newest first as PECL orders them.
- **`curl -s` → `curl -fsS`,** so an HTTP error or DNS failure is reported instead of feeding empty input downstream.
- **A guard.** The install runs only when `VLD_VERSION` is non-empty; otherwise the reader gets the URL and is told to set it by hand.

## Testing

Fetched the live PECL page rather than guessing at its markup, and ran both pipelines over it — the old form (via `ugrep`, which has `-P`) and the new one both return **0.19.1**, so behaviour is unchanged wherever the old form worked at all.

Then executed both snippets with `PATH=/usr/bin:/bin` to force BSD tools:

| Snippet | Success path | PECL unreachable |
|---|---|---|
| `references/php.md` | `Latest VLD version: 0.19.1`, install proceeds | prints the fallback guidance, no install attempted |
| `README.md` | `pecl install channel://pecl.php.net/vld-0.19.1` | exits 1, no install attempted |

`make validate` clean (0 errors), `prek` passes. Version `0.2.1` → `0.2.2`, PATCH.

## Related, not in this PR

The same one-liner shape appears twice more, as the identical `man curl | grep -oP '^\s*(--|-)\K\S+'` dictionary-extraction command in `testing-handbook-skills/skills/fuzzing-dictionary/SKILL.md:87` and `libfuzzer/SKILL.md:480`. Left out deliberately: that plugin has an open PR (#276) which already bumps its version, so fixing them here would collide on the version line.

Worth doing once those land: the repo validator already scans `.md` files for legacy `pip`/`python` invocations, and a `grep -P` check would sit beside it and stop this recurring. That guard only arms cleanly once every site is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
