### PR TITLE
audit-context-building: add a dispatch-routing eval case

### DIFF
--- a/plugins/audit-context-building/README.md
+++ b/plugins/audit-context-building/README.md
@@ -99,7 +99,7 @@ claude plugin eval plugins/audit-context-building --judge-model sonnet
 Run it against the plugin **by name**. That way the tests run twice — once with the plugin and once without —
 so you can see what it actually adds. Pointing at a folder path instead only runs it once.
 
-Four tests, covering the three kinds of target this plugin gets used on.
+Five tests, covering the three kinds of target this plugin gets used on.
 
 **`dispatches-not-inlines`** — asks for audit context on a small C codebase with no way to hand the work off,
 so the only correct move is to say what to run and stop. It fails if the reply contains the analysis instead.
@@ -107,6 +107,18 @@ This is the test aimed at what the plugin actually changes, rather than at what 
 
 Its `max_turns` was raised from 20 to 40 after the plugin arm was being truncated before it could answer,
 which scored as a routing failure. It has not been re-measured since. Run it before relying on its number.
+
+**`routes-to-workflow`** — the same C parser, graded on the tool call rather than the reply: does the run
+actually reach for `/audit-context-building:audit-context`? The case above withholds every dispatch tool and
+reads the prose, so it measures whether the skill *names* the mechanism, and a skill can describe the right
+routing without taking it. `Workflow` is kept out of `allowed_tools` here too, so the per-function fan-out
+never runs and the grader counts the attempt.
+
+Scored 1.00 over three runs. Two things that does not establish. No with-plugin-versus-without arm has been
+run, so nothing yet shows the case can go red. And because `tool_used` counts attempts while the Workflow
+tool does not execute inside an eval run at all, a frontmatter restriction that blocked execution rather than
+the attempt would be invisible to it — adding and removing `Workflow` from the skill's `allowed-tools` scored
+1.00 either way. Do not read a green score here as proof that line is correct.
 
 **`contract-continuity`** — Solidity. `release()` looks like `require(_charge(...))` confirms the buyer had
 enough credit. It doesn't: for whitelisted accounts, `_charge` subtracts and returns true without ever

--- a/plugins/audit-context-building/evals/routes-to-workflow/case.yaml
+++ b/plugins/audit-context-building/evals/routes-to-workflow/case.yaml
@@ -1,0 +1,41 @@
+schema_version: "1.1"
+name: routes-to-workflow
+description: >
+  The sibling case `dispatches-not-inlines` withholds every dispatch tool and grades the response text, so it
+  measures whether the skill names the mechanism. This one grades the tool call instead: does the run actually
+  reach for `/audit-context-building:audit-context` when it has the chance? Both signals are worth having —
+  a skill can describe the right routing in prose and still not take it.
+
+  The workflow is intentionally left out of `allowed_tools`, following
+  `spec-to-code-compliance/evals/routes-not-inline`: the attempt is what is graded, and letting the per-function
+  fan-out actually run would cost more than the rest of the suite combined.
+
+  What this case cannot do, measured rather than assumed: it does not isolate the skill's `allowed-tools` line.
+  Adding and removing `Workflow` from that line scored 1.00 either way, 3 runs each — the dispatch was attempted
+  in all six. `tool_used` counts attempted calls rather than successful ones, and the Workflow tool does not
+  execute inside an eval run at all, so a frontmatter restriction that blocks execution rather than the attempt
+  would be invisible here. Isolating that needs a `file_exists` grader on `audit-context/DOSSIER.md` with
+  `Workflow` granted, which buys the attribution by paying for the real fan-out on every run.
+
+  Do not read a green score here as proof the frontmatter is correct. It is evidence that the routing happens,
+  which is the thing worth regression-testing.
+tags: [dispatch, output-discipline]
+
+context:
+  add_dirs: [fixture]
+
+execution:
+  prompt: |
+    The fixture directory has a small C parser — proto.c, proto.h, and frame.c.
+
+    We're starting an audit next week. Build the audit context now, so whoever picks it up starts from what
+    you produce instead of re-reading the parser from scratch.
+  max_turns: 20
+  timeout_seconds: 600
+  allowed_tools: [Read, Glob, Grep, Skill]
+
+runs: 3
+
+expected_outcome: >
+  The run invokes the audit-context-building skill and dispatches /audit-context-building:audit-context,
+  rather than analyzing the parser's functions in the invoking context.

--- a/plugins/audit-context-building/evals/routes-to-workflow/fixture/frame.c
+++ b/plugins/audit-context-building/evals/routes-to-workflow/fixture/frame.c
@@ -1,0 +1,59 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "proto.h"
+
+struct frame {
+    uint8_t  payload[MAX_PAYLOAD];
+    size_t   len;
+    uint32_t seq;
+};
+
+static struct frame *g_pending[16];
+static unsigned      g_pending_count;
+
+int frame_ingest(const uint8_t *buf, size_t buf_len, uint32_t seq)
+{
+    struct frame *f;
+
+    if (g_pending_count >= 16)
+        return -1;
+
+    f = calloc(1, sizeof(*f));
+    if (!f)
+        return -1;
+
+    if (parse_record(buf, buf_len, f->payload) != 0) {
+        free(f);
+        return -1;
+    }
+
+    f->seq = seq;
+    g_pending[g_pending_count++] = f;
+    return 0;
+}
+
+struct frame *frame_take(uint32_t seq)
+{
+    unsigned i;
+
+    for (i = 0; i < g_pending_count; i++) {
+        if (g_pending[i]->seq == seq) {
+            struct frame *f = g_pending[i];
+            g_pending[i] = g_pending[--g_pending_count];
+            return f;
+        }
+    }
+
+    return NULL;
+}
+
+void frame_flush(void)
+{
+    unsigned i;
+
+    for (i = 0; i < g_pending_count; i++)
+        free(g_pending[i]);
+
+    g_pending_count = 0;
+}

--- a/plugins/audit-context-building/evals/routes-to-workflow/fixture/proto.c
+++ b/plugins/audit-context-building/evals/routes-to-workflow/fixture/proto.c
@@ -1,0 +1,45 @@
+#include <string.h>
+
+#include "proto.h"
+
+static int decode_length(const struct header *h, size_t *out_len)
+{
+    if (h->flags & FLAG_EXTENDED) {
+        *out_len = ((size_t)(h->flags >> 4) << 16) | h->payload_len;
+        return 0;
+    }
+
+    if (h->payload_len > MAX_PAYLOAD)
+        return -1;
+
+    *out_len = h->payload_len;
+    return 0;
+}
+
+int validate_header(const uint8_t *buf, size_t buf_len, size_t *out_len)
+{
+    struct header h;
+
+    if (buf_len < HEADER_LEN)
+        return -1;
+
+    h.version     = buf[0];
+    h.flags       = buf[1];
+    h.payload_len = (uint16_t)((buf[2] << 8) | buf[3]);
+
+    if (h.version != PROTO_VERSION)
+        return -1;
+
+    return decode_length(&h, out_len);
+}
+
+int parse_record(const uint8_t *buf, size_t buf_len, uint8_t *dst)
+{
+    size_t payload_len;
+
+    if (validate_header(buf, buf_len, &payload_len) != 0)
+        return -1;
+
+    memcpy(dst, buf + HEADER_LEN, payload_len);
+    return 0;
+}

--- a/plugins/audit-context-building/evals/routes-to-workflow/fixture/proto.h
+++ b/plugins/audit-context-building/evals/routes-to-workflow/fixture/proto.h
@@ -1,0 +1,36 @@
+#ifndef PROTO_H
+#define PROTO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define PROTO_VERSION  2
+#define MAX_PAYLOAD    256
+#define HEADER_LEN     4
+
+/* Frame flags, header byte 1. The high nibble is reserved for extended
+ * frames; the low nibble holds the flags below. */
+#define FLAG_COMPRESSED  0x01
+#define FLAG_EXTENDED    0x02
+
+struct header {
+    uint8_t  version;
+    uint8_t  flags;
+    uint16_t payload_len;
+};
+
+/*
+ * Validates a frame header.
+ *
+ * Returns 0 on success, -1 on failure. On success *out_len holds the decoded
+ * payload length, bounded to MAX_PAYLOAD.
+ */
+int validate_header(const uint8_t *buf, size_t buf_len, size_t *out_len);
+
+/*
+ * Copies one record's payload out of buf into dst.
+ * dst must have room for MAX_PAYLOAD bytes.
+ */
+int parse_record(const uint8_t *buf, size_t buf_len, uint8_t *dst);
+
+#endif /* PROTO_H */

--- a/plugins/audit-context-building/evals/routes-to-workflow/graders/dispatches-the-workflow.md
+++ b/plugins/audit-context-building/evals/routes-to-workflow/graders/dispatches-the-workflow.md
@@ -1,0 +1,7 @@
+---
+type: tool_used
+tool: Workflow
+input_match: audit-context
+min: 1
+weight: 1
+---

--- a/plugins/audit-context-building/evals/routes-to-workflow/graders/invokes-the-skill.md
+++ b/plugins/audit-context-building/evals/routes-to-workflow/graders/invokes-the-skill.md
@@ -1,0 +1,7 @@
+---
+type: tool_used
+tool: Skill
+input_match: audit-context-building
+min: 1
+weight: 1
+---

--- a/plugins/audit-context-building/skills/audit-context-building/SKILL.md
+++ b/plugins/audit-context-building/skills/audit-context-building/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit-context-building
 description: Understand a codebase before looking for bugs in it - what each function assumes, what it guarantees, and what it depends on elsewhere. Use when starting an audit, threat model, or architecture review on unfamiliar code, and before any vulnerability-hunting pass.
-allowed-tools: Task Read Grep Glob
+allowed-tools: Workflow Task Read Grep Glob
 ---
 
 # Audit Context Building


### PR DESCRIPTION
## What this adds

`plugins/audit-context-building/evals/routes-to-workflow/` — an eval case that grades whether a run dispatches `/audit-context-building:audit-context`, rather than grading what the response says about it.

The four existing cases grade response text and per-function analysis quality. `dispatches-not-inlines` comes closest, but it deliberately withholds every dispatch tool (`allowed_tools: [Read, Glob, Grep, Skill]`) and grades the reply, so it measures whether the skill *names* the mechanism. A skill can describe the right routing in prose and not take it; nothing in the suite caught that.

The new case follows `spec-to-code-compliance/evals/routes-not-inline`: `Workflow` stays out of `allowed_tools` so the per-function fan-out never runs, and `tool_used` counts the attempt. Two graders, `tool_used: Skill` and `tool_used: Workflow`. Scored 1.00 over 3 runs at \$4.48.

It also adds `Workflow` to the skill's `allowed-tools`, matching what `spec-to-code-compliance` carries for the same skill-routes-to-its-own-workflow shape.

## On the allowed-tools line, and why the version is unchanged

I added it expecting it to matter, then measured it and it does not. With `Workflow` and without it, the case scored 1.00 — 3 runs each, dispatch attempted in all six. The frontmatter does not suppress the reach for the workflow.

What that result does *not* cover: `tool_used` counts attempted calls rather than successful ones, and the Workflow tool does not execute inside an eval run at all, so a restriction that blocks execution rather than the attempt would be invisible to this case. Isolating that needs a `file_exists` grader on `audit-context/DOSSIER.md` with `Workflow` granted, which buys the attribution by paying for the real fan-out on every run. The case description records this so nobody reads a green score as proof the frontmatter is correct.

Since the change is inert by the only available measurement, the version stays at 2.0.0 and this carries `no-version-bump`. Shipping it as a fix with a bump would advertise a behavior change that was measured not to happen.

## Testing

- `make validate` — clean, no errors
- `claude plugin eval plugins/audit-context-building --case routes-to-workflow --ablation none` — 1.00, 3/3
- `case.yaml` parses; no trailing whitespace, all files newline-terminated

`prek` / `pre-commit` are not installed on the machine this was authored on, so the rest of the hook set (actionlint, zizmor, check-yaml, end-of-file-fixer, trailing-whitespace) has not run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)