### PR TITLE
mutation-testing: verify source files with find, not a ** glob

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -126,7 +126,7 @@
     },
     {
       "name": "mutation-testing",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Configures mewt or muton mutation testing campaigns — scopes targets, tunes timeouts, and optimizes long-running runs. Use when the user mentions mewt, muton, mutation testing, or wants to configure or optimize a mutation testing campaign.",
       "author": {
         "name": "Trail of Bits",

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mutation-testing",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Configures mewt or muton mutation testing campaigns — scopes targets, tunes timeouts, and optimizes long-running runs. Use when the user mentions mewt, muton, mutation testing, or wants to configure or optimize a mutation testing campaign.",
   "author": {
     "name": "Trail of Bits",

--- a/plugins/mutation-testing/skills/mutation-testing/workflows/configuration.md
+++ b/plugins/mutation-testing/skills/mutation-testing/workflows/configuration.md
@@ -277,8 +277,10 @@ mewt print mutations --language rust
 **Verify patterns:**
 ```bash
 mewt print config
-ls src/**/*.rs  # Do files exist and match include patterns?
+find src -name '*.rs' | head  # Do source files exist where include points?
 ```
+
+`find`, not `ls src/**/*.rs`. Whether `**` recurses depends on the shell: zsh expands it, bash does not unless `globstar` is set, and the bash 3.2 that macOS ships has no `globstar` option to set. So the `ls` form degrades to `src/*/*.rs` under bash — given `src/top.rs`, `src/a/one.rs`, and `src/a/b/two.rs` it lists only `src/a/one.rs` — while the same line is correct under zsh. A diagnostic that under-reports on some machines and not others is worse than none: the files it drops read as "the include pattern doesn't match," sending you to edit a pattern that was already right. `find` behaves identically in every shell and exits 0 when nothing matches, instead of erroring. Keep the `**` in `mewt.toml`, where mewt expands it rather than the shell.
 
 **Common causes:**
 - Include pattern doesn't match files


### PR DESCRIPTION
## What

The **Verify patterns** step under *No Mutants Generated* ran `ls src/**/*.rs` to answer whether source files exist where the include pattern points.

Whether `**` recurses depends on the shell. zsh expands it; bash does not unless `globstar` is set; and the bash 3.2 that macOS ships has no `globstar` option to set, so there is no workaround there. Under bash the glob degrades to `src/*/*.rs`.

Measured on a tree holding `src/top.rs`, `src/a/one.rs`, `src/a/b/two.rs`, `src/a/b/c/three.rs`:

| Command | Files listed |
|---|---|
| `find src -name '*.rs'` | 4 |
| `ls src/**/*.rs` (bash 3.2, macOS default) | **1** — only `src/a/one.rs` |
| `ls src/**/*.rs` (zsh) | 4 |

So the one command whose job is confirming the include pattern matches files instead under-reported the files that matched it — on some machines and not others. The files it drops read as "include pattern doesn't match," which is the first entry in the **Common causes** list printed directly below it, sending someone to edit a pattern that was already correct.

## Change

```diff
-ls src/**/*.rs  # Do files exist and match include patterns?
+find src -name '*.rs' | head  # Do source files exist where include points?
```

`find` behaves identically in every shell and exits 0 when nothing matches rather than erroring. The added note records why, with the numbers above.

Only the unquoted shell glob changed. The `**` in `mewt.toml` `include` values and in quoted `--target 'src/auth/**/*.rs'` arguments is mewt's own glob syntax — expanded by mewt, not the shell — and is correct as written. The note says so explicitly, so the fix does not spread there.

Version 1.0.2 → 1.0.3.

## Verification

- Behavior confirmed on a real fixture rather than from memory; the table above is measured output. `shopt -s globstar` fails on this machine with `invalid shell option name` (bash 3.2.57).
- `make validate --base-ref origin/main` clean; version-increment check passes.
- JSON parses, no trailing whitespace, final newlines intact. The plugin ships no scripts or tests.

This repo already documents the same pitfall in two places — the `shell-suites` comment in `Makefile` and `plugins/rust-review/skills/rust-review/SKILL.md:70` — so the `find` form is the house-standard fix.

Related: #281 (same glob-audit pass, different plugin). Independent branches, either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)