### PR TITLE
burpsuite-project-parser: fail rather than report an unverified search as clean

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "burpsuite-project-parser",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "description": "Search and extract data from Burp Suite project files (.burp) for security analysis",
       "author": {
         "name": "Will Vandevanter"

--- a/plugins/burpsuite-project-parser/.claude-plugin/plugin.json
+++ b/plugins/burpsuite-project-parser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "burpsuite-project-parser",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Search and extract data from Burp Suite project files (.burp) for security analysis",
   "author": {
     "name": "Will Vandevanter",

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
@@ -53,6 +53,23 @@ matched nothing.
 Anything other than 0 means the search result is unverified, and saying "no matching traffic" on the strength
 of it is a false negative reported as a clean finding.
 
+**Through a pipe the exit code is not yours to read.** A pipeline reports the status of its *last* command, and
+nearly every example here ends in `| jq`, `| head` or `| wc -cl` — so `$?` is `head`'s 0, not the script's 3.
+Two reliable signals:
+
+- **stderr**, which reaches you regardless of piping. `Error: the parser produced no output.` or
+  `Error: Burp produced output, but not one JSON object` is the answer; no such block means the run was fine.
+- **`set -o pipefail`** when you want the code itself, or read `${PIPESTATUS[0]}`:
+
+```bash
+set -o pipefail
+{baseDir}/scripts/burp-search.sh project.burp auditItems | jq -c 'select(.severity == "High")'
+echo "exit: $?"
+```
+
+Non-JSON output never reaches stdout, so a downstream `grep` or `jq` cannot match a Burp startup banner and
+mistake it for data.
+
 See [Platform Configuration](#platform-configuration) for setup instructions.
 
 ## Sub-Component Filters (USE THESE)

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
@@ -47,11 +47,34 @@ matched nothing.
 |------|---------|------------|
 | 0 | Output produced | Proceed |
 | 1 | Bad usage, or a missing file, Java or JAR | Read the message; fix the path |
-| 3 | No output at all | **Do not report this as "nothing found".** An empty result set and an unloaded extension are indistinguishable from here. Confirm the extension is loaded, then re-run; if it is loaded, the query genuinely matched nothing |
+| 3 | No output at all | **Do not report this as "nothing found".** An empty result set and an unloaded extension are indistinguishable from here. Run the control query below to tell them apart |
 | 4 | Output was not JSON | The extension is not loaded and Burp ignored the flags. Install it before trusting any result |
 
 Anything other than 0 means the search result is unverified, and saying "no matching traffic" on the strength
 of it is a false negative reported as a clean finding.
+
+### Resolving Exit 3: the control query
+
+Exit 3 is the common case — most narrowly-scoped regexes legitimately match nothing — so it needs a resolution
+you can carry out yourself. You have `Bash` and `Read`; Burp runs headless here, so there is no Extensions tab
+to open and no GUI to inspect. Re-running the same query just returns 3 again.
+
+Run a **control query** instead: a selector broad enough that it must return rows if the parser is working at
+all, against the same project file.
+
+```bash
+{baseDir}/scripts/burp-search.sh project.burp proxyHistory | head -n 1
+```
+
+| Control result | What it means | What to do |
+|---|---|---|
+| Rows on stdout | The parser works | Your narrower query genuinely matched nothing. Report that as a result |
+| Exit 3 again | Nothing comes back at all | Either the extension is not loaded, or this project holds no proxy history. Check you named the right project file and that it is non-empty, then ask the user to confirm `burpsuite-project-file-parser` under Burp Suite → Extensions |
+| Exit 4 | Burp started and dropped the flags | The extension is not loaded. Say so; do not report on traffic |
+
+**Run the control before concluding anything about the project's traffic.** Assuming the extension is loaded is
+exactly how an unverified empty result becomes a clean bill of health — and asking the user to check the GUI is
+a legitimate answer where the control is inconclusive. Guessing is not.
 
 **Through a pipe the exit code is not yours to read.** A pipeline reports the status of its *last* command, and
 nearly every example here ends in `| jq`, `| head` or `| wc -cl` — so `$?` is `head`'s 0, not the script's 3.

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
@@ -60,11 +60,17 @@ you can carry out yourself. You have `Bash` and `Read`; Burp runs headless here,
 to open and no GUI to inspect. Re-running the same query just returns 3 again.
 
 Run a **control query** instead: a selector broad enough that it must return rows if the parser is working at
-all, against the same project file.
+all, against the same project file. Use the sub-component filter, not the bare selector — a control is still a
+query, and the rules above apply to it unchanged.
 
 ```bash
-{baseDir}/scripts/burp-search.sh project.burp proxyHistory | head -n 1
+{baseDir}/scripts/burp-search.sh project.burp proxyHistory.request.headers | head -c 2000
 ```
+
+`proxyHistory.request.headers` is the right control precisely because it is broad but bounded: it covers every
+record in the project, at under 1KB each. Bare `proxyHistory` would answer the same question and is banned
+above for a reason — one record with bodies can be megabytes, and `head -n 1` does not stop that, it delivers
+exactly one of them in full.
 
 | Control result | What it means | What to do |
 |---|---|---|

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/SKILL.md
@@ -39,6 +39,20 @@ The script uses environment variables for platform compatibility:
 - `BURP_JAVA`: Path to Java executable
 - `BURP_JAR`: Path to burpsuite_pro.jar
 
+**Check the exit code. Empty output is not a clean result.** Burp ignores flags it does not recognise, so
+without the parser extension it starts normally and drops the query — which looks exactly like a search that
+matched nothing.
+
+| Exit | Meaning | What to do |
+|------|---------|------------|
+| 0 | Output produced | Proceed |
+| 1 | Bad usage, or a missing file, Java or JAR | Read the message; fix the path |
+| 3 | No output at all | **Do not report this as "nothing found".** An empty result set and an unloaded extension are indistinguishable from here. Confirm the extension is loaded, then re-run; if it is loaded, the query genuinely matched nothing |
+| 4 | Output was not JSON | The extension is not loaded and Burp ignored the flags. Install it before trusting any result |
+
+Anything other than 0 means the search result is unverified, and saying "no matching traffic" on the strength
+of it is a false negative reported as a clean finding.
+
 See [Platform Configuration](#platform-configuration) for setup instructions.
 
 ## Sub-Component Filters (USE THESE)
@@ -162,6 +176,9 @@ The `wc -cl` output shows: `<bytes> <lines>` (e.g., `524288 42` means 512KB acro
 
 **A single 10MB response on one line will show high byte count but only 1 line - the byte check catches this.**
 
+`0 0` from `wc -cl` is not a size to act on — the script exited 3 and nothing was verified. Piping hides that,
+so re-run the query on its own and read the exit code before concluding the project holds no matching traffic.
+
 ### Step 2: Refine Broad Searches
 
 If count/size is too high:
@@ -284,6 +301,7 @@ Common shortcuts that lead to missed vulnerabilities or false reports:
 | "All audit items are relevant" | Filter by actual threat model; not every finding matters for every app |
 | "Proxy history is complete" | May be filtered by Burp scope/intercept settings; you see only what Burp captured |
 | "Burp found it, so it's a vuln" | Burp findings require manual verification—they indicate potential issues, not proof |
+| "The search returned nothing, so the traffic isn't there" | Check the exit code first. Exit 3 means the script could not tell an empty result from an unloaded extension, and exit 4 means the query never ran. Only a 0 makes "nothing found" a statement about the project rather than about the tooling |
 
 ## Output Format
 

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
@@ -16,6 +16,10 @@ set -euo pipefail
 # Twenty lines is enough to recognise a licence banner or a Java stack trace; the suppressed count is what says
 # the stream kept going.
 readonly STDERR_LINE_CAP=20
+# And how long any one of those lines may be. The line cap alone bounds nothing when the stream is one very
+# long line, which SKILL.md:217 already records as a real shape ("A single 10MB response on one line will show
+# high byte count but only 1 line").
+readonly STDERR_LINE_MAXLEN=500
 
 # Platform-specific default paths
 case "$(uname -s)" in
@@ -139,11 +143,23 @@ fi
 set +e
 "$JAVA_PATH" -jar -Djava.awt.headless=true "$BURP_JAR" \
   --project-file="$PROJECT_FILE" \
-  "$@" | awk -v cap="$STDERR_LINE_CAP" '
+  "$@" | awk -v cap="$STDERR_LINE_CAP" -v maxlen="$STDERR_LINE_MAXLEN" '
     /^[[:space:]]*\{/ { print; fflush(); json++; next }
+    # A blank or whitespace-only line is not output Burp meant to produce, and counting it makes an
+    # empty-but-correct result exit 4 with "the extension is not loaded" -- a wrong diagnosis on a healthy
+    # install, off one trailing newline. It also mirrors as a diagnostic with nothing after the colon.
+    /^[[:space:]]*$/ { next }
     {
       other++
-      if (other <= cap) print "burp-search.sh: ignored non-JSON output: " $0 > "/dev/stderr"
+      if (other <= cap) {
+        line = $0
+        # The cap bounds how many lines are mirrored; this bounds how long one may be. Without it a single
+        # 10 MB line -- a raw body or a base64 blob, which SKILL.md documents as a real shape -- passes the
+        # count check and is written to stderr in full, where the documented `head -c` on stdout cannot reach
+        # it. These bytes come from captured HTTP traffic, so length is attacker-influenced.
+        if (length(line) > maxlen) line = substr(line, 1, maxlen) " ... [truncated, " length($0) " bytes]"
+        print "burp-search.sh: ignored non-JSON output: " line > "/dev/stderr"
+      }
     }
     END {
       if (other > cap) {
@@ -175,7 +191,7 @@ case "$awk_status" in
     echo "Tell them apart with a control query -- a selector that must return rows if the parser is" >&2
     echo "working at all, run against the same project file:" >&2
     echo "" >&2
-    printf '  %s %q proxyHistory | head -n 1\n' "$0" "$PROJECT_FILE" >&2
+    printf '  %s %q proxyHistory.request.headers | head -c 2000\n' "$0" "$PROJECT_FILE" >&2
     echo "" >&2
     echo "  rows on stdout -> the parser works, and your narrower query genuinely matched nothing." >&2
     echo "                    Report that as a result, not as a failure." >&2

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
@@ -4,6 +4,19 @@
 
 set -euo pipefail
 
+# How many non-JSON lines are echoed to stderr before the rest are counted instead of printed.
+#
+# Uncapped this is a hole, not a diagnostic. When NO line is JSON -- the missing-extension case this script
+# exists to catch -- awk never writes to stdout, so it never takes SIGPIPE, so a documented downstream
+# `head -c 50000` cannot close the pipeline early. It blocks to EOF while every line Burp produced is mirrored
+# to stderr, where the caller captures it and no documented output limit applies. Measured against a 100k-line
+# non-JSON stream: 8.4 MB of stderr behind a `head -c 200` that could not terminate. Under the bare exec this
+# replaced, those bytes went to stdout where `head` truncated them.
+#
+# Twenty lines is enough to recognise a licence banner or a Java stack trace; the suppressed count is what says
+# the stream kept going.
+readonly STDERR_LINE_CAP=20
+
 # Platform-specific default paths
 case "$(uname -s)" in
   Darwin)
@@ -126,10 +139,19 @@ fi
 set +e
 "$JAVA_PATH" -jar -Djava.awt.headless=true "$BURP_JAR" \
   --project-file="$PROJECT_FILE" \
-  "$@" | awk '
+  "$@" | awk -v cap="$STDERR_LINE_CAP" '
     /^[[:space:]]*\{/ { print; fflush(); json++; next }
-    { print "burp-search.sh: ignored non-JSON output: " $0 > "/dev/stderr"; other++ }
-    END { if (json == 0 && other == 0) exit 3; if (json == 0) exit 4 }
+    {
+      other++
+      if (other <= cap) print "burp-search.sh: ignored non-JSON output: " $0 > "/dev/stderr"
+    }
+    END {
+      if (other > cap) {
+        printf "burp-search.sh: %d further non-JSON line(s) suppressed.\n", other - cap > "/dev/stderr"
+      }
+      if (json == 0 && other == 0) exit 3
+      if (json == 0) exit 4
+    }
   '
 pipe_status=("${PIPESTATUS[@]}")
 set -e
@@ -149,8 +171,22 @@ case "$awk_status" in
     echo "Error: the parser produced no output." >&2
     echo "Either the query matched nothing, or the burpsuite-project-file-parser extension is not" >&2
     echo "loaded -- this script cannot tell which, so it does not report success." >&2
-    echo "Check Burp Suite -> Extensions for burpsuite-project-file-parser, and that it is enabled." >&2
-    echo "With the extension confirmed loaded, no output means the query matched nothing." >&2
+    echo "" >&2
+    echo "Tell them apart with a control query -- a selector that must return rows if the parser is" >&2
+    echo "working at all, run against the same project file:" >&2
+    echo "" >&2
+    printf '  %s %q proxyHistory | head -n 1\n' "$0" "$PROJECT_FILE" >&2
+    echo "" >&2
+    echo "  rows on stdout -> the parser works, and your narrower query genuinely matched nothing." >&2
+    echo "                    Report that as a result, not as a failure." >&2
+    echo "  exit 3 again   -> nothing at all comes back through the parser. Either the extension is" >&2
+    echo "                    not loaded, or this project holds no proxy history. Check the project" >&2
+    echo "                    file is the one you meant and is non-empty, then check Burp Suite ->" >&2
+    echo "                    Extensions for burpsuite-project-file-parser." >&2
+    echo "  exit 4 again   -> Burp started and dropped the flags; the extension is not loaded." >&2
+    echo "" >&2
+    echo "Run the control query before concluding anything about this project's traffic. Assuming the" >&2
+    echo "extension is loaded is how an unverified empty result becomes a clean bill of health." >&2
     exit 3
     ;;
   4)

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
@@ -61,8 +61,11 @@ Output: JSON objects, one per line
 Exit codes:
   0   output produced
   1   bad usage, or a missing file, Java or JAR
-  3   no output -- an empty result set and a missing parser extension look the same
-  4   output was not JSON -- Burp ignored the query flags, extension not loaded
+  3   no output at all -- an empty result set and a missing parser extension look the same
+  4   output, but not one JSON object -- Burp ignored the query flags, extension not loaded
+
+Only JSON objects reach stdout; any other line is reported on stderr. Through a pipe the exit
+code is invisible, so stderr is the signal to read -- or set -o pipefail and check PIPESTATUS.
 EOF
   exit 1
 }
@@ -104,21 +107,24 @@ fi
 # Burp silently ignores flags it does not recognise, so with the parser extension missing it starts
 # normally and drops the query -- producing either its own non-JSON startup output or nothing at all.
 # Both look like a successful search that found nothing. Stream the output through awk so the common
-# case still pipes to jq/head unbuffered by a temp file, and classify what went past:
-#   exit 3  no output at all       -- an empty result set and a missing extension are indistinguishable
-#   exit 4  output that is not JSON -- the flags were dropped; the extension is not loaded
+# case still pipes to jq/head unbuffered by a temp file, and classify the WHOLE stream rather than
+# just its first line. Judging line 1 alone breaks both ways: a working install may print a licence
+# or startup line before the JSON, and a Java log line like `[main] INFO ...` would pass a check
+# that accepts a leading `[`.
+#
+# Only JSON objects reach stdout. Anything else goes to stderr rather than being dropped, so a
+# downstream `grep` or `jq` can never match a startup banner.
+#   exit 3  nothing at all      -- an empty result set and a missing extension are indistinguishable
+#   exit 4  output, but no JSON -- the flags were dropped; the extension is not loaded
 # `set +e` rather than `|| true`: `true` is a command of its own and would reset PIPESTATUS before it
 # could be read.
 set +e
 "$JAVA_PATH" -jar -Djava.awt.headless=true "$BURP_JAR" \
   --project-file="$PROJECT_FILE" \
   "$@" | awk '
-    NR == 1 && $0 !~ /^[[:space:]]*[{[]/ {
-      not_json = 1
-      print "burp-search.sh: first line of output was not JSON: " $0 > "/dev/stderr"
-    }
-    { print; lines++ }
-    END { if (lines == 0) exit 3; if (not_json) exit 4 }
+    /^[[:space:]]*\{/ { print; json++; next }
+    { print "burp-search.sh: ignored non-JSON output: " $0 > "/dev/stderr"; other++ }
+    END { if (json == 0 && other == 0) exit 3; if (json == 0) exit 4 }
   '
 pipe_status=("${PIPESTATUS[@]}")
 set -e
@@ -143,7 +149,7 @@ case "$awk_status" in
     exit 3
     ;;
   4)
-    echo "Error: Burp produced output that is not JSON, so it ignored the query flags." >&2
+    echo "Error: Burp produced output, but not one JSON object, so it ignored the query flags." >&2
     echo "This is what a missing burpsuite-project-file-parser extension looks like: Burp starts" >&2
     echo "normally and drops flags it does not recognise." >&2
     echo "Install it from https://github.com/BuffaloWill/burpsuite-project-file-parser and add the" >&2

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
@@ -57,6 +57,12 @@ Examples:
   burp-search.sh project.burp proxyHistory.request.headers
 
 Output: JSON objects, one per line
+
+Exit codes:
+  0   output produced
+  1   bad usage, or a missing file, Java or JAR
+  3   no output -- an empty result set and a missing parser extension look the same
+  4   output was not JSON -- Burp ignored the query flags, extension not loaded
 EOF
   exit 1
 }
@@ -93,7 +99,59 @@ elif [ ! -f "$BURP_JAR" ]; then
   exit 1
 fi
 
-# Execute the search
+# Execute the search.
+#
+# Burp silently ignores flags it does not recognise, so with the parser extension missing it starts
+# normally and drops the query -- producing either its own non-JSON startup output or nothing at all.
+# Both look like a successful search that found nothing. Stream the output through awk so the common
+# case still pipes to jq/head unbuffered by a temp file, and classify what went past:
+#   exit 3  no output at all       -- an empty result set and a missing extension are indistinguishable
+#   exit 4  output that is not JSON -- the flags were dropped; the extension is not loaded
+# `set +e` rather than `|| true`: `true` is a command of its own and would reset PIPESTATUS before it
+# could be read.
+set +e
 "$JAVA_PATH" -jar -Djava.awt.headless=true "$BURP_JAR" \
   --project-file="$PROJECT_FILE" \
-  "$@"
+  "$@" | awk '
+    NR == 1 && $0 !~ /^[[:space:]]*[{[]/ {
+      not_json = 1
+      print "burp-search.sh: first line of output was not JSON: " $0 > "/dev/stderr"
+    }
+    { print; lines++ }
+    END { if (lines == 0) exit 3; if (not_json) exit 4 }
+  '
+pipe_status=("${PIPESTATUS[@]}")
+set -e
+java_status="${pipe_status[0]}"
+awk_status="${pipe_status[1]}"
+
+# 141 is SIGPIPE: a downstream `head` or `jq` closed the pipe early, which the documented workflows do
+# on purpose. The output already flowed, so it is not a failure.
+if [ "$java_status" -ne 0 ] && [ "$java_status" -ne 141 ]; then
+  echo "Error: Burp exited with status $java_status." >&2
+  exit "$java_status"
+fi
+
+case "$awk_status" in
+  0 | 141) ;;
+  3)
+    echo "Error: the parser produced no output." >&2
+    echo "Either the query matched nothing, or the burpsuite-project-file-parser extension is not" >&2
+    echo "loaded -- this script cannot tell which, so it does not report success." >&2
+    echo "Check Burp Suite -> Extensions for burpsuite-project-file-parser, and that it is enabled." >&2
+    echo "With the extension confirmed loaded, no output means the query matched nothing." >&2
+    exit 3
+    ;;
+  4)
+    echo "Error: Burp produced output that is not JSON, so it ignored the query flags." >&2
+    echo "This is what a missing burpsuite-project-file-parser extension looks like: Burp starts" >&2
+    echo "normally and drops flags it does not recognise." >&2
+    echo "Install it from https://github.com/BuffaloWill/burpsuite-project-file-parser and add the" >&2
+    echo "JAR under Burp Suite -> Extensions." >&2
+    exit 4
+    ;;
+  *)
+    echo "Error: output check failed with status $awk_status." >&2
+    exit "$awk_status"
+    ;;
+esac

--- a/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
+++ b/plugins/burpsuite-project-parser/skills/burpsuite-project-parser/scripts/burp-search.sh
@@ -106,11 +106,16 @@ fi
 #
 # Burp silently ignores flags it does not recognise, so with the parser extension missing it starts
 # normally and drops the query -- producing either its own non-JSON startup output or nothing at all.
-# Both look like a successful search that found nothing. Stream the output through awk so the common
-# case still pipes to jq/head unbuffered by a temp file, and classify the WHOLE stream rather than
-# just its first line. Judging line 1 alone breaks both ways: a working install may print a licence
-# or startup line before the JSON, and a Java log line like `[main] INFO ...` would pass a check
-# that accepts a leading `[`.
+# Both look like a successful search that found nothing. Stream the output through awk rather than a
+# temp file, so a large dump never lands on disk, and classify the WHOLE stream rather than just its
+# first line. Judging line 1 alone breaks both ways: a working install may print a licence or startup
+# line before the JSON, and a Java log line like `[main] INFO ...` would pass a check that accepts a
+# leading `[`.
+#
+# `fflush()` on every emitted line is load-bearing, not decoration: awk block-buffers when its stdout
+# is a pipe, and the documented workflows all pipe. Without it a long search over a large project
+# prints nothing until Burp exits, where the bare `exec` this replaced streamed line by line. The
+# flush restores that at the cost of one write per JSON object.
 #
 # Only JSON objects reach stdout. Anything else goes to stderr rather than being dropped, so a
 # downstream `grep` or `jq` can never match a startup banner.
@@ -122,7 +127,7 @@ set +e
 "$JAVA_PATH" -jar -Djava.awt.headless=true "$BURP_JAR" \
   --project-file="$PROJECT_FILE" \
   "$@" | awk '
-    /^[[:space:]]*\{/ { print; json++; next }
+    /^[[:space:]]*\{/ { print; fflush(); json++; next }
     { print "burp-search.sh: ignored non-JSON output: " $0 > "/dev/stderr"; other++ }
     END { if (json == 0 && other == 0) exit 3; if (json == 0) exit 4 }
   '

--- a/plugins/burpsuite-project-parser/tests/run_search_tests.sh
+++ b/plugins/burpsuite-project-parser/tests/run_search_tests.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Regression suite for burp-search.sh's output classification.
+#
+# Deterministic, offline, free. This is the suite `make shell-suites` and CI discover via
+# `find plugins -type f -path '*/tests/*' -name 'run_*.sh'`, so it must stay cheap and must
+# never need Burp Suite.
+#
+# What it exists to pin: the script's whole reason for classifying output is that Burp silently
+# ignores flags it does not recognise, so a missing parser extension produces a clean-looking
+# empty run. Every assertion below distinguishes "the query matched nothing" from "the query
+# never ran". Burp Pro is not a CI dependency, so a stub stands in for it -- which means this
+# suite proves the classification logic, NOT Burp's real behaviour. See the note at the end.
+#
+# The assertion count is asserted. A suite that stops running its checks reports success just as
+# loudly as one that passes them, which is the failure mode the script under test also exists to
+# prevent.
+
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/skills/burpsuite-project-parser/scripts/burp-search.sh"
+readonly EXPECTED_ASSERTIONS=16
+
+[ -x "$SCRIPT" ] || {
+  echo "run_search_tests.sh: not executable: $SCRIPT" >&2
+  exit 1
+}
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/burp-search-tests.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+touch "$WORK/project.burp" "$WORK/fake.jar"
+
+# Stands in for Burp. Ignores its arguments and replays STUB_MODE, which is the point: the real
+# Burp ignoring --project-file and the query flags is exactly the bug being guarded against.
+cat >"$WORK/java" <<'STUB'
+#!/usr/bin/env bash
+case "$STUB_MODE" in
+  json)     printf '{"a":1}\n{"b":2}\n' ;;
+  empty)    : ;;
+  banner)   printf 'Burp Suite Professional v2024.1\nStarting...\n' ;;
+  logline)  printf '[main] INFO burp.Startup - ready\n' ;;
+  mixed)    printf 'Burp Suite Professional\n{"a":1}\n' ;;
+  indented) printf '   {"a":1}\n' ;;
+  fail7)    printf 'boom\n' >&2; exit 7 ;;
+  jsonfail) printf '{"a":1}\n'; exit 7 ;;
+  big)      awk 'BEGIN{for(i=0;i<100000;i++) printf "{\"i\":%d}\n", i}' ;;
+  slow)     for i in 1 2 3; do printf '{"i":%d}\n' "$i"; sleep 1; done ;;
+esac
+STUB
+chmod +x "$WORK/java"
+
+PASS=0
+FAIL=0
+RAN=0
+
+eq() { # eq <actual> <expected> <description>
+  RAN=$((RAN + 1))
+  if [ "$1" = "$2" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ $3" >&2
+    echo "      expected: $2" >&2
+    echo "      actual:   $1" >&2
+  fi
+}
+
+contains() { # contains <haystack> <needle> <description>
+  RAN=$((RAN + 1))
+  case "$1" in
+    *"$2"*) PASS=$((PASS + 1)) ;;
+    *)
+      FAIL=$((FAIL + 1))
+      echo "  ✗ $3" >&2
+      echo "      expected to contain: $2" >&2
+      echo "      actual:              $1" >&2
+      ;;
+  esac
+}
+
+# Runs the script under a stub. Sets RC, OUT and ERR.
+run() { # run <stub-mode> [args...]
+  local mode=$1
+  shift
+  set +e
+  OUT=$(STUB_MODE="$mode" BURP_JAVA="$WORK/java" BURP_JAR="$WORK/fake.jar" \
+    "$SCRIPT" "$WORK/project.burp" query "$@" 2>"$WORK/err")
+  RC=$?
+  set -e
+  ERR=$(cat "$WORK/err")
+}
+
+echo "→ output classification"
+
+# The working case. Nothing else in this suite means anything if this does not hold.
+run json
+eq "$RC" "0" "JSON output must exit 0"
+eq "$(printf '%s' "$OUT" | grep -c '^')" "2" "both JSON lines must reach stdout"
+
+# The bug this PR exists for: no output is NOT a clean result, because an empty result set and an
+# unloaded extension are indistinguishable from here.
+run empty
+eq "$RC" "3" "no output must exit 3, not report success"
+contains "$ERR" "burpsuite-project-file-parser" "exit 3 must name the extension as a possibility"
+
+# Burp started normally and dropped the query flags -- what a missing extension looks like.
+run banner
+eq "$RC" "4" "a startup banner must exit 4"
+eq "$OUT" "" "a banner must never reach stdout, where a downstream jq could match it"
+contains "$ERR" "Burp Suite Professional v2024.1" "the offending line must be echoed to stderr"
+
+# A Java log line starts with `[`, so a check that accepted a leading bracket as JSON would pass it.
+run logline
+eq "$RC" "4" "a Java log line must exit 4, not be mistaken for JSON"
+
+# A working install may print a licence or startup line before the JSON. Classifying the whole
+# stream keeps that a success; judging line 1 alone would have failed it.
+run mixed
+eq "$RC" "0" "JSON preceded by a banner must still exit 0"
+eq "$OUT" '{"a":1}' "only the JSON half of a mixed stream reaches stdout"
+
+# Leading whitespace is still JSON.
+run indented
+eq "$RC" "0" "indented JSON must be recognised"
+
+# Burp's own failure must not be masked by the classification layer.
+run fail7
+eq "$RC" "7" "Burp's non-zero exit must propagate"
+run jsonfail
+eq "$RC" "7" "Burp's failure must win even when JSON was produced"
+
+echo "→ pipeline behaviour"
+
+# The documented workflows pipe to `head` on every call. SIGPIPE from an early close is not a
+# failure, and must not print an error the user will read as one.
+set +e
+big_out=$(STUB_MODE=big BURP_JAVA="$WORK/java" BURP_JAR="$WORK/fake.jar" \
+  "$SCRIPT" "$WORK/project.burp" query 2>"$WORK/err" | head -2)
+set -e
+eq "$(printf '%s' "$big_out" | grep -c '^')" "2" "a downstream head -2 must get its two lines"
+eq "$(wc -c <"$WORK/err" | tr -d ' ')" "0" "an early pipe close must produce no stderr noise"
+
+# awk block-buffers when stdout is a pipe, so without fflush() a long search prints nothing until
+# Burp exits. The bare exec this replaced streamed line by line; this keeps that.
+# SECONDS is reset inside the subshell, so this measures from the run rather than from suite
+# start. Compared as a threshold, not an exact second, so a loaded CI box does not flake: the
+# stub takes 3s total, and buffered output cannot appear before then.
+first_line_at=$(
+  SECONDS=0
+  STUB_MODE=slow BURP_JAVA="$WORK/java" BURP_JAR="$WORK/fake.jar" \
+    "$SCRIPT" "$WORK/project.burp" query 2>/dev/null |
+    while IFS= read -r _; do
+      echo "$SECONDS"
+      break
+    done
+)
+[ "$first_line_at" -lt 2 ] && streaming=yes || streaming=no
+eq "$streaming" "yes" "output must stream, not arrive only when the producer exits"
+
+echo
+if [ "$RAN" -ne "$EXPECTED_ASSERTIONS" ]; then
+  echo "✗ ran $RAN assertions, expected $EXPECTED_ASSERTIONS" >&2
+  echo "  A suite that stops running its checks passes as loudly as one that does not." >&2
+  echo "  Update EXPECTED_ASSERTIONS deliberately when adding or removing a check." >&2
+  exit 1
+fi
+
+echo "$PASS passed, $FAIL failed, $RAN run"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "$RAN assertions passed"
+
+# NOT covered, and worth knowing before trusting a green run: the stub proves the classification
+# logic, not Burp's actual behaviour with the extension missing. If Burp launches and waits for
+# input rather than exiting, neither exit 3 nor exit 4 fires and the script blocks indefinitely --
+# no timeout guards that. Settling it needs Burp Pro: rename the extension JAR, run one query, and
+# record the exit code and whether it returns at all.

--- a/plugins/burpsuite-project-parser/tests/run_search_tests.sh
+++ b/plugins/burpsuite-project-parser/tests/run_search_tests.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/skills/burpsuite-project-parser/scripts/burp-search.sh"
-readonly EXPECTED_ASSERTIONS=18
+readonly EXPECTED_ASSERTIONS=21
 
 [ -x "$SCRIPT" ] || {
   echo "run_search_tests.sh: not executable: $SCRIPT" >&2
@@ -46,6 +46,8 @@ case "$STUB_MODE" in
   jsonfail) printf '{"a":1}\n'; exit 7 ;;
   big)      awk 'BEGIN{for(i=0;i<100000;i++) printf "{\"i\":%d}\n", i}' ;;
   noisy)    awk 'BEGIN{for(i=0;i<100000;i++) print "Burp Suite Professional startup line " i}' ;;
+  longline) awk 'BEGIN{s="x"; while (length(s) < 2000000) s = s s; print s}' ;;
+  blank)    printf '\n   \n' ;;
   slow)     for i in 1 2 3; do printf '{"i":%d}\n' "$i"; sleep 1; done ;;
 esac
 STUB
@@ -172,6 +174,21 @@ noisy_bytes=$(wc -c <"$WORK/err" | tr -d ' ')
 eq "$capped" "yes" "stderr from a no-JSON stream must be capped, not mirrored in full"
 contains "$(cat "$WORK/err")" "further non-JSON line(s) suppressed" \
   "the cap must report how many lines it suppressed, so a truncated diagnostic is not mistaken for a short one"
+
+# The line cap bounds how MANY lines are mirrored, not how long one may be. SKILL.md:217 records a single 10MB
+# response on one line as a real shape, and those bytes are captured HTTP traffic -- attacker-influenced text
+# on a channel the documented `head -c` on stdout cannot reach.
+run longline
+eq "$RC" "4" "a single huge non-JSON line is still not JSON"
+long_bytes=$(printf '%s' "$ERR" | wc -c | tr -d ' ')
+[ "$long_bytes" -lt 5000 ] && bounded=yes || bounded=no
+eq "$bounded" "yes" "one very long non-JSON line must be truncated, not mirrored in full"
+
+# A trailing newline is not output Burp meant to produce. Counting it flips an empty-but-correct result to
+# exit 4 -- "the extension is not loaded" -- on a healthy install, and mirrors a diagnostic with nothing
+# after the colon.
+run blank
+eq "$RC" "3" "whitespace-only output must read as empty (exit 3), not as non-JSON (exit 4)"
 
 echo
 if [ "$RAN" -ne "$EXPECTED_ASSERTIONS" ]; then

--- a/plugins/burpsuite-project-parser/tests/run_search_tests.sh
+++ b/plugins/burpsuite-project-parser/tests/run_search_tests.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$PLUGIN_ROOT/skills/burpsuite-project-parser/scripts/burp-search.sh"
-readonly EXPECTED_ASSERTIONS=16
+readonly EXPECTED_ASSERTIONS=18
 
 [ -x "$SCRIPT" ] || {
   echo "run_search_tests.sh: not executable: $SCRIPT" >&2
@@ -45,6 +45,7 @@ case "$STUB_MODE" in
   fail7)    printf 'boom\n' >&2; exit 7 ;;
   jsonfail) printf '{"a":1}\n'; exit 7 ;;
   big)      awk 'BEGIN{for(i=0;i<100000;i++) printf "{\"i\":%d}\n", i}' ;;
+  noisy)    awk 'BEGIN{for(i=0;i<100000;i++) print "Burp Suite Professional startup line " i}' ;;
   slow)     for i in 1 2 3; do printf '{"i":%d}\n' "$i"; sleep 1; done ;;
 esac
 STUB
@@ -157,6 +158,20 @@ first_line_at=$(
 )
 [ "$first_line_at" -lt 2 ] && streaming=yes || streaming=no
 eq "$streaming" "yes" "output must stream, not arrive only when the producer exits"
+
+# A stream with NO JSON is the missing-extension case, and it is the one where awk never writes to stdout --
+# so it never takes SIGPIPE, and a downstream `head` cannot close the pipeline early. Uncapped, every line
+# Burp produced is mirrored to stderr, which the caller captures and no documented output limit covers.
+# Measured before the cap: 8.4 MB behind a `head -c 200` that could not terminate.
+set +e
+STUB_MODE=noisy BURP_JAVA="$WORK/java" BURP_JAR="$WORK/fake.jar" \
+  "$SCRIPT" "$WORK/project.burp" query 2>"$WORK/err" | head -c 200 >/dev/null
+set -e
+noisy_bytes=$(wc -c <"$WORK/err" | tr -d ' ')
+[ "$noisy_bytes" -lt 5000 ] && capped=yes || capped=no
+eq "$capped" "yes" "stderr from a no-JSON stream must be capped, not mirrored in full"
+contains "$(cat "$WORK/err")" "further non-JSON line(s) suppressed" \
+  "the cap must report how many lines it suppressed, so a truncated diagnostic is not mistaken for a short one"
 
 echo
 if [ "$RAN" -ne "$EXPECTED_ASSERTIONS" ]; then


### PR DESCRIPTION
## The gap

`burp-search.sh` ended in a bare `exec` of Burp and returned whatever came back. Burp silently ignores flags it does not recognise, so with the `burpsuite-project-file-parser` extension missing it starts normally, drops the query, and the script exits 0 with nothing on stdout. An agent reads that as "the project contains no matching traffic" and reports a clean result.

The extension is a prerequisite the script never verified.

## Why "empty output means error" is the wrong fix

My first framing of this was that empty output should simply be a failure. It should not: a narrow regex that matches nothing is a legitimate, correct, empty result, and failing on it turns a right answer into an error. The two cases are genuinely different and need separating.

- **Output that is not JSON → exit 4.** Deterministic. The parser emits JSON objects one per line; Burp's own startup banner does not. Non-JSON on line 1 means the flags were dropped, which is what a missing extension looks like.
- **No output at all → exit 3.** Stated plainly as what it is: an empty result set and an unloaded extension are indistinguishable from here, so the script does not report success. Not a claim of failure — a refusal to claim a clean result it cannot back. This is the `AGENTS.md` rule that a checker inspecting zero items must not pass.

Burp's own non-zero exits now propagate instead of being masked.

## Implementation

Output streams through `awk` rather than a temp file, so `| jq` and `| head` stay unbuffered and a large dump does not land on disk. SIGPIPE (141) from a downstream `head` closing early is explicitly **not** a failure — the documented workflows in SKILL.md do that deliberately on every call.

One bug worth recording, caught by the test rather than by reading: `... | awk '...' || true` resets `PIPESTATUS` to a single element, because `true` is a command of its own, so `pipe_status[1]` was unbound under `set -u`. Replaced with `set +e` around the pipeline.

## Testing

Verified against a stub standing in for Burp, since Burp Pro is not installed on the authoring machine:

| Stub behaviour | Exit | Result |
|---|---|---|
| Two JSON lines | 0 | both lines on stdout |
| No output | 3 | diagnostic naming both possibilities |
| Startup banner | 4 | offending first line echoed to stderr |
| Exits 7 | 7 | Burp's status propagated |
| 100k lines into `head -2` | — | 2 lines, no stderr noise |
| Documented `\| wc -cl` size check on an empty result | — | still `0 0`, pipeline unbroken |

`make shell` (shellcheck + shfmt) and `make validate` both clean.

## SKILL.md

An exit-code table in Quick Reference; a note that `0 0` from the documented size check is not a size to act on because the script exited 3 and the pipe hid it; and a Rationalizations row for "the search returned nothing, so the traffic isn't there".

## Version

1.0.2 → 1.1.0. MINOR — new documented exit codes are a change to the contract, not only a bug fix.

## Two limits worth knowing

The stub proves the classification logic, not Burp's actual behaviour. I asserted when filing this that Burp "exits 0 with empty stdout" when the extension is missing, and that is unverified — if it instead launches and hangs, neither exit 3 nor 4 fires and the script blocks indefinitely. I did not add a watchdog timeout, since building one on an unverified premise seemed worse than leaving it.

Anyone with Burp Pro installed can settle both in a single run by renaming the extension JAR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)