### PR TITLE
agentic-actions-auditor: the pre-v1 claude-code-action inputs, and the composite-action secrets gap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -333,7 +333,7 @@
     },
     {
       "name": "agentic-actions-auditor",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "description": "Audits GitHub Actions workflows for security vulnerabilities in AI agent integrations (Claude Code Action, Gemini CLI, OpenAI Codex, GitHub AI Inference)",
       "author": {
         "name": "Emilio López & Will Vandevanter"

--- a/plugins/agentic-actions-auditor/.claude-plugin/plugin.json
+++ b/plugins/agentic-actions-auditor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-actions-auditor",
   "description": "Audits GitHub Actions workflows for security vulnerabilities in AI agent integrations (Claude Code Action, Gemini CLI, OpenAI Codex, GitHub AI Inference)",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Emilio López & Will Vandevanter"
   }

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/SKILL.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/SKILL.md
@@ -169,7 +169,9 @@ Capture these security-relevant input fields based on the action type:
 
 **Claude Code Action:**
 - `prompt` -- the instruction sent to the AI agent
+- `direct_prompt`, `override_prompt` -- the same sink on pre-v1 workflows, which are still common
 - `claude_args` -- CLI arguments passed to Claude (may contain `--allowedTools`, `--disallowedTools`)
+- `allowed_tools`, `disallowed_tools`, `custom_instructions` -- the pre-v1 spellings of what `claude_args` now carries
 - `allowed_non_write_users` -- which users can trigger the action (wildcard `"*"` is a red flag)
 - `allowed_bots` -- which bots can trigger the action
 - `settings` -- path to Claude settings file (may configure tool permissions)

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/action-profiles.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/action-profiles.md
@@ -6,7 +6,7 @@ Security-relevant configuration fields, default behaviors, dangerous configurati
 
 ### Default Security Posture
 
-- Bash tool disabled by default; commands must be explicitly allowed via `--allowedTools` in `claude_args`
+- Bash tool disabled by default; commands must be explicitly allowed via `--allowedTools` in `claude_args`, or via the `allowed_tools` input on pre-v1 workflows (see foundations.md)
 - Only users with repository write access can trigger (default when `allowed_non_write_users` is omitted)
 - GitHub Apps and bots blocked by default (when `allowed_bots` is omitted)
 - Commits to new branch, does NOT auto-create PRs (requires human review)
@@ -18,10 +18,11 @@ Security-relevant configuration fields, default behaviors, dangerous configurati
 | Configuration | Risk |
 |--------------|------|
 | `claude_args: "--allowedTools Bash(*)"` | Unrestricted shell access; any prompt injection achieves full RCE |
+| `allowed_tools: "Bash(*)"` | The same risk on pre-v1 workflows, under the older input name |
 | `allowed_non_write_users: "*"` | Any GitHub user can trigger the action, including external contributors and attackers |
 | `allowed_bots: "*"` | Any bot can trigger, enables automated attack chains via bot-to-bot escalation |
 | `show_full_output: true` (in public repos) | Exposes full conversation including potential secrets in workflow logs |
-| `prompt` containing `${{ github.event.* }}` | Direct expression injection of attacker-controlled content into AI prompt |
+| `prompt` or `direct_prompt` containing `${{ github.event.* }}` | Direct expression injection of attacker-controlled content into AI prompt |
 
 ### Remediation Patterns
 

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/cross-file-resolution.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/cross-file-resolution.md
@@ -137,11 +137,13 @@ Composite action (actions/issue-triage/action.yml):
 
 ```
 Caller workflow (.github/workflows/ci.yml):
+  on: pull_request_target
   jobs:
     ai-review:
       uses: org/shared/.github/workflows/ai-review.yml@main
       with:
         pr_body: ${{ github.event.pull_request.body }}
+      secrets: inherit
 
 Called workflow (org/shared/.github/workflows/ai-review.yml):
   on:
@@ -167,10 +169,27 @@ Called workflow (org/shared/.github/workflows/ai-review.yml):
    -> org/shared/.github/workflows/ai-review.yml, on.workflow_call.inputs
 4. AI action: prompt contains ${{ inputs.pr_body }}
    -> org/shared/.github/workflows/ai-review.yml, jobs.review.steps[0]
-5. Claude executes with tainted prompt via pull_request_target (has secrets access)
+5. Claude executes with tainted prompt via pull_request_target
+   -> secrets reach the callee through `secrets: inherit` on the calling job
+   -> .github/workflows/ci.yml, jobs.ai-review.secrets
 ```
 
 The trace format follows the same stacked multi-line style as other data flow traces in this skill. Each hop shows the relevant YAML location. Cross-file findings have a longer trace because they span multiple files, but are otherwise identical to direct findings.
+
+## Secrets Across the Boundary
+
+SKILL.md Step 5b scores severity partly on secrets availability, and the two kinds of resolved file carry secrets in opposite ways. Neither can be read off the resolved file alone.
+
+**Composite actions have no `secrets` context.** GitHub's [contexts reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#secrets-context) states it is unavailable there and that a secret must be passed explicitly as an input. Two consequences, in opposite directions:
+
+- A `${{ secrets.NAME }}` written inside `runs.steps[]` resolves to empty. An `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` in a composite action is not a secret exposure; it is a broken workflow. Do not report it as one.
+- A secret that did reach the action arrived through the caller's `with:` and now lives in `inputs.*`. Searching the composite file for `secrets.` finds nothing while the secret is present. Read the caller's `with:` block to decide whether one is.
+
+**Reusable workflows receive secrets explicitly or by inheritance.** The caller names them under `jobs.<id>.secrets`, or passes all of them with `secrets: inherit`. Under `inherit` the called workflow need not declare them in `on.workflow_call.secrets` to reference them, so an empty `secrets:` block there is not evidence of a callee without secrets. `secrets: inherit` is the maximum, not a default: it raises severity rather than lowering it.
+
+**Inheritance is not transitive.** In a chain A calls B calls C, C receives a secret only if A passed it to B and B passed it to C. The depth limit stops resolution at B, so nothing about C's secrets can be asserted from A.
+
+Record what the caller passes alongside the input trace. A finding whose severity rests on secrets access should name the line that grants it.
 
 ## Depth Limit and Unresolved References
 

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/foundations.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/foundations.md
@@ -85,10 +85,26 @@ Where each supported action receives prompt content that could carry attacker in
 
 | Action | Prompt Fields | Notes |
 |--------|--------------|-------|
-| `anthropics/claude-code-action` | `with.prompt` | Also check `with.claude_args` for embedded instructions |
+| `anthropics/claude-code-action` | `with.prompt`, `with.direct_prompt`, `with.override_prompt` | The last two are the pre-v1 names; also check `with.claude_args` for embedded instructions |
 | `google-github-actions/run-gemini-cli` | `with.prompt` | Shell-style env var interpolation in prompt text |
 | `google-gemini/gemini-cli-action` | `with.prompt` | Legacy/archived Gemini action reference |
 | `openai/codex-action` | `with.prompt`, `with.prompt-file` | `prompt-file` may point to attacker-controlled file |
 | `actions/ai-inference` | `with.prompt`, `with.system-prompt`, `with.system-prompt-file` | System prompt is also an injection surface |
 
 When checking for attacker-controlled content in prompts, examine ALL fields listed for the relevant action, not just the primary `prompt` field.
+
+### Claude Code Action Renamed Its Inputs at v1
+
+`claude-code-action` replaced its input surface at v1. The v0.x names are absent from the v1 `action.yml` and the v1 names are absent from v0.x, so a signature written against one set silently matches nothing in the other. The action's [migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md) gives the mapping; these are the security-relevant rows:
+
+| v0.x, including the `@beta` tag | v1 and later | Why it matters |
+|---------------------------------|--------------|----------------|
+| `direct_prompt` | `prompt` | Prompt sink |
+| `override_prompt` | `prompt` | Prompt sink |
+| `custom_instructions` | `claude_args: --append-system-prompt` | System prompt sink |
+| `allowed_tools` | `claude_args: --allowedTools` | Tool allowlist, Vectors F and H |
+| `disallowed_tools` | `claude_args: --disallowedTools` | Tool denylist |
+
+Both sets appear in the wild, so match on either. The ref after `@` does not identify the set: `@beta` carries the v0.x names, and files pinned at `@v1` or a commit SHA still carry `direct_prompt`. Read the field names present in the file, not the ref.
+
+The tool lists also separate differently. `claude_args: '--allowedTools "Bash(a:*) Bash(b:*)"'` separates on spaces; the v0.x `allowed_tools: "Bash(a:*),Bash(b:*)"` separates on commas. A matcher that splits one way reads the other as a single entry.

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/vector-b-direct-expression-injection.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/vector-b-direct-expression-injection.md
@@ -33,6 +33,7 @@ The expression is resolved before any step code executes. The AI action receives
 `${{ github.event.* }}` expressions inside any text-accepting field of an AI action step:
 
 - `with.prompt` -- the primary prompt field (all actions)
+- `with.direct_prompt`, `with.override_prompt` -- the same field on pre-v1 Claude Code Action workflows
 - `with.system-prompt` -- system prompt (GitHub AI Inference)
 - `with.prompt-file` -- if it resolves to an attacker-controlled path (Codex, AI Inference)
 - `with.claude_args` -- may embed expressions as inline instructions (Claude Code Action)

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/vector-f-subshell-expansion.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/vector-f-subshell-expansion.md
@@ -35,14 +35,14 @@ The critical insight: the restriction is on the **command name**, not on shell i
 ## What to Look For
 
 1. **Gemini CLI:** `with.settings` JSON containing a `coreTools` array that includes `run_shell_command(echo)` or other shell commands supporting expansion
-2. **Claude Code Action:** `with.claude_args` containing `--allowedTools` with `Bash(echo:*)`, `Bash(cat:*)`, `Bash(printf:*)`, or similar restricted-but-expandable command patterns
+2. **Claude Code Action:** `with.claude_args` containing `--allowedTools`, or the pre-v1 `with.allowed_tools` input, with `Bash(echo:*)`, `Bash(cat:*)`, `Bash(printf:*)`, or similar restricted-but-expandable command patterns
 3. **General:** Any tool restriction pattern that allows a shell command supporting `$()`, backtick substitution, or process substitution (`<()`)
 4. **Dangerous expandable commands:** `echo`, `cat`, `printf`, `tee`, `head`, `tail`, `wc`, `sort`, and most standard Unix utilities -- these all pass arguments through a shell that evaluates subshell expressions
 
 ## Where to Look
 
 1. `with.settings` (Gemini CLI) -- parse the JSON string for `coreTools` arrays containing shell command names
-2. `with.claude_args` (Claude Code Action) -- look for `--allowedTools` flags with `Bash(command:*)` patterns
+2. `with.claude_args` (Claude Code Action) -- look for `--allowedTools` flags with `Bash(command:*)` patterns. Pre-v1 workflows carry the same patterns in a `with.allowed_tools` string instead
 3. `with.codex-args` (OpenAI Codex) -- check for tool restriction flags
 4. Look specifically for patterns suggesting **restricted** tool access rather than fully open access -- fully open tool access is Vector H, not Vector F
 

--- a/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/vector-h-dangerous-sandbox-configs.md
+++ b/plugins/agentic-actions-auditor/skills/agentic-actions-auditor/references/vector-h-dangerous-sandbox-configs.md
@@ -32,6 +32,7 @@ Without dangerous configs, a successful prompt injection may still be contained 
 **Claude Code Action (`anthropics/claude-code-action`):**
 
 - `with.claude_args` containing `--allowedTools Bash(*)` or `--allowedTools "Bash(*)"` -- unrestricted shell access, the AI can execute any command
+- `with.allowed_tools` containing `Bash(*)` -- the pre-v1 spelling of the same thing, on a plain input rather than inside `claude_args`
 - `with.claude_args` with broad tool patterns combining multiple unrestricted categories (e.g., `Bash(npm:*) Bash(git:*) Bash(curl:*)`)
 - `with.settings` pointing to a settings file -- flag for manual review, the file may override tool permissions in ways not visible in the workflow YAML
 
@@ -51,7 +52,7 @@ Without dangerous configs, a successful prompt injection may still be contained 
 
 The `with:` block of AI action steps:
 
-- **Claude:** Parse `with.claude_args` string for `--allowedTools` patterns. Also check `with.settings` for external config file path
+- **Claude:** Parse `with.claude_args` string for `--allowedTools` patterns, and `with.allowed_tools` on pre-v1 workflows. Also check `with.settings` for external config file path
 - **Codex:** Check `with.sandbox` and `with.safety-strategy` field values directly
 - **Gemini:** Parse `with.settings` JSON string for `"sandbox": false` and approval mode settings. Check any args-style fields for `--yolo` or `--approval-mode=yolo`
 


### PR DESCRIPTION
The two items you invited when you closed #241, on their own merits and with nothing else attached.

## The pre-v1 input surface

`claude-code-action` replaced its whole input surface at v1, read from the action's own `action.yml`:

    @v0.0.32          direct_prompt, allowed_tools, disallowed_tools, custom_instructions
    @v0.0.56, @beta   the above plus override_prompt, mode
    @v1, @main        prompt, claude_args, settings

`agentic-actions-auditor` names only the v1 set. On `main` it never writes `direct_prompt`, `override_prompt`, `custom_instructions` or `disallowed_tools`, and its single mention of `allowed_tools` is a heading debunking it as a security control. SKILL.md Step 2 says to ignore the ref after `@`, so a workflow carrying `direct_prompt: ${{ github.event.issue.body }}` presents no prompt field the skill knows about and Step 3a captures nothing.

Measured on 58 workflow files sampled by the action rather than by a field name: 13 carry a v0.x input name. 19 are pinned `@beta` and 12 of those 19 are among the 13. The ref is not a proxy either way: in a second sample of 59 files selected by `direct_prompt`, 8 were pinned at `@v1` or a SHA.

Two corrections to what I wrote in #241 are in this diff. The mapping table was headed "Through v0.0.32" while `override_prompt` first appears at `@beta` and `v0.0.56`, so it now reads "v0.x, including the `@beta` tag". And the Vector H signature was written `allowed_tools: "Bash(*)"` from the v1 spelling; of 17 real workflows using that input, 12 carry `Bash(...)` patterns and one carries `Bash(*)`, so the form is real, but v1 splits `--allowedTools` on spaces while v0.x splits `allowed_tools` on commas, and a matcher built for one reads the other as a single entry.

## The composite-action secrets gap

`cross-file-resolution.md` covers resolving and input tracing, and Step 5b scores severity on secrets availability. Nothing joined the two.

A composite action has no `secrets` context, per GitHub's contexts reference, and a secret must arrive as an input. Both directions are wrong today. A `${{ secrets.NAME }}` inside `runs.steps[]` resolves to empty, which is a broken workflow rather than an exposure. A secret that did arrive sits in `inputs.*`, where searching for `secrets.` finds nothing. And a called workflow under `secrets: inherit` holds every secret the caller has without declaring one, so an empty `on.workflow_call.secrets` proves nothing; inheritance stops at the directly called workflow.

The file's own reusable-workflow trace ended "via `pull_request_target` (has secrets access)" above a caller showing neither a trigger nor a `secrets:` line. Both are in the example now.
