### PR TITLE
supply-chain-risk-auditor: discard undecodable cache entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -303,7 +303,7 @@
     },
     {
       "name": "supply-chain-risk-auditor",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "description": "Audit a project's npm, PyPI, and Go dependencies for supply-chain risk: version-matched advisories for direct dependencies and the full lockfile tree, abandoned upstreams, npm publisher concentration, and install scripts",
       "author": {
         "name": "Eric Quintero"

--- a/plugins/supply-chain-risk-auditor/.claude-plugin/plugin.json
+++ b/plugins/supply-chain-risk-auditor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "supply-chain-risk-auditor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Audit a project's npm, PyPI, and Go dependencies for supply-chain risk: version-matched advisories for direct dependencies and the full lockfile tree, abandoned upstreams, npm publisher concentration, and install scripts",
   "author": {
     "name": "Eric Quintero"

--- a/plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor/scripts/sources.py
+++ b/plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor/scripts/sources.py
@@ -150,7 +150,7 @@ class Http:
             return None
         try:
             stored = json.loads(path.read_text(encoding="utf-8"), strict=False)
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
             # A run interrupted mid-write leaves a truncated file that would otherwise
             # crash every later run. Drop it and refetch.
             self.stats["errors"] += 1

--- a/plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor/scripts/test_sources.py
+++ b/plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor/scripts/test_sources.py
@@ -138,6 +138,19 @@ def test_truncated_cache_entry_is_dropped(tmp_path: Path):
     assert not path.exists()
 
 
+def test_non_utf8_cache_entry_is_dropped(tmp_path: Path):
+    """Undecodable cache bytes are corruption, not a permanent client crash."""
+    http = Http(tmp_path, offline=True)
+    path = seed(http, "GET", "https://example.com/x", {"ok": 1})
+    path.write_bytes(b"\xff")
+
+    with pytest.raises(Unavailable):
+        http.get_json("https://example.com/x")
+
+    assert http.stats["errors"] == 1
+    assert not path.exists()
+
+
 def test_cache_owner_is_verified_on_posix(tmp_path: Path):
     """The usual case: ownership checks out, so there is no caveat to report."""
     http = Http(tmp_path, offline=True)


### PR DESCRIPTION
## Summary

- treat `UnicodeDecodeError` as cache corruption
- remove an undecodable cache entry so online runs can refetch and offline runs degrade to `Unavailable`
- add a regression test using invalid UTF-8 bytes
- bump supply-chain-risk-auditor to 2.0.2

## Problem

`Http._read_cache` now reads cache files explicitly as UTF-8, but its corruption handler catches JSON syntax and I/O errors only. Invalid UTF-8 therefore escapes as a raw traceback and the bad file remains, so every later run fails on the same cache entry.

## Validation

- supply-chain-risk-auditor suite — 105 passed
- plugin metadata validation with `--base-ref d1f1575` — no errors
