### PR TITLE
second-opinion: Gemini CLI is EOL — move to Antigravity, and bump Codex to gpt-5.6-sol

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -263,8 +263,8 @@
     },
     {
       "name": "second-opinion",
-      "version": "1.7.0",
-      "description": "Runs code reviews using external LLM CLIs (OpenAI Codex, Google Gemini) on uncommitted changes, branch diffs, or specific commits. Bundles Codex's built-in MCP server for direct tool access.",
+      "version": "1.8.0",
+      "description": "Runs code reviews using external LLM CLIs (OpenAI Codex, Google Antigravity) on uncommitted changes, branch diffs, or specific commits. Bundles Codex's built-in MCP server for direct tool access.",
       "author": {
         "name": "Dan Guido"
       },

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cd /path/to/parent  # e.g., if repo is at ~/projects/skills, be in ~/projects
 | [modern-cpp](plugins/modern-cpp/) | Modern C++ best practices (C++20/23/26) with compiler hardening and safe idioms |
 | [modern-python](plugins/modern-python/) | Modern Python tooling and best practices with uv, ruff, and pytest |
 | [open-sourcing](plugins/open-sourcing/) | Prepare a repository for public release: secrets hygiene, licensing, CI readiness, and release automation |
-| [second-opinion](plugins/second-opinion/) | Run code reviews using external LLM CLIs (OpenAI Codex, Google Gemini) on changes, diffs, or commits. Bundles Codex's built-in MCP server. |
+| [second-opinion](plugins/second-opinion/) | Run code reviews using external LLM CLIs (OpenAI Codex, Google Antigravity) on changes, diffs, or commits. Bundles Codex's built-in MCP server. |
 
 ### Team Management
 

--- a/plugins/second-opinion/.claude-plugin/plugin.json
+++ b/plugins/second-opinion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "second-opinion",
-  "version": "1.7.0",
-  "description": "Runs code reviews using external LLM CLIs (OpenAI Codex, Google Gemini) on uncommitted changes, branch diffs, or specific commits. Bundles Codex's built-in MCP server for direct tool access.",
+  "version": "1.8.0",
+  "description": "Runs code reviews using external LLM CLIs (OpenAI Codex, Google Antigravity) on uncommitted changes, branch diffs, or specific commits. Bundles Codex's built-in MCP server for direct tool access.",
   "author": {
     "name": "Dan Guido"
   }

--- a/plugins/second-opinion/README.md
+++ b/plugins/second-opinion/README.md
@@ -1,6 +1,6 @@
 # second-opinion
 
-Run code reviews using external LLM CLIs (OpenAI Codex, Google Gemini) on uncommitted changes, branch diffs, or specific commits.
+Run code reviews using external LLM CLIs (OpenAI Codex, Google Antigravity) on uncommitted changes, branch diffs, or specific commits.
 
 ## Prerequisites
 
@@ -9,12 +9,24 @@ Run code reviews using external LLM CLIs (OpenAI Codex, Google Gemini) on uncomm
 - [Codex CLI](https://github.com/openai/codex) installed: `npm i -g @openai/codex`
 - OpenAI API key or ChatGPT Plus subscription configured for Codex
 
-### Google Gemini CLI
+### Google Antigravity CLI
+
+- [Antigravity](https://antigravity.google) installed; binary is `agy`
+  (installs to `~/.local/bin`, which may need adding to PATH)
+- Google account authenticated (`agy models` should list models)
+- No extensions required
+
+### Google Gemini CLI (legacy — paid tiers only)
+
+Gemini CLI stopped serving individual accounts (AI Pro, Ultra, free) on
+2026-06-18; they now get `UNSUPPORTED_CLIENT` and are pointed at
+Antigravity. Only Gemini Code Assist Standard/Enterprise licenses or a
+paid `GEMINI_API_KEY` still work.
 
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed: `npm i -g @google/gemini-cli`
-- Google account authenticated
 - Code review extension: `gemini extensions install https://github.com/gemini-cli-extensions/code-review`
 - Security extension: `gemini extensions install https://github.com/gemini-cli-extensions/security`
+- Headless runs need `--skip-trust` or `GEMINI_CLI_TRUST_WORKSPACE=true`
 
 ## Installation
 

--- a/plugins/second-opinion/skills/second-opinion/SKILL.md
+++ b/plugins/second-opinion/skills/second-opinion/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: second-opinion
-description: "Runs external LLM code reviews (OpenAI Codex or Google Gemini CLI) on uncommitted changes, branch diffs, or specific commits. Use when the user asks for a second opinion, external review, codex review, gemini review, or mentions /second-opinion."
+description: "Runs external LLM code reviews (OpenAI Codex or Google Antigravity CLI) on uncommitted changes, branch diffs, or specific commits. Use when the user asks for a second opinion, external review, codex review, gemini review, antigravity review, or mentions /second-opinion."
 allowed-tools: Bash Read Glob Grep AskUserQuestion
 ---
 
 # Second Opinion
 
 Shell out to external LLM CLIs for an independent code review powered by
-a separate model. Supports OpenAI Codex CLI and Google Gemini CLI.
+a separate model. Supports OpenAI Codex CLI (`codex`) and Google
+Antigravity CLI (`agy`).
 
 ## When to Use
 
@@ -19,32 +20,38 @@ a separate model. Supports OpenAI Codex CLI and Google Gemini CLI.
 
 ## When NOT to Use
 
-- Neither Codex CLI nor Gemini CLI is installed
+- Neither Codex CLI nor Antigravity CLI is installed
 - No API key or subscription configured for either tool
 - Reviewing non-code files (documentation, config)
 - You want Claude's own review (just ask Claude directly)
 
-## Safety Note
+## Gemini CLI Is End-of-Life
 
-Gemini CLI is invoked with `--yolo`, which auto-approves all
-tool calls without confirmation. This is required for headless
-(non-interactive) operation but means Gemini will execute any
-tool actions its extensions request without prompting.
+As of 2026-06-18, `gemini` (Gemini CLI) stopped serving Google AI Pro,
+Ultra, and free-tier individual accounts. Those accounts now get
+`UNSUPPORTED_CLIENT` on every request, pointing at
+<https://antigravity.google>. The replacement is **Antigravity CLI**,
+binary `agy`.
+
+Default to `agy`. Only fall back to `gemini` when the user has a Gemini
+Code Assist Standard/Enterprise license or a paid Gemini API key
+(`GEMINI_API_KEY`) — those still work. See
+[references/gemini-invocation.md](references/gemini-invocation.md) for
+that legacy path.
 
 ## Quick Reference
 
 ```
 # Codex (headless exec with structured JSON output)
-codex exec --sandbox read-only --ephemeral \
+codex exec -c model='"gpt-5.6-sol"' -c model_reasoning_effort='"xhigh"' \
+  --sandbox read-only --ephemeral \
   --output-schema codex-review-schema.json \
   -o "$output_file" - < "$prompt_file"
 
-# Gemini (code review extension)
-gemini -p "/code-review" --yolo -e code-review
-# Gemini (headless with diff — see references/ for full pattern)
+# Antigravity (headless print mode — prompt must be an ARGUMENT, not stdin)
 git diff HEAD > /tmp/review-diff.txt
-{ printf '%s\n\n' 'Review this diff for issues.'; cat /tmp/review-diff.txt; } \
-  | gemini -p - --yolo -m gemini-3.1-pro-preview
+agy --model gemini-3.1-pro-high --output-format text \
+  --disable-slash-commands -p="$(cat /tmp/review-prompt.txt)"
 ```
 
 ## Invocation
@@ -64,10 +71,13 @@ call (max 4 questions).
 header: "Review tool"
 question: "Which tool should run the review?"
 options:
-  - "Both Codex and Gemini (Recommended)" → run both in parallel
-  - "Codex only"                          → codex exec
-  - "Gemini only"                         → gemini CLI
+  - "Both Codex and Antigravity (Recommended)" → run both in parallel
+  - "Codex only"                               → codex exec
+  - "Antigravity only"                         → agy print mode
 ```
+
+If the user says "gemini", treat it as Antigravity unless they
+explicitly have a paid Code Assist / API-key setup.
 
 **Question 2 — Scope** (skip if user already specified):
 
@@ -114,6 +124,10 @@ an extension is missing, report the install command from the
 Error Handling table below and skip that tool (if "Both" was
 selected, run only the available one).
 
+`agy` installs to `~/.local/bin`, which is not always on PATH.
+Prefix the call with `export PATH="$HOME/.local/bin:$PATH"` before
+concluding it is missing.
+
 ## Diff Preview
 
 After collecting answers, show the diff stats:
@@ -135,26 +149,6 @@ If the diff is empty, stop and tell the user.
 If the diff is very large (>2000 lines changed), warn the user
 and ask whether to proceed or narrow the scope.
 
-## Skipping Inapplicable Checks
-
-After determining the diff scope, skip checks that don't apply
-to the files actually changed.
-
-### Dependency Scanning
-
-Only run `/security:scan-deps` when the diff touches dependency
-manifest files. Check with:
-
-```bash
-git diff --name-only <scope> \
-  | grep -qiE '(package\.json|package-lock|yarn\.lock|pnpm-lock|Gemfile|\.gemspec|requirements\.txt|setup\.py|setup\.cfg|pyproject\.toml|poetry\.lock|uv\.lock|Cargo\.toml|Cargo\.lock|go\.mod|go\.sum|composer\.json|composer\.lock|Pipfile)'
-```
-
-If no dependency files are in the diff, skip the scan even when
-security focus is selected. The scan analyzes the entire project's
-dependency tree regardless of diff scope, so it adds significant
-time for zero value when dependencies weren't touched.
-
 ## Auto-detect Default Branch
 
 For branch diff scope, detect the default branch name:
@@ -171,36 +165,47 @@ for full details on command syntax, prompt assembly, and the
 structured output schema.
 
 Summary:
-- Uses `codex exec` (not `codex review`) for headless operation
-- Model: `gpt-5.5`, reasoning: `xhigh`
+- Uses `codex exec` (not `codex exec review`) for headless operation.
+  `codex exec review` has native `--uncommitted` / `--base` /
+  `--commit` scope flags, but they are mutually exclusive with a
+  custom `[PROMPT]`, so it cannot carry project context or focus
+  instructions. Keep the manual prompt-assembly approach.
+- Model: `gpt-5.6-sol`, reasoning: `xhigh`
 - Uses OpenAI's published code review prompt (fine-tuned into the model)
 - Diff is generated manually and piped via stdin with the prompt
 - `--output-schema` produces structured JSON findings
 - `-o` captures only the final message (no thinking/exec noise)
 - All three scopes (uncommitted, branch, commit) support project
   context and focus instructions (no limitations)
-- Falls back to `gpt-5.4` on auth errors
+- Falls back to `gpt-5.6`, then `gpt-5.4`, on auth errors
 - Output is clean JSON — parse and present findings by priority
 - Set `timeout: 600000` on the Bash call
 
-## Gemini Invocation
+## Antigravity Invocation
 
-See [references/gemini-invocation.md](references/gemini-invocation.md)
-for full details on flags, scope mapping, and extension usage.
+See [references/antigravity-invocation.md](references/antigravity-invocation.md)
+for full details on flags, scope mapping, and model selection.
 
 Summary:
-- Model: `gemini-3.1-pro-preview`, flags: `--yolo`, `-e`, `-m`
-- For uncommitted general review: `gemini -p "/code-review" --yolo -e code-review`
-- For branch/commit diffs: pipe `git diff` into `gemini -p`
-- Security extension name is `gemini-cli-security` (not `security`)
-- `/security:analyze` is interactive-only — use `-p` with a
-  security prompt instead
-- Run `/security:scan-deps` only when security focus is selected
-  AND the diff touches dependency manifest files (see Diff-Aware
-  Optimizations)
+- Model: `gemini-3.1-pro-high` (effort is baked into the model slug)
+- **The prompt must be a command-line argument, not stdin.** `agy`
+  print mode does not read prompts from stdin unless
+  `--input-format stream-json` is used. Assemble the prompt into a
+  file, then pass `-p="$(cat "$prompt_file")"`.
+- **Use `-p=<value>` with an equals sign.** Bare `-p` swallows the
+  next flag as its prompt value and silently discards the real one.
+- Add `--disable-slash-commands` so a line in the untrusted diff cannot
+  be expanded as a slash command
+- Do NOT pass `--mode plan`. It intermittently returns a "plan artifact
+  / click Proceed" stub instead of the review. Omit `--mode` entirely
+- Do NOT pass `--dangerously-skip-permissions`; it is unnecessary for
+  a text-only diff review and will be blocked in restricted environments
+- Prefer `--output-format text`. `--json-schema` is advisory, not
+  enforced: it emits schema-shaped JSON nested inside a `response`
+  string, duplicates the payload, and ran ~3x slower in testing
 - Set `timeout: 600000` on the Bash call
 
-**Scope mapping for `git diff`** (Gemini has no built-in scope flags):
+**Scope mapping for `git diff`** (Antigravity has no built-in scope flags):
 
 | Scope | Diff command |
 |-------|-------------|
@@ -212,18 +217,18 @@ Summary:
 
 When the user picks "Both" (the default):
 
-1. Run Codex and Gemini in parallel — issue both Bash tool
+1. Run Codex and Antigravity in parallel — issue both Bash tool
    calls in a single response. Both commands are read-only
    (they review diffs via external APIs) so there is no
    shared state or git lock contention.
 2. Collect both results, then present with clear headers:
 
 ```
-## Codex Review (gpt-5.5)
+## Codex Review (gpt-5.6-sol)
 <codex output>
 
-## Gemini Review (gemini-3.1-pro-preview)
-<gemini output>
+## Antigravity Review (gemini-3.1-pro-high)
+<agy output>
 ```
 
 Summarize where the two reviews agree and differ.
@@ -233,10 +238,11 @@ Summarize where the two reviews agree and differ.
 | Error | Action |
 |-------|--------|
 | `codex: command not found` | Tell user: `npm i -g @openai/codex` |
-| `gemini: command not found` | Tell user: `npm i -g @google/gemini-cli` |
-| Gemini `code-review` extension missing | Tell user: `gemini extensions install https://github.com/gemini-cli-extensions/code-review` |
-| Gemini `gemini-cli-security` extension missing | Tell user: `gemini extensions install https://github.com/gemini-cli-extensions/security` |
-| Model auth error (Codex) | Retry with `gpt-5.4` |
+| `agy: command not found` | Retry with `export PATH="$HOME/.local/bin:$PATH"`. Still missing → tell user to install Antigravity from <https://antigravity.google> |
+| `agy` error: `-p took "--model" as its prompt` | Use `-p=<value>` form and move other flags before it |
+| `agy` error: `empty prompt` | The prompt was piped on stdin. Pass it as an argument instead |
+| `gemini` error: `UNSUPPORTED_CLIENT` / "migrate to the Antigravity suite" | Gemini CLI is EOL for individual tiers. Switch to `agy` |
+| Model auth error (Codex) | Retry with `gpt-5.6`, then `gpt-5.4` |
 | Empty diff | Tell user there are no changes to review |
 | Timeout | Inform user and suggest narrowing the diff scope |
 | Tool partially unavailable | Run only the available tool, note the skip |
@@ -251,7 +257,7 @@ User: picks "Both", "Branch diff", "Yes include CLAUDE.md", "Security"
 Claude: [detects default branch = main]
 Claude: [shows diff --stat: 6 files, +103 -15]
 Claude: [assembles prompt with review instructions + CLAUDE.md + security focus + diff]
-Claude: [runs codex exec and gemini in parallel]
+Claude: [runs codex exec and agy in parallel]
 Claude: [reads codex output file, parses structured findings]
 Claude: [presents both reviews, highlights agreements/differences]
 ```
@@ -268,13 +274,13 @@ Claude: [runs codex exec, reads structured JSON output]
 Claude: [presents findings by priority with file:line refs]
 ```
 
-**Gemini only:**
+**Antigravity only:**
 ```
 User: /second-opinion
 Claude: [asks 4 questions]
-User: picks "Gemini only", "Uncommitted", "No", "General"
+User: picks "Antigravity only", "Uncommitted", "No", "General"
 Claude: [shows diff --stat: 2 files, +20 -5]
-Claude: [runs gemini -p "/code-review" --yolo -e code-review]
+Claude: [writes prompt file, runs agy --model gemini-3.1-pro-high -p="$(cat prompt.txt)"]
 Claude: [presents review]
 ```
 

--- a/plugins/second-opinion/skills/second-opinion/references/antigravity-invocation.md
+++ b/plugins/second-opinion/skills/second-opinion/references/antigravity-invocation.md
@@ -1,0 +1,202 @@
+# Antigravity CLI (`agy`) Invocation
+
+Antigravity CLI replaced Gemini CLI for individual Google accounts on
+2026-06-18. Binary is `agy`. Verified against `agy` 1.1.21.
+
+## Default Configuration
+
+- Model: `gemini-3.1-pro-high`
+- Output: `--output-format text`
+- Add `--disable-slash-commands` — the prompt embeds an untrusted diff,
+  and without this a line in the diff that looks like `/something` can
+  be expanded as a slash command
+
+## PATH
+
+`agy` installs to `~/.local/bin`, which is often absent from a
+non-interactive shell's PATH. Always prefix:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Models
+
+`agy models` lists what the account can reach. As of testing:
+
+```
+gemini-3.7-flash-high / -medium / -low
+gemini-3.6-flash-high / -medium / -low
+gemini-3.5-flash-high / -medium / -low
+gemini-3.1-pro-high
+gemini-3.1-pro-low
+claude-sonnet-4-6
+claude-opus-4-6-thinking
+gpt-oss-120b-medium
+```
+
+Reasoning effort is part of the model slug — there is no separate
+effort flag to set for these (though `--effort low|medium|high` exists
+for models that take it). Use `gemini-3.1-pro-high` for code review:
+it is the strongest Gemini option exposed.
+
+Do not select `claude-*` slugs for a second opinion — the point is a
+different model family from Claude.
+
+## Key Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-p=<prompt>` / `--print=<prompt>` | Non-interactive (headless) mode |
+| `--model <slug>` | Model selection |
+| `--mode plan` | Plan mode — **do not use for reviews**, see below |
+| `--disable-slash-commands` | Stop diff text from being read as slash commands |
+| `--output-format text\|json\|stream-json` | Output shape |
+| `--json-schema <file>` | Advisory structured output (see caveat) |
+| `--sandbox` | Terminal restrictions |
+| `--dangerously-skip-permissions` | Auto-approve tools — **do not use** |
+
+## Two Gotchas That Will Break the Call
+
+### 1. The prompt must be an argument, not stdin
+
+Unlike `codex exec -`, `agy` print mode does **not** read the prompt
+from stdin (only `--input-format stream-json` consumes stdin, as
+NDJSON). Piping a diff into `agy -p` fails with:
+
+```
+Error: Error: empty prompt. Usage: agy --print "your prompt here"
+```
+
+Assemble the prompt into a file, then pass its contents:
+
+```bash
+agy --model gemini-3.1-pro-high --output-format text \
+  --disable-slash-commands -p="$(cat "$prompt_file")"
+```
+
+### 2. Use `-p=<value>`, never bare `-p`
+
+Bare `-p` consumes the next token as its prompt value. `agy -p --model x`
+takes `--model` as the prompt and discards the real one:
+
+```
+Error: -p took "--model" as its prompt, so the intended prompt was left
+as an argument and ignored.
+```
+
+Always use the `=` form and put other flags before it.
+
+## Prompt Assembly
+
+Same structure as the Codex path. Write to `$prompt_file`:
+
+```
+You are reviewing a proposed code change made by another engineer.
+Flag only actionable issues introduced by this diff, citing the affected
+file and line range. Prioritize correctness, security, performance, and
+maintainability over nits. After the findings, give an overall
+correctness verdict and a confidence score.
+Review the diff text only.
+
+<If project context was requested>
+Project conventions and standards:
+---
+<full contents of CLAUDE.md or AGENTS.md>
+---
+
+<If focus area was selected>
+Focus: <focus area instructions>
+
+Diff to review:
+---
+<git diff output for the selected scope>
+---
+```
+
+## Scope-to-Diff Mapping
+
+`agy` has no built-in scope flags. Map the user's choice:
+
+| Scope | Diff command |
+|-------|-------------|
+| Uncommitted | `git diff HEAD` + untracked files (see codex-invocation.md) |
+| Branch diff | `git diff <branch>...HEAD` |
+| Specific commit | `git diff <sha>~1..<sha>` |
+
+**For uncommitted scope, use `git diff HEAD`, not bare `git diff`** —
+bare `git diff` misses staged changes. Include untracked files too.
+
+## Do Not Use `--mode plan`
+
+`--mode plan` makes `agy` treat the review as a planning task. It
+intermittently writes its findings into a plan artifact and returns
+only a stub asking for approval that will never come:
+
+```
+I have created an implementation plan artifact containing my proposed
+code review findings.
+Please review the artifact and click "Proceed" if you agree...
+```
+
+The same command printed a full review on one run and this stub on the
+next, so it is not safely reproducible. Omit `--mode` entirely — plain
+print mode does not request tool approvals for a text-only diff review.
+
+## Full Command
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+agy --model gemini-3.1-pro-high \
+    --output-format text \
+    --disable-slash-commands \
+    -p="$(cat "$prompt_file")" \
+  > "$output_file" 2>"$stderr_log"
+```
+
+Typical wall time for a small diff: 19–34s. Set `timeout: 600000`.
+
+## Structured Output: Prefer Text
+
+`--json-schema <file>` with `--output-format json` runs, but the schema
+is advisory, not enforced. Observed with the Codex review schema:
+
+- The findings JSON arrives as an **escaped string** inside a
+  `response` field of the outer envelope, requiring a double parse
+- `code_location` came back as a string (`"app.py:3-4"`) in one block
+  and an object in another, contradicting the schema
+- `confidence_score` came back as `100` where the schema says 0–1
+- `overall_correctness` came back as `"Needs Work"`, not one of the
+  schema's enum values
+- The payload was emitted twice in the same response
+- Took ~68s versus ~24s for the text path
+
+Use `--output-format text` and present `agy`'s prose review as-is.
+Keep the structured-JSON path for Codex only.
+
+## Do Not Pass `--dangerously-skip-permissions`
+
+A text-only diff review needs no tool approvals, and the flag is
+blocked outright in permission-restricted environments. Leave it off.
+
+## Extensions / Security Scanning
+
+Antigravity CLI does not carry over the Gemini CLI `code-review` or
+`gemini-cli-security` extensions, and has no `/security:scan-deps`
+equivalent. For dependency scanning, use a dedicated tool
+(`osv-scanner`, `npm audit`, `pip-audit`) rather than routing it
+through `agy`.
+
+`agy plugin list` shows what is installed if the user has added
+plugins; there is no bundled review plugin to rely on.
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| `agy: command not found` | Add `~/.local/bin` to PATH; else install from <https://antigravity.google> |
+| `-p took "--model" as its prompt` | Use `-p=<value>`, flags before it |
+| `empty prompt` | Prompt was on stdin; pass as argument |
+| Permission denied on `--dangerously-skip-permissions` | Drop the flag; plain print mode needs no approvals |
+| Output is a "plan artifact / click Proceed" stub | `--mode plan` was passed. Remove it |
+| Timeout | Inform user, suggest scoping down the diff |

--- a/plugins/second-opinion/skills/second-opinion/references/codex-invocation.md
+++ b/plugins/second-opinion/skills/second-opinion/references/codex-invocation.md
@@ -2,8 +2,35 @@
 
 ## Default Configuration
 
-- Model: `gpt-5.5`
+- Model: `gpt-5.6-sol`
 - Reasoning effort: `xhigh`
+
+Verified against `codex-cli` 0.149.1. The `gpt-5.6` family exposes
+`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.6-terra`, and
+`gpt-5.6-pro`. `sol` is the general-purpose choice and the one the
+Codex CLI's own default config selected on the machine this was
+verified on.
+
+Valid `model_reasoning_effort` values are now `none`, `minimal`, `low`,
+`medium`, `high`, `xhigh`, `max`, `ultra`. `xhigh` is the right default
+for review — `max`/`ultra` cost substantially more wall time for
+marginal gain on a diff-sized input.
+
+## Why Not `codex exec review`
+
+`codex exec review` now has native scope flags (`--uncommitted`,
+`--base <BRANCH>`, `--commit <SHA>`) and supports `--output-schema`,
+`-o`, and `--ephemeral`. It looks like a simplification, but those
+scope flags are **mutually exclusive with the `[PROMPT]` argument**:
+
+```
+error: the argument '--uncommitted' cannot be used with '[PROMPT]'
+```
+
+That makes it impossible to inject project conventions (CLAUDE.md /
+AGENTS.md) or a focus area alongside a scope flag. Keep the manual
+`codex exec` prompt-assembly approach below, which supports context
+and focus for all three scopes.
 
 ## Approach
 
@@ -17,8 +44,8 @@ stdout.
 
 Use this prompt verbatim — it is from OpenAI's [Build Code Review
 with the Codex SDK](https://developers.openai.com/cookbook/examples/codex/build_code_review_with_codex_sdk)
-cookbook, and GPT-5.4 and later received specific training
-on it:
+cookbook, and GPT-5.4 and later (including the 5.6 family)
+received specific training on it:
 
 ```
 You are acting as a reviewer for a proposed code change made by another engineer.
@@ -86,7 +113,7 @@ been staged would be silently excluded. Generate the full diff:
 
 ```bash
 codex exec \
-  -c model='"gpt-5.5"' \
+  -c model='"gpt-5.6-sol"' \
   -c model_reasoning_effort='"xhigh"' \
   --sandbox read-only \
   --ephemeral \
@@ -141,16 +168,20 @@ diagnose the failure.
 
 ## Model Fallback
 
-If `gpt-5.5` fails with an auth error (e.g., "not supported
-when using Codex with a ChatGPT account"), retry with
-`gpt-5.4`. Log the fallback for the user.
+If `gpt-5.6-sol` fails with an auth error (e.g., "not supported
+when using Codex with a ChatGPT account"), retry in order:
+`gpt-5.6`, then `gpt-5.4`. Log the fallback for the user.
+
+`gpt-5.6-pro` is deliberately not in the fallback chain: it is a
+higher-tier, slower model, so it is a poor automatic substitute for an
+auth failure. Untested here — reach for it only on explicit request.
 
 ## Error Handling
 
 | Error | Action |
 |-------|--------|
 | `codex: command not found` | Tell user: `npm i -g @openai/codex` |
-| Model auth error | Retry with `gpt-5.4` |
+| Model auth error | Retry with `gpt-5.6`, then `gpt-5.4` |
 | Timeout | Suggest narrowing the diff scope |
 | `EPERM` / sandbox errors | Expected — `codex exec` runs sandboxed. Ignore these. |
 | Empty/missing output file | Read `$stderr_log` to diagnose the failure |

--- a/plugins/second-opinion/skills/second-opinion/references/gemini-invocation.md
+++ b/plugins/second-opinion/skills/second-opinion/references/gemini-invocation.md
@@ -1,4 +1,41 @@
-# Gemini CLI Invocation
+# Gemini CLI Invocation (Legacy — Paid Tiers Only)
+
+> **Gemini CLI is end-of-life for individual accounts.** On 2026-06-18
+> Google stopped serving Gemini CLI requests for AI Pro, Ultra, and
+> free-tier individual accounts. Those accounts now fail with:
+>
+> ```
+> reasonCode: 'UNSUPPORTED_CLIENT'
+> reasonMessage: 'This client is no longer supported for Gemini Code
+>   Assist for individuals. To continue using Gemini, please migrate to
+>   the Antigravity suite of products: https://antigravity.google'
+> ```
+>
+> This is the shutdown, not a broken install. Reinstalling, clearing
+> `~/.gemini`, or signing in with a different personal Google account
+> will not fix it.
+>
+> **Use [antigravity-invocation.md](antigravity-invocation.md) instead.**
+
+## Who Can Still Use This Path
+
+Only these keep working:
+
+- Organizations with **Gemini Code Assist Standard or Enterprise**
+  licenses
+- Accounts using a **paid Gemini API key** via `GEMINI_API_KEY`
+  (AI Studio / Vertex), which bypasses Code Assist tier gating
+  entirely
+- **Vertex AI** via `GOOGLE_GENAI_USE_VERTEXAI=true`
+
+Check before using this path:
+
+```bash
+env | grep -q GEMINI_API_KEY && echo "api-key auth available"
+```
+
+If auth is `oauth-personal` (see `~/.gemini/settings.json`) and the
+account is an individual tier, this path will fail. Go to Antigravity.
 
 ## Default Configuration
 
@@ -9,15 +46,29 @@
 
 | Flag | Purpose |
 |------|---------|
-| `-p <prompt>` | Non-interactive (headless) mode |
+| `-p <prompt>` | Non-interactive (headless) mode; reads stdin too |
 | `--yolo` / `-y` | Auto-approve all tool calls |
 | `-m <model>` | Model selection |
 | `-e <ext>` | Load specific extension(s) |
+| `--skip-trust` | Trust the workspace for this session — **required in headless runs** |
+
+### Trusted-folder gotcha
+
+`--yolo` is **silently downgraded** in an untrusted directory:
+
+```
+YOLO mode is enabled. All tool calls will be automatically approved.
+Approval mode overridden to "default" because the current folder is not trusted.
+Gemini CLI is not running in a trusted directory. To proceed, either use
+`--skip-trust`, set the `GEMINI_CLI_TRUST_WORKSPACE=true` environment
+variable, or trust this directory in interactive mode.
+```
+
+Any headless invocation must add `--skip-trust` (or export
+`GEMINI_CLI_TRUST_WORKSPACE=true`), or the extension-driven paths will
+stall waiting for approvals that can never arrive.
 
 ## Scope-to-Diff Mapping
-
-Gemini does not have built-in scope flags like Codex. Map the
-user's scope choice to the correct `git diff` command:
 
 | Scope | Diff command |
 |-------|-------------|
@@ -25,65 +76,62 @@ user's scope choice to the correct `git diff` command:
 | Branch diff | `git diff <branch>...HEAD` |
 | Specific commit | `git diff <sha>~1..<sha>` |
 
-**Important:** For uncommitted scope, use `git diff HEAD` not
-bare `git diff`. Bare `git diff` misses staged changes.
+**Important:** For uncommitted scope, use `git diff HEAD` not bare
+`git diff`. Bare `git diff` misses staged changes.
 
 ## Code Review (General, Performance, Error Handling)
 
-For uncommitted changes, the `/code-review` extension
-automatically picks up the working tree diff:
+For uncommitted changes, the `/code-review` extension automatically
+picks up the working tree diff:
 
 ```bash
 gemini -p "/code-review" \
   --yolo \
+  --skip-trust \
   -e code-review \
   -m gemini-3.1-pro-preview
 ```
 
-For branch diffs or specific commits, pipe the diff with a
-prompt header (avoids heredocs — diffs contain `$` and backticks
-that break shell expansion):
+For branch diffs or specific commits, pipe the diff with a prompt
+header (avoids heredocs — diffs contain `$` and backticks that break
+shell expansion):
 
 ```bash
 git diff <branch>...HEAD > /tmp/review-diff.txt
 { printf '%s\n\n' 'Review this diff for code quality issues. <focus prompt>'; \
   cat /tmp/review-diff.txt; } \
-  | gemini -p - -m gemini-3.1-pro-preview --yolo
+  | gemini -p - -m gemini-3.1-pro-preview --yolo --skip-trust
 ```
 
 ## Security Review
 
-The `/security:analyze` extension is interactive-only, so use
-headless mode with a security-focused prompt instead:
+`/security:analyze` is interactive-only, so use headless mode with a
+security-focused prompt instead:
 
 ```bash
 git diff HEAD > /tmp/review-diff.txt
 { printf '%s\n\n' 'Analyze this diff for security vulnerabilities, including injection, auth bypass, data exposure, and input validation issues. Report each finding with severity, location, and remediation.'; \
   cat /tmp/review-diff.txt; } \
-  | gemini -p - -e gemini-cli-security -m gemini-3.1-pro-preview --yolo
+  | gemini -p - -e gemini-cli-security -m gemini-3.1-pro-preview --yolo --skip-trust
 ```
 
-When security focus is selected, only run the supply chain scan
-if the diff touches dependency manifest files:
+Only run the supply chain scan if the diff touches dependency manifests:
 
 ```bash
-# Check whether dependency files changed before scanning
 git diff --name-only <scope> \
   | grep -qiE '(package\.json|package-lock|yarn\.lock|pnpm-lock|Gemfile|\.gemspec|requirements\.txt|setup\.py|setup\.cfg|pyproject\.toml|poetry\.lock|uv\.lock|Cargo\.toml|Cargo\.lock|go\.mod|go\.sum|composer\.json|composer\.lock|Pipfile)' \
   && gemini -p "/security:scan-deps" \
        --yolo \
+       --skip-trust \
        -e gemini-cli-security \
        -m gemini-3.1-pro-preview
 ```
 
-Skip the scan when only non-dependency files changed. The scan
-analyzes the entire project's dependency tree regardless of diff
-scope, so it adds significant time for no value when dependencies
-weren't touched.
+The scan analyzes the entire project's dependency tree regardless of
+diff scope, so it adds significant time for no value when dependencies
+were not touched.
 
 ## Adding Project Context
-
-If project context was requested, prepend it to the prompt:
 
 ```bash
 git diff HEAD > /tmp/review-diff.txt
@@ -91,14 +139,16 @@ git diff HEAD > /tmp/review-diff.txt
   cat CLAUDE.md; \
   printf '\n---\n\n%s\n\n' '<review instructions and focus>'; \
   cat /tmp/review-diff.txt; } \
-  | gemini -p - -m gemini-3.1-pro-preview --yolo
+  | gemini -p - -m gemini-3.1-pro-preview --yolo --skip-trust
 ```
 
 ## Error Handling
 
 | Error | Action |
 |-------|--------|
+| `UNSUPPORTED_CLIENT` / "migrate to the Antigravity suite" | Individual tier is shut off. Switch to `agy` |
 | `gemini: command not found` | Tell user: `npm i -g @google/gemini-cli` |
+| `not running in a trusted directory` | Add `--skip-trust` |
 | Extension missing | Tell user: `gemini extensions install <github-url>` |
 | `-e security` silently ignored | Use `-e gemini-cli-security` (the actual installed name) |
 | Timeout | Inform user, suggest scoping down the diff |
@@ -110,6 +160,5 @@ gemini extensions install https://github.com/gemini-cli-extensions/code-review
 gemini extensions install https://github.com/gemini-cli-extensions/security
 ```
 
-Note: The security extension installs as `gemini-cli-security`
-(not `security`). Always use `-e gemini-cli-security` when
-loading it.
+The security extension installs as `gemini-cli-security` (not
+`security`). Always use `-e gemini-cli-security` when loading it.


### PR DESCRIPTION
Both of this skill's documented invocations are currently broken. I hit this using the skill for real, then verified each command by hand against a small diff with two planted defects (a SQL injection and an unguarded `os.environ[...]`).

Verified against `codex-cli` 0.149.1, `gemini-cli` 0.57.0, and `agy` 1.1.21 on macOS.

## Codex: stale model pin

The skill pinned `gpt-5.5`. The current family is `gpt-5.6` with `-sol`, `-luna`, `-terra`, and `-pro` variants. `gpt-5.6-sol` is the general-purpose choice and what the CLI's own default config selected here. Fallback chain is now sol → 5.6 → 5.4.

`model_reasoning_effort` has also gained `max` and `ultra`. I kept `xhigh` as the default — the higher tiers cost meaningful wall time for little gain on a diff-sized input.

Confirmed working: 14s, clean schema-conformant JSON.

## Gemini: cannot authenticate at all

This is the substantive part. Running the documented Gemini command fails outright:

```
reasonCode: 'UNSUPPORTED_CLIENT'
reasonMessage: 'This client is no longer supported for Gemini Code Assist for
  individuals. To continue using Gemini, please migrate to the Antigravity suite
  of products: https://antigravity.google'
tierId: 'free-tier'
```

Google **stopped serving Gemini CLI to individual accounts (free, AI Pro, Ultra) on 2026-06-18** ([google-gemini/gemini-cli#27274](https://github.com/google-gemini/gemini-cli/discussions/27274)). Not recoverable by reinstalling or switching personal accounts. The replacement is Antigravity CLI, binary `agy`.

Code Assist Standard/Enterprise licenses and paid `GEMINI_API_KEY` do still reach Gemini CLI, so I kept that path as an explicitly-legacy reference rather than deleting it.

### Three `agy` behaviours that break a naive port

All found by running it, and all silent or misleading failures:

1. **The prompt must be a command-line argument.** Print mode does not read stdin unless `--input-format stream-json`. Piping a diff in fails with `empty prompt` — the exact shape the old Gemini docs used.
2. **`-p=<value>` is required.** Bare `-p` consumes the *next flag* as its prompt value and discards the real one: `agy -p --model x` reviews the string `--model`.
3. **`--mode plan` is unsafe here.** It intermittently returns a *"created an implementation plan artifact … click Proceed"* stub instead of the review. Same command printed a full review on one run and the stub on the next, so it is not reproducible. Omit `--mode` entirely; a text-only diff review requests no tool approvals.

### `--json-schema` is advisory, not enforced

I tried to give Antigravity the same structured-output path as Codex. It does not hold up — with the existing `codex-review-schema.json` it nested the findings as an escaped string inside a `response` field, returned `code_location` as a string in one block and an object in another, used `100` where the schema says 0–1, returned `"Needs Work"` outside the `overall_correctness` enum, emitted the payload twice, and ran ~68s versus ~24s for text.

So the Antigravity path uses `--output-format text` and structured JSON stays Codex-only. Documented with the reasoning so it isn't re-attempted.

## Also in this change

- **`--disable-slash-commands`** on the `agy` call. The prompt embeds an untrusted diff, and without it a diff line resembling `/something` can be expanded as a slash command.
- **`--skip-trust` added throughout the legacy Gemini path.** Separate pre-existing bug: `--yolo` is *silently downgraded* to `default` approval mode in an untrusted directory (`Approval mode overridden to "default" because the current folder is not trusted`). Every headless extension invocation as previously documented would stall waiting for approvals that cannot arrive.
- **A note on `codex exec review`.** It has gained native `--uncommitted`/`--base`/`--commit` flags and supports `--output-schema`, so it looks like a simplification — but those flags are mutually exclusive with `[PROMPT]` (`error: the argument '--uncommitted' cannot be used with '[PROMPT]'`), so it cannot carry project context or a focus area. Documented so the manual prompt-assembly approach isn't "simplified" away later.
- **One deletion worth flagging:** the "Skipping Inapplicable Checks" dependency-scanning section is dropped from `SKILL.md`. It existed only to gate `/security:scan-deps`, a Gemini security-extension command with no Antigravity equivalent. It survives in the legacy Gemini reference, and the Antigravity reference points at `osv-scanner` / `npm audit` / `pip-audit` instead.

## Checks

`make validate` (401 references resolved, no errors), `make self-test` (96 assertions), `check_claude_loadability.py`, and `check_codex_loadability.py` all pass. Version bumped 1.7.0 → 1.8.0 in `plugin.json` and `marketplace.json`, with descriptions kept in sync across `plugin.json`, `marketplace.json`, the root README table, and the plugin README.

`make check` was not run in full locally — `shellcheck`, `shfmt`, and `bats` are not installed on this machine. This change touches only Markdown and JSON, so those targets have nothing to act on.

Note: `check_codex_loadability.py` needs Python ≥ 3.12 (`tempfile.TemporaryDirectory(ignore_cleanup_errors=...)`); it crashes on an older system `python3`. Pre-existing, unrelated to this change, and it passes under `uv run --python 3.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
